### PR TITLE
don't try to force UPPERCASE column names; FITS_rec will do that for you

### DIFF
--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -46,15 +46,8 @@ def read_tractor(filename):
 
         Returns:
             ndarray with the tractor schema, uppercase field names.
-        
     """
-    data = fits.open(filename)[1].data.copy()
-
-    # convert all fields to upper case. 
-    # We expect normalized upper case field names.
-    data.dtype.names = [name.upper() for name in data.dtype.names]
-
-    return data
+    return fits.getdata(filename, 1)
 
 def write_targets(filename, data, tsbits):
     """ 


### PR DESCRIPTION
Updates desitarget.read_tractor() to just return the astropy.io.fits.FITS_rec object as-is rather than trying to force the column names to be capitalized.  FITS_rec objects will already support upper- or lower-case column names without having to do anything special.  Trying to force it breaks with more recent versions of astropy (perhaps starting with 1.0.2?).  Fixes issue #3 .

Review question for @rainwoodman: did you actually have a case where you had to force the column names to be uppercase, or were you just expecting to need to do this?  If you added this code because of some case that was broken without it, please recheck because I may have broken that.