### PR TITLE
cleanup desitarget priorities

### DIFF
--- a/py/desitarget/__init__.py
+++ b/py/desitarget/__init__.py
@@ -38,6 +38,6 @@ def gitversion():
         return 'unknown'
 
 # desitarget.targetmask makes more sense?
-from .targetmask import priorities, obsconditions, obsstate
+from .targetmask import obsconditions, obsstate
 from .targetmask import desi_mask, mws_mask, bgs_mask
 

--- a/py/desitarget/targetmask.py
+++ b/py/desitarget/targetmask.py
@@ -29,8 +29,14 @@ for maskname, priorities in _bitdefs['priorities'].items():
                 priorities[bitname]['MORE_ZWARN'] = priorities[bitname]['UNOBS']
             if 'MORE_ZGOOD' not in priorities[bitname]:
                 priorities[bitname]['MORE_ZGOOD'] = priorities[bitname]['UNOBS']
+
+            #- fill in other states as 0 priority
+            for state, blat, foo in _bitdefs['obsstate']:
+                if state not in priorities[bitname]:
+                    priorities[bitname][state] = 0
         else:
             priorities[bitname] = dict()
+            
         
     #- add to the extra info dictionary for this target mask
     for bitdef in _bitdefs[maskname]:

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -36,7 +36,17 @@ class TestPriorities(unittest.TestCase):
         self.assertEqual(p[1], bgs_mask.BGS_FAINT.priorities['MORE_ZWARN'])
         self.assertEqual(p[2], bgs_mask.BGS_FAINT.priorities['MORE_ZGOOD'])
         ### BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2200, MORE_ZGOOD: 2300}
-        
-                
+
+    def test_priorities(self):
+        for mask in [desi_mask, bgs_mask, mws_mask]:
+            for name in mask.names():
+                if name == 'SKY' or name.startswith('STD') \
+                    or name in ['BGS_ANY', 'MWS_ANY', 'ANCILLARY_ANY']:
+                    self.assertEqual(mask[name].priorities, {}, 'mask.{} has priorities?'.format(name))
+                else:
+                    for state in obsstate.names():
+                        self.assertIn(state, mask[name].priorities,
+                            '{} not in mask.{}.priorities'.format(state, name))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes an incorrect desitarget.priorities variable, and updates how the priorities are loaded from desitarget.yaml .  In particular, priorities like desi_mask['ELG'].priorities['DONE'] now default to 0 rather than having the non-existence of the key 'DONE' indicate 0 priority.  Tests have been expanded to check more cases.