### PR TITLE
merged target list

### DIFF
--- a/py/desitarget/__init__.py
+++ b/py/desitarget/__init__.py
@@ -38,6 +38,6 @@ def gitversion():
         return 'unknown'
 
 # desitarget.targetmask makes more sense?
-from .targetmask import obsconditions, obsstate
+from .targetmask import obsconditions, obsmask
 from .targetmask import desi_mask, mws_mask, bgs_mask
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -414,34 +414,3 @@ def select_targets(infiles, numproc=4, verbose=False):
     targets = np.concatenate(targets)
     
     return targets
-
-# def calc_numobs(targets, targetflags):
-#     """
-#     Return array of number of observations needed for each target.
-#     
-#     Args:
-#         targets: numpy structured array with tractor inputs
-#         targetflags: array of target selection bit flags 
-#     
-#     Returns:
-#         array of integers of number of observations needed
-#     """
-#     #- Default is one observation
-#     nobs = np.ones(len(targets), dtype='i4')
-#     
-#     #- If it wasn't selected by any target class, it gets 0 observations
-#     #- Normally these would have already been removed, but just in case...
-#     nobs[targetflags == 0] = 0
-#     
-#     #- LRGs get 1, 2, or 3 observations depending upon magnitude
-#     zflux = targets['DECAM_FLUX'][:,4] / targets['DECAM_MW_TRANSMISSION'][:,4]    
-#     islrg = (targetflags & targetmask.LRG) != 0
-#     lrg2 = islrg & (zflux < 10**((22.5-20.36)/2.5))
-#     lrg3 = islrg & (zflux < 10**((22.5-20.56)/2.5))
-#     nobs[lrg2] = 2
-#     nobs[lrg3] = 3
-#     
-#     #- TBD: flag QSOs for 4-5 obs ahead of time, or only after confirming
-#     #- that they are redshift>2.15 (i.e. good for Lyman-alpha)?
-#     
-#     return nobs

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from desitarget import desi_mask
+from desitarget.targets import calc_numobs
+
+def make_mtl(targets):
+    '''
+    Adds NUMOBS, PRIORITY, and LASTPASS columns to a targets table
+    
+    Args:
+        targets : Table with columns DESI_TARGET
+    
+    Returns:
+        MTL Table with targets columns plus NUMOBS, PRIORITY, LASTPASS
+
+    Note:
+        v0 - no zcatalog information used yet
+    '''
+    n = len(targets)
+    mtl = targets.copy(copy_data=False)
+    
+    priority = np.zeros(n, dtype='i4')
+    for name in desi_mask.names():
+        if name.startswith('STD_') or \
+           name in ('SKY', 'BGS_ANY', 'MWS_ANY', 'ANCILLARY_ANY'):
+            continue
+        ii = (mtl['DESI_TARGET'] & desi_mask[name]) != 0
+        if np.any(ii):
+            priority[ii] = np.maximum(priority[ii], desi_mask[name].priorities['UNOBS'])
+                
+    mtl['PRIORITY'] = priority
+
+    mtl['NUMOBS'] = calc_numobs(targets)
+
+    #- ELGs can be observed during gray time (the "last pass")
+    lastpass = np.zeros(n, dtype='i4')
+    iselg = (mtl['DESI_TARGET'] & desi_mask.ELG) != 0
+    lastpass[iselg] = 1    
+    mtl['LASTPASS'] = lastpass
+    
+    return mtl

--- a/py/desitarget/targetmask.py
+++ b/py/desitarget/targetmask.py
@@ -31,7 +31,7 @@ for maskname, priorities in _bitdefs['priorities'].items():
                 priorities[bitname]['MORE_ZGOOD'] = priorities[bitname]['UNOBS']
 
             #- fill in other states as 0 priority
-            for state, blat, foo in _bitdefs['obsstate']:
+            for state, blat, foo in _bitdefs['obsmask']:
                 if state not in priorities[bitname]:
                     priorities[bitname][state] = 0
         else:
@@ -48,7 +48,7 @@ desi_mask = BitMask('desi_mask', _bitdefs)
 mws_mask = BitMask('mws_mask', _bitdefs)
 bgs_mask = BitMask('bgs_mask', _bitdefs)
 obsconditions = BitMask('obsconditions', _bitdefs)
-obsstate = BitMask('obsstate', _bitdefs)
+obsmask = BitMask('obsmask', _bitdefs)
 
 #-------------------------------------------------------------------------
 #- Do some error checking that the bitmasks are consistent with each other

--- a/py/desitarget/targetmask.yaml
+++ b/py/desitarget/targetmask.yaml
@@ -72,7 +72,7 @@ obsconditions:
 #- if a target passes more than one target bit, it is possible that one bit
 #- will consider the observations "DONE" while another bit will want "MORE".
 #- DONOTOBSERVE trumps MORE which trumps DONE
-obsstate:
+obsmask:
     - [UNOBS,       0, "unobserved"]
     - [OBS,         1, "observed but no spectro pipeline answer yet"]
     - [DONE,        2, "enough observations already obtained"]

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -1,52 +1,91 @@
 import numpy as np
 import numpy.lib.recfunctions as rfn
 
-from desitarget import desi_mask, bgs_mask, mws_mask
-from desitarget import obsstate
+from astropy.table import Table
 
-def calc_priority(targets, targetstate=None):
+from desitarget import desi_mask, bgs_mask, mws_mask
+from desitarget import obsmask
+
+def calc_priority(targets):
     '''
     Calculate target priorities given observation state and target masks
 
     Args:
         targets: numpy structured array or astropy Table of targets, including
             columns DESI_TARGET, BGS_TARGET, and MWS_TARGET
-            
-    Optional:
-        targetstate: array of integers with the obstate mask for each target.
-            If None, treat as desitarget.obsstate.UNOBS
-                        
+    
     Returns:
         integer array of priorities
 
     Notes:
         If a target passes more than one selection, the highest priority wins
     '''
-    if targetstate is None:
-        targetstate = obsstate.UNOBS
+    targets = Table(targets).copy()
+    if 'NUMOBS' not in targets.colnames:
+        targets['NUMOBS'] = np.zeros(len(targets), dtype=np.int32)
     
     #- default is 0 priority, i.e. do not observe
     priority = np.zeros(len(targets), dtype='i8')
-    
-    #- Cache what targets are in what states
-    targetstate = np.asarray(targetstate)
-    isstate = dict()
-    for x in obsstate.names():
-        isstate[x] = (targetstate & obsstate[x]) != 0
 
-    for xxx_target, xxx_mask in [
-            (targets['DESI_TARGET'], desi_mask),
-            (targets['BGS_TARGET'], bgs_mask),
-            (targets['MWS_TARGET'], mws_mask),
-        ]:
-        for objtype in xxx_mask.names():
-            #- targets of this objtype
-            thistype = (xxx_target & xxx_mask[objtype]) != 0
-            for state, p in xxx_mask[objtype].priorities.items():
-                #- targets of this type and in this obsstate
-                ii = isstate[state] & thistype
-                priority[ii] = np.maximum(priority[ii], p)
-                ### print objtype, state, ii, priority
+    #- Determine which targets have been observed
+    #- TODO: this doesn't distinguish between really unobserved vs not yet processed
+    unobs = (targets['NUMOBS'] == 0)
+    if np.all(unobs):
+        done  = np.zeros(len(targets), dtype=bool)
+        zgood = np.zeros(len(targets), dtype=bool)
+        zwarn = np.zeros(len(targets), dtype=bool)
+    else:
+        nmore = np.maximum(0, calc_numobs(targets) - targets['NUMOBS'])
+        assert np.all(nmore >= 0)
+        done = ~unobs & (nmore == 0)
+        zgood = ~unobs & (nmore > 0) & (targets['ZWARN'] == 0)
+        zwarn = ~unobs & (nmore > 0) & (targets['ZWARN'] != 0)
+
+    #- zgood, zwarn, done, and unobs should be mutually exclusive and cover all targets
+    assert not np.any(unobs & zgood)
+    assert not np.any(unobs & zwarn)
+    assert not np.any(unobs & done)
+    assert not np.any(zgood & zwarn)
+    assert not np.any(zgood & done)
+    assert not np.any(zwarn & done)
+    assert np.all(unobs | done | zgood | zwarn)
+
+    #- DESI dark time targets
+    if 'DESI_TARGET' in targets.colnames:
+        for name in ('ELG', 'LRG'):
+            ii = (targets['DESI_TARGET'] & desi_mask[name]) != 0
+            priority[ii & unobs] = np.maximum(priority[ii & unobs], desi_mask[name].priorities['UNOBS'])
+            priority[ii & done] = np.maximum(priority[ii & done], desi_mask[name].priorities['DONE'])
+            priority[ii & zgood] = np.maximum(priority[ii & zgood], desi_mask[name].priorities['MORE_ZGOOD'])
+            priority[ii & zwarn] = np.maximum(priority[ii & zwarn], desi_mask[name].priorities['MORE_ZWARN'])
+    
+        #- QSO could be Lyman-alpha or Tracer
+        name = 'QSO'
+        ii = (targets['DESI_TARGET'] & desi_mask[name]) != 0
+        good_hiz = zgood & (targets['Z'] >= 2.15) & (targets['ZWARN'] == 0)    
+        priority[ii & unobs] = np.maximum(priority[ii & unobs], desi_mask[name].priorities['UNOBS'])
+        priority[ii & done] = np.maximum(priority[ii & done], desi_mask[name].priorities['DONE'])
+        priority[ii & good_hiz] = np.maximum(priority[ii & good_hiz], desi_mask[name].priorities['MORE_ZGOOD'])
+        priority[ii & ~good_hiz] = np.maximum(priority[ii & ~good_hiz], desi_mask[name].priorities['DONE'])
+        priority[ii & zwarn] = np.maximum(priority[ii & zwarn], desi_mask[name].priorities['MORE_ZWARN'])
+
+    #- BGS targets
+    if 'BGS_TARGET' in targets.colnames:
+        for name in bgs_mask.names():
+            ii = (targets['BGS_TARGET'] & bgs_mask[name]) != 0
+            priority[ii & unobs] = np.maximum(priority[ii & unobs], bgs_mask[name].priorities['UNOBS'])
+            priority[ii & done] = np.maximum(priority[ii & done], bgs_mask[name].priorities['DONE'])
+            priority[ii & zgood] = np.maximum(priority[ii & zgood], bgs_mask[name].priorities['MORE_ZGOOD'])
+            priority[ii & zwarn] = np.maximum(priority[ii & zwarn], bgs_mask[name].priorities['MORE_ZWARN'])
+
+    #- MWS targets
+    if 'MWS_TARGET' in targets.colnames:
+        for name in mws_mask.names():
+            ii = (targets['MWS_TARGET'] & mws_mask[name]) != 0
+            priority[ii & unobs] = np.maximum(priority[ii & unobs], mws_mask[name].priorities['UNOBS'])
+            priority[ii & done] = np.maximum(priority[ii & done], mws_mask[name].priorities['DONE'])
+            priority[ii & zgood] = np.maximum(priority[ii & zgood], mws_mask[name].priorities['MORE_ZGOOD'])
+            priority[ii & zwarn] = np.maximum(priority[ii & zwarn], mws_mask[name].priorities['MORE_ZWARN'])
 
     return priority
 
@@ -95,6 +134,11 @@ def calc_numobs(targets):
     #- that they are redshift>2.15 (i.e. good for Lyman-alpha)?
     isqso = (targets['DESI_TARGET'] & desi_mask.QSO) != 0
     nobs[isqso] = 4
+
+    #- TBD: BGS Faint = 2 observations
+    if 'BGS_TARGET' in targets.dtype.names:
+        ii = (targets['BGS_TARGET'] & bgs_mask.BGS_FAINT) != 0
+        nobs[ii] = np.maximum(nobs[ii], 2)
 
     return nobs
 

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -14,9 +14,16 @@ class TestMTL(unittest.TestCase):
         self.targets['DESI_TARGET'] = [Mx[t].mask for t in self.types]
         self.targets['ZFLUX'] = 10**((22.5-np.linspace(20, 21, 3))/2.5)
             
+    def test_mtl(self):
+        mtl = make_mtl(self.targets)
+        goodkeys = set(self.targets.dtype.names) | set(['NUMOBS_MORE', 'PRIORITY', 'LASTPASS'])
+        self.assertTrue(set(mtl.dtype.names) == goodkeys, \
+                        'colname mismatch: {} vs. {}'.format( \
+                            mtl.dtype.names, goodkeys))
+                    
     def test_numobs(self):
         mtl = make_mtl(self.targets)
-        self.assertTrue(np.all(mtl['NUMOBS'] == [1, 2, 4]))
+        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [1, 2, 4]))
         self.assertTrue(np.all(mtl['PRIORITY'] == self.priorities))
         iselg = (self.types == 'ELG')
         self.assertTrue(np.all(mtl['LASTPASS'][iselg] != 0))

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -1,0 +1,24 @@
+import unittest
+import numpy as np
+from astropy.table import Table
+
+from desitarget import desi_mask as Mx
+from desitarget.mtl import make_mtl
+
+class TestMTL(unittest.TestCase):
+    
+    def setUp(self):
+        self.targets = Table()
+        self.types = np.array(['ELG', 'LRG', 'QSO'])
+        self.priorities = [Mx[t].priorities['UNOBS'] for t in self.types]
+        self.targets['DESI_TARGET'] = [Mx[t].mask for t in self.types]
+        self.targets['ZFLUX'] = 10**((22.5-np.linspace(20, 21, 3))/2.5)
+            
+    def test_numobs(self):
+        mtl = make_mtl(self.targets)
+        self.assertTrue(np.all(mtl['NUMOBS'] == [1, 2, 4]))
+        self.assertTrue(np.all(mtl['PRIORITY'] == self.priorities))
+        iselg = (self.types == 'ELG')
+        self.assertTrue(np.all(mtl['LASTPASS'][iselg] != 0))
+        self.assertTrue(np.all(mtl['LASTPASS'][~iselg] == 0))
+            

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -16,7 +16,7 @@ class TestMTL(unittest.TestCase):
             
     def test_mtl(self):
         mtl = make_mtl(self.targets)
-        goodkeys = set(self.targets.dtype.names) | set(['NUMOBS_MORE', 'PRIORITY', 'LASTPASS'])
+        goodkeys = set(self.targets.dtype.names) | set(['NUMOBS_MORE', 'PRIORITY', 'GRAYLAYER'])
         self.assertTrue(set(mtl.dtype.names) == goodkeys, \
                         'colname mismatch: {} vs. {}'.format( \
                             mtl.dtype.names, goodkeys))
@@ -26,6 +26,6 @@ class TestMTL(unittest.TestCase):
         self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [1, 2, 4]))
         self.assertTrue(np.all(mtl['PRIORITY'] == self.priorities))
         iselg = (self.types == 'ELG')
-        self.assertTrue(np.all(mtl['LASTPASS'][iselg] != 0))
-        self.assertTrue(np.all(mtl['LASTPASS'][~iselg] == 0))
+        self.assertTrue(np.all(mtl['GRAYLAYER'][iselg] != 0))
+        self.assertTrue(np.all(mtl['GRAYLAYER'][~iselg] == 0))
             

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -1,7 +1,9 @@
 import unittest
 import numpy as np
 
-from desitarget import desi_mask, bgs_mask, mws_mask, obsstate
+from astropy.table import Table
+
+from desitarget import desi_mask, bgs_mask, mws_mask, obsmask
 from desitarget.targets import calc_priority
 
 class TestPriorities(unittest.TestCase):
@@ -11,10 +13,12 @@ class TestPriorities(unittest.TestCase):
             ('DESI_TARGET',np.int64),
             ('BGS_TARGET',np.int64),
             ('MWS_TARGET',np.int64),
+            ('Z',np.float32),
+            ('ZWARN',np.float32),
         ]
-        self.targets = np.zeros(3, dtype=dtype)
+        self.targets = Table(np.zeros(3, dtype=dtype))
             
-    def test_numobs(self):
+    def test_priorities(self):
         t = self.targets
         #- No targeting bits set is priority=0
         self.assertTrue(np.all(calc_priority(t) == 0))
@@ -28,23 +32,37 @@ class TestPriorities(unittest.TestCase):
         self.assertTrue(np.all(calc_priority(t) == desi_mask.QSO.priorities['UNOBS']))
         
         #- different states -> different priorities
-        t['DESI_TARGET'] *= 0
-        t['BGS_TARGET'] = bgs_mask.BGS_FAINT
-        targetstate = [obsstate.UNOBS, obsstate.MORE_ZWARN, obsstate.MORE_ZGOOD]
-        p = calc_priority(t, targetstate)
+        t['DESI_TARGET'] = desi_mask.BGS_ANY
+        t['BGS_TARGET'] |= bgs_mask.BGS_FAINT
+        t['NUMOBS'] = [0, 1, 1]
+        t['ZWARN'] = [1, 1, 0]
+        p = calc_priority(t)
+                
         self.assertEqual(p[0], bgs_mask.BGS_FAINT.priorities['UNOBS'])
         self.assertEqual(p[1], bgs_mask.BGS_FAINT.priorities['MORE_ZWARN'])
         self.assertEqual(p[2], bgs_mask.BGS_FAINT.priorities['MORE_ZGOOD'])
         ### BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2200, MORE_ZGOOD: 2300}
+        
+        #- Done is Done, regardless of ZWARN
+        t['DESI_TARGET'] = desi_mask.BGS_ANY
+        t['BGS_TARGET'] = bgs_mask.BGS_BRIGHT  #- only one obs needed
+        t['NUMOBS'] = [0, 1, 1]
+        t['ZWARN'] = [1, 1, 0]
+        p = calc_priority(t)        
+                
+        self.assertEqual(p[0], bgs_mask.BGS_BRIGHT.priorities['UNOBS'])
+        self.assertEqual(p[1], bgs_mask.BGS_BRIGHT.priorities['DONE'])
+        self.assertEqual(p[2], bgs_mask.BGS_BRIGHT.priorities['DONE'])
+        ### BGS_BRIGHT: {UNOBS: 2100, MORE_ZWARN: 2200, MORE_ZGOOD: 2300}
 
-    def test_priorities(self):
+    def test_mask_priorities(self):
         for mask in [desi_mask, bgs_mask, mws_mask]:
             for name in mask.names():
                 if name == 'SKY' or name.startswith('STD') \
                     or name in ['BGS_ANY', 'MWS_ANY', 'ANCILLARY_ANY']:
                     self.assertEqual(mask[name].priorities, {}, 'mask.{} has priorities?'.format(name))
                 else:
-                    for state in obsstate.names():
+                    for state in obsmask.names():
                         self.assertIn(state, mask[name].priorities,
                             '{} not in mask.{}.priorities'.format(state, name))
 


### PR DESCRIPTION
This PR adds desitarget.mtl module for managing the "merged target list" for input to fiber assignment.  It merges the target list from select_targets with any updates from the observations + spectro pipeline, and assigns priorities and number of requested observations based upon the parameters in targetmask.yaml .  The basic usage is:
```
mtl = desitarget.mtl.make_mtl(targets, zcatalog)   #- zcatalog is optional
```

this PR also updates that desitarget.targets.calc_priorities() and .calc_numobs() functions to be used by make_mtl().

This PR is a companion to [fiberassign PR #24](https://github.com/desihub/fiberassign/pull/24).