### PR TITLE
optionally allow the user to specify the tractor catalog columns to read

### DIFF
--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -113,7 +113,7 @@ def read_mock_durham(core_filename, photo_filename):
     
     return data
 
-def read_tractor(filename, header=False):
+def read_tractor(filename, header=False, morecolumns=False):
     """ 
         Read a tractor catalogue. Always the latest DR. 
         
@@ -129,16 +129,29 @@ def read_tractor(filename, header=False):
     """
     check_fitsio_version()
 
-    #- Columns needed for target selection and/or passing forward
-    columns = [
-        'BRICKID', 'BRICKNAME', 'OBJID', 'TYPE',
-        'RA', 'RA_IVAR', 'DEC', 'DEC_IVAR',
-        'DECAM_FLUX', 'DECAM_MW_TRANSMISSION',
-        'DECAM_FRACFLUX', 'DECAM_FLUX_IVAR',
-        'WISE_FLUX', 'WISE_MW_TRANSMISSION',
-        'WISE_FLUX_IVAR',
-        'SHAPEDEV_R', 'SHAPEEXP_R',
-        ]
+    if morecolumns:
+        #- Expanded set of columns.
+        columns = [
+            'BRICKID', 'BRICKNAME', 'OBJID', 'TYPE',
+            'RA', 'RA_IVAR', 'DEC', 'DEC_IVAR',
+            'DECAM_FLUX', 'DECAM_MW_TRANSMISSION',
+            'DECAM_FRACFLUX', 'DECAM_FLUX_IVAR', 'DECAM_NOBS',
+            'DECAM_ANYMASK', 'DECAM_DEPTH', 'DECAM_GALDEPTH',
+            'WISE_FLUX', 'WISE_MW_TRANSMISSION',
+            'WISE_FLUX_IVAR',
+            'SHAPEDEV_R', 'SHAPEEXP_R',
+            ]
+    else:
+        #- Minimum columns needed for target selection and/or passing forward
+        columns = [
+            'BRICKID', 'BRICKNAME', 'OBJID', 'TYPE',
+            'RA', 'RA_IVAR', 'DEC', 'DEC_IVAR',
+            'DECAM_FLUX', 'DECAM_MW_TRANSMISSION',
+            'DECAM_FRACFLUX', 'DECAM_FLUX_IVAR',
+            'WISE_FLUX', 'WISE_MW_TRANSMISSION',
+            'WISE_FLUX_IVAR',
+            'SHAPEDEV_R', 'SHAPEEXP_R',
+            ]
 
     fx = fitsio.FITS(filename, upper=True)
     #- tractor files have BRICK_PRIMARY; sweep files don't

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -113,7 +113,7 @@ def read_mock_durham(core_filename, photo_filename):
     
     return data
 
-def read_tractor(filename, header=False, morecolumns=False):
+def read_tractor(filename, header=False, mycolumns=None):
     """ 
         Read a tractor catalogue. Always the latest DR. 
         
@@ -122,25 +122,15 @@ def read_tractor(filename, header=False, morecolumns=False):
             
         Optional:
             header: if true, return (data, header) instead of just data
-            morecolumns: read additional Tractor catalog columns
+            mycolumns: optionally specify the desired Tractor catalog columns to read
 
         Returns:
             ndarray with the tractor schema, uppercase field names.
     """
     check_fitsio_version()
 
-    if morecolumns:
-        #- Expanded set of columns.
-        columns = [
-            'BRICKID', 'BRICKNAME', 'OBJID', 'TYPE',
-            'RA', 'RA_IVAR', 'DEC', 'DEC_IVAR',
-            'DECAM_FLUX', 'DECAM_MW_TRANSMISSION',
-            'DECAM_FRACFLUX', 'DECAM_FLUX_IVAR', 'DECAM_NOBS',
-            'DECAM_ANYMASK', 'DECAM_DEPTH', 'DECAM_GALDEPTH',
-            'WISE_FLUX', 'WISE_MW_TRANSMISSION',
-            'WISE_FLUX_IVAR',
-            'SHAPEDEV_R', 'SHAPEEXP_R',
-            ]
+    if mycolumns:
+        columns = mycolumns
     else:
         #- Minimum columns needed for target selection and/or passing forward
         columns = [
@@ -152,7 +142,7 @@ def read_tractor(filename, header=False, morecolumns=False):
             'WISE_FLUX_IVAR',
             'SHAPEDEV_R', 'SHAPEEXP_R',
             ]
-
+        
     fx = fitsio.FITS(filename, upper=True)
     #- tractor files have BRICK_PRIMARY; sweep files don't
     if 'BRICK_PRIMARY' in fx[1].get_colnames():
@@ -280,4 +270,3 @@ def check_fitsio_version():
             print('ERROR: fitsio >0.9.8rc1 required (not {})'.format(\
                     fitsio.__version__))
             raise ImportError
-€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5:q

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -122,7 +122,7 @@ def read_tractor(filename, header=False, morecolumns=False):
             
         Optional:
             header: if true, return (data, header) instead of just data
-            sweep: sweep file; doesn't have BRICK_PRIMARY
+            morecolumns: read additional Tractor catalog columns
 
         Returns:
             ndarray with the tractor schema, uppercase field names.
@@ -280,3 +280,4 @@ def check_fitsio_version():
             print('ERROR: fitsio >0.9.8rc1 required (not {})'.format(\
                     fitsio.__version__))
             raise ImportError
+€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5€ý5:q

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -56,8 +56,18 @@ class TestIO(unittest.TestCase):
         
         newobjects = io.fix_tractor_dr1_dtype(badobjects)
         self.assertEqual(newobjects['TYPE'].dtype, np.dtype('S4'))
-        
-    
+
+    def test_tractor_columns(self):
+        tscolumns = io.tscolumns + ['BRICK_PRIMARY',]
+        tractorfile = io.list_tractorfiles(self.datadir)[0]
+        data = io.read_tractor(tractorfile)
+        self.assertEqual(set(data.dtype.names), set(tscolumns))
+        columns = ['BX', 'BY']
+        data = io.read_tractor(tractorfile, columns=columns)
+        self.assertEqual(set(data.dtype.names), set(columns))
+        data = io.read_tractor(tractorfile, columns=tuple(columns))
+        self.assertEqual(set(data.dtype.names), set(columns))
+
     def test_readwrite_tractor(self):
         tractorfile = io.list_tractorfiles(self.datadir)[0]
         sweepfile = io.list_sweepfiles(self.datadir)[0]


### PR DESCRIPTION
It would be helpful for a variety of target selection tests (and science!) to be able to specify the desired tractor catalog columns to read across many bricks.  This PR allows a user to optionally (explicitly) choose these columns.