### PR TITLE
fix make_mtl calculation

### DIFF
--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -45,6 +45,10 @@ def make_mtl(targets, zcat=None, trim=True):
     ### mtl['NUMOBS_MORE'] = ztargets['NUMOBS_MORE']
     mtl['PRIORITY'] = calc_priority(ztargets)
 
+    #- If priority went to 0, then NUMOBS_MORE should also be 0
+    ii = (mtl['PRIORITY'] == 0)
+    mtl['NUMOBS_MORE'][ii] = 0
+
     #- remove extra zcat columns from join(targets, zcat) that are not needed
     #- for final MTL output
     for name in ['NUMOBS', 'Z', 'ZWARN']:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -28,7 +28,8 @@ def make_mtl(targets, zcat=None, trim=True):
     n = len(targets)
     targets = Table(targets)
     if zcat is not None:
-        ztargets = join(targets, zcat, keys='TARGETID', join_type='outer')
+        ztargets = join(targets, zcat['TARGETID', 'NUMOBS', 'Z', 'ZWARN'],
+                            keys='TARGETID', join_type='outer')
         if ztargets.masked:
             unobs = ztargets['NUMOBS'].mask
             ztargets['NUMOBS'][unobs] = 0
@@ -37,12 +38,17 @@ def make_mtl(targets, zcat=None, trim=True):
         ztargets['NUMOBS'] = np.zeros(n, dtype=np.int32)
         ztargets['Z'] = -1 * np.ones(n, dtype=np.float32)
         ztargets['ZWARN'] = -1  * np.ones(n, dtype=np.int32)
-    
+
     ztargets['NUMOBS_MORE'] = np.maximum(0, calc_numobs(ztargets) - ztargets['NUMOBS'])
 
-    mtl = targets.copy()
-    mtl['NUMOBS_MORE'] = ztargets['NUMOBS_MORE']
+    mtl = ztargets.copy()
+    ### mtl['NUMOBS_MORE'] = ztargets['NUMOBS_MORE']
     mtl['PRIORITY'] = calc_priority(ztargets)
+
+    #- remove extra zcat columns from join(targets, zcat) that are not needed
+    #- for final MTL output
+    for name in ['NUMOBS', 'Z', 'ZWARN']:
+        mtl.remove_column(name)
 
     #- ELGs can be observed during gray time
     graylayer = np.zeros(n, dtype='i4')
@@ -53,5 +59,5 @@ def make_mtl(targets, zcat=None, trim=True):
     if trim:
         notdone = mtl['NUMOBS_MORE'] > 0
         mtl = mtl[notdone]
-    
+
     return mtl

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -103,6 +103,9 @@ def calc_numobs(targets):
     Notes:
         if ZFLUX or (DECAM_FLUX and DECAM_MW_TRANSMISSION) are in targets,
             then LRG numobs depends upon zmag, else defaults to 2
+        This is NUMOBS desired before any spectroscopic observations; i.e.
+            it does *not* take redshift into consideration (which is relevant
+            for interpreting low-z vs high-z QSOs)
     """
     #- Default is one observation
     nobs = np.ones(len(targets), dtype='i4')

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -45,7 +45,6 @@ class TestMTL(unittest.TestCase):
     def test_zcat(self):
         mtl = make_mtl(self.targets, self.zcat, trim=False)
         mtl.sort(keys='TARGETID')
-        print mtl
         self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [0, 1, 0, 3]))
         self.assertTrue(np.all(mtl['PRIORITY'] == self.post_prio))
 


### PR DESCRIPTION
This PR fixes a critical bug in make_mtl.  The previous code incorrectly assumed that `x = astropy.table.join(a, b)` would create `x` that was row-matched to `a` if `a` was a superset of `b`.  This is not the case -- `x` can end up in a random order relative to `a`, which was causing NUMOBS_MORE to be assigned to the wrong targets.

It also fixes a bug with NUMOBS_MORE for observed low-z QSOs.  Previously their priority was set to 0 (i.e. we don't need to continue observing them) but they still had NUMOBS_MORE > 0.  Now PRIORITY=0 implies NUMOBS_MORE=0.