### PR TITLE
work around astropy Table bugs

### DIFF
--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -64,4 +64,9 @@ def make_mtl(targets, zcat=None, trim=True):
         notdone = mtl['NUMOBS_MORE'] > 0
         mtl = mtl[notdone]
 
+    #- filtering can reset the fill_value, which is just wrong wrong wrong
+    #- See https://github.com/astropy/astropy/issues/4707
+    #- and https://github.com/astropy/astropy/issues/4708
+    mtl['NUMOBS_MORE'].fill_value = -1
+
     return mtl

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import numpy as np
 from astropy.table import Table
@@ -9,19 +10,19 @@ class TestMTL(unittest.TestCase):
     
     def setUp(self):
         self.targets = Table()
-        self.types = np.array(['ELG', 'LRG', 'QSO', 'QSO'])
+        self.types = np.array(['ELG', 'LRG', 'QSO', 'QSO', 'ELG'])
         self.priorities = [Mx[t].priorities['UNOBS'] for t in self.types]
         self.post_prio = [Mx[t].priorities['MORE_ZGOOD'] for t in self.types]
         self.post_prio[0] = 0  #- ELG
         self.post_prio[2] = 0  #- low-z QSO
         self.targets['DESI_TARGET'] = [Mx[t].mask for t in self.types]
         n = len(self.targets)
-        self.targets['ZFLUX'] = 10**((22.5-np.linspace(20, 21.5, n))/2.5)
+        self.targets['ZFLUX'] = 10**((22.5-np.linspace(20, 22, n))/2.5)
         self.targets['TARGETID'] = range(n)
         
         #- reverse the order for zcat to make sure joins work
         self.zcat = Table()
-        self.zcat['TARGETID'] = self.targets['TARGETID'][-1::-1]
+        self.zcat['TARGETID'] = self.targets['TARGETID'][-2::-1]
         self.zcat['Z'] = [2.5, 1.0, 0.5, 1.0]
         self.zcat['ZWARN'] = [0, 0, 0, 0]
         self.zcat['NUMOBS'] = [1, 1, 1, 1]
@@ -36,7 +37,7 @@ class TestMTL(unittest.TestCase):
     def test_numobs(self):
         mtl = make_mtl(self.targets)
         mtl.sort(keys='TARGETID')
-        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [1, 2, 4, 4]))
+        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [1, 2, 4, 4, 1]))
         self.assertTrue(np.all(mtl['PRIORITY'] == self.priorities))
         iselg = (self.types == 'ELG')
         self.assertTrue(np.all(mtl['GRAYLAYER'][iselg] != 0))
@@ -45,8 +46,18 @@ class TestMTL(unittest.TestCase):
     def test_zcat(self):
         mtl = make_mtl(self.targets, self.zcat, trim=False)
         mtl.sort(keys='TARGETID')
-        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [0, 1, 0, 3]))
+        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [0, 1, 0, 3, 1]))
         self.assertTrue(np.all(mtl['PRIORITY'] == self.post_prio))
+
+    def test_mtl_io(self):
+        mtl = make_mtl(self.targets, self.zcat, trim=True)
+        testfile = 'test-aszqweladfqwezceas.fits'
+        mtl.write(testfile, overwrite=True)
+        x = mtl.read(testfile)
+        os.remove(testfile)
+        if x.masked:
+            self.assertTrue(np.all(mtl['NUMOBS_MORE'].mask == x['NUMOBS_MORE'].mask))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR works around astropy.table.Table bugs [#4707](https://github.com/astropy/astropy/issues/4707) and [#4708](https://github.com/astropy/astropy/issues/4708).  The combination of those bugs was causing Merged Target List tables with NUMOBS_MORE=1 to be masked when read back in, but only when those Tables had been generated including feedback from previous spectroscopic observations.

All tests pass, including a new test that verifies that this workaround works (i.e. if they "fix" it in a way that breaks our workaround, we'll find out).