### PR TITLE
update color cuts to match the FDR

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -149,13 +149,13 @@ def psflike(psftype):
     psflike = ((psftype == 'PSF') | (psftype == 'PSF '))
     return psflike
 
-def isBGS(rflux, type=None, primary=None):
+def isBGS(rflux, objtype=None, primary=None):
     """Target Definition of BGS. Returning a boolean array.
 
     Args:
         rflux: array_like
             The flux in nano-maggies of r band.
-        type: array_like or None
+        objtype: array_like or None
             If given, The TYPE column of the catalogue.
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
@@ -170,11 +170,11 @@ def isBGS(rflux, type=None, primary=None):
         primary = np.ones_like(rflux, dtype='?')
     bgs = primary.copy()
     bgs &= rflux > 10**((22.5-19.5)/2.5)
-    if type is not None:
-        bgs &= ~psflike(type)
+    if objtype is not None:
+        bgs &= ~psflike(objtype)
     return bgs
 
-def isQSO(gflux, rflux, zflux, wflux, type=None, wise_snr=None, primary=None):
+def isQSO(gflux, rflux, zflux, wflux, objtype=None, wise_snr=None, primary=None):
     """Target Definition of QSO. Returning a boolean array.
 
     Args:
@@ -188,7 +188,7 @@ def isQSO(gflux, rflux, zflux, wflux, type=None, wise_snr=None, primary=None):
             is assumed to be w1flux and w2flux, and the composition
             rule described in the TargetSelection documentation is used to
             composite a wflux.
-        type: arary_like or None
+        objtype: arary_like or None
             If given, the TYPE column of the catalogue
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
@@ -232,8 +232,8 @@ def isQSO(gflux, rflux, zflux, wflux, type=None, wise_snr=None, primary=None):
         qso &= wise_snr[..., 0] > 4
         qso &= wise_snr[..., 1] > 2
 
-    if type is not None:
-        qso &= psflike(type)
+    if objtype is not None:
+        qso &= psflike(objtype)
 
     return qso
 
@@ -338,16 +338,16 @@ def apply_cuts(objects):
 
     elg = isELG(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux)
 
-    bgs = isBGS(primary=primary, rflux=rflux, type=objects['TYPE'])
+    bgs = isBGS(primary=primary, rflux=rflux, objtype=objtype)
 
     qso = isQSO(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
-                wflux=(w1flux, w2flux), type=objects['TYPE'],
+                wflux=(w1flux, w2flux), objtype=objtype,
                 wise_snr=wise_snr)
 
     #----- Standard stars
     fstd = isFSTD_colors(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux)
 
-    fstd &= psflike(objects['TYPE'])
+    fstd &= psflike(objtype)
     fracflux = objects['DECAM_FRACFLUX'].T        
     signal2noise = objects['DECAM_FLUX'] * np.sqrt(objects['DECAM_FLUX_IVAR'])
     with warnings.catch_warnings():

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -37,14 +37,13 @@ def isLRG(rflux, zflux, w1flux, primary=None):
         primary = np.ones_like(rflux, dtype='?')
 
     lrg = primary.copy()
-    lrg &= rflux > 10**((22.5-23.0)/2.5)
-    lrg &= zflux > 10**((22.5-22.56)/2.5)
-    lrg &= w1flux > 10**((22.5-19.35)/2.5)
-    lrg &= zflux > rflux * 10**(1.6/2.5)
+    lrg &= zflux > 10**((22.5-22.46)/2.5)  # z<20.46
+    lrg &= zflux > rflux * 10**(1.5/2.5)   # (r-z)>1.5
+    lrg &= w1flux > 0                      # W1flux>0
     #- clip to avoid warnings from negative numbers raised to fractional powers
     rflux = rflux.clip(0)
     zflux = zflux.clip(0)
-    lrg &= w1flux * rflux**(1.33-1) > zflux**1.33 * 10**(-0.33/2.5)
+    lrg &= w1flux * rflux**(1.8-1.0) > zflux**1.8 * 10**(-1.0/2.5)
 
     return lrg
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -174,13 +174,13 @@ def isBGS(rflux, objtype=None, primary=None):
         bgs &= ~psflike(objtype)
     return bgs
 
-def isQSO(gflux, rflux, zflux, wflux, objtype=None, wise_snr=None, primary=None):
+def isQSO(gflux, rflux, zflux, w1flux, w2flux, objtype=None,
+          wise_snr=None, primary=None):
     """Target Definition of QSO. Returning a boolean array.
 
     Args:
-        gflux, rflux, zflux: array_like
-            The flux in nano-maggies of g, r, z band.
-        wflux: two-element tuple of w1flux and w2flux
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, W1, and W2 bands.
         objtype: array_like or None
             If given, the TYPE column of the Tractor catalogue.
         wise_snr: array_like or None
@@ -196,9 +196,6 @@ def isQSO(gflux, rflux, zflux, wflux, objtype=None, wise_snr=None, primary=None)
     #----- Quasars
     if primary is None:
         primary = np.ones_like(gflux, dtype='?')
-
-    if isinstance(wflux, tuple):
-        w1flux, w2flux = wflux[0], wflux[1]
 
     # Create some composite fluxes.
     wflux = 0.75* w1flux + 0.25*w2flux
@@ -254,12 +251,12 @@ def unextinct_fluxes(objects):
             WISE_FLUX, and WISE_MW_TRANSMISSION
             
     Returns:
-        array or Table with columns GFLUX, RFLUX, ZFLUX, W1FLUX, W2FLUX, WFLUX
+        array or Table with columns GFLUX, RFLUX, ZFLUX, W1FLUX, W2FLUX
         
     Output type is Table if input is Table, otherwise numpy structured array
     """
     dtype = [('GFLUX', 'f4'), ('RFLUX', 'f4'), ('ZFLUX', 'f4'),
-             ('W1FLUX', 'f4'), ('W2FLUX', 'f4'), ('WFLUX', 'f4')]
+             ('W1FLUX', 'f4'), ('W2FLUX', 'f4')]
     if _is_row(objects):
         result = np.zeros(1, dtype=dtype)[0]
     else:
@@ -273,7 +270,6 @@ def unextinct_fluxes(objects):
     dered_wise_flux = objects['WISE_FLUX'] / objects['WISE_MW_TRANSMISSION']
     result['W1FLUX'] = dered_wise_flux[..., 0]
     result['W2FLUX'] = dered_wise_flux[..., 1]
-    result['WFLUX']  = 0.75* result['W1FLUX'] + 0.25*result['W2FLUX']
 
     if isinstance(objects, Table):
         return Table(result)
@@ -336,7 +332,7 @@ def apply_cuts(objects):
     bgs = isBGS(primary=primary, rflux=rflux, objtype=objtype)
 
     qso = isQSO(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
-                wflux=(w1flux, w2flux), objtype=objtype,
+                w1flux=w1flux, w2flux=w2flux, objtype=objtype,
                 wise_snr=wise_snr)
 
     #----- Standard stars

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -66,11 +66,11 @@ def isELG(gflux, rflux, zflux, primary=None):
     if primary is None:
         primary = np.ones_like(gflux, dtype='?')
     elg = primary.copy()
-    elg &= rflux > 10**((22.5-23.4)/2.5)
-    elg &= zflux > rflux * 10**(0.3/2.5)
-    elg &= zflux < rflux * 10**(1.5/2.5)
-    elg &= rflux**2 < gflux * zflux * 10**(-0.2/2.5)
-    elg &= zflux < gflux * 10**(1.2/2.5)
+    elg &= rflux > 10**((22.5-23.4)/2.5)                       # r<23.4
+    elg &= zflux > rflux * 10**(0.3/2.5)                       # (r-z)>0.3
+    elg &= zflux < rflux * 10**(1.6/2.5)                       # (r-z)<1.6
+    elg &= rflux**2.15 < gflux * zflux**1.15 * 10**(-0.15/2.5) # (g-r)<1.15(r-z)-0.15
+    elg &= zflux**1.2 < gflux * rflux**0.2 * 10**(1.6/2.5)     # (g-r)<1.6-1.2(r-z)
 
     return elg
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -201,6 +201,7 @@ def isQSO(gflux, rflux, zflux, w1flux, w2flux, objtype=None,
     wflux = 0.75* w1flux + 0.25*w2flux
     grzflux = (gflux + 0.8*rflux + 0.5*zflux) / 2.4
 
+    qso = primary.copy()
     qso &= rflux > 10**((22.5-23.0)/2.5)    # r<23
     qso &= grzflux < 10**((22.5-17)/2.5)    # grz>17
     qso &= rflux < gflux * 10**(1.3/2.5)    # (g-r)<1.3

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -180,16 +180,11 @@ def isQSO(gflux, rflux, zflux, wflux, objtype=None, wise_snr=None, primary=None)
     Args:
         gflux, rflux, zflux: array_like
             The flux in nano-maggies of g, r, z band.
-        wflux: array or tuple of arrays
-            If an array is given, the array is the composited
-            w band flux in nano-maggies. (from w1 and w2,
-            refer to TargetSelection documentation for the definition).
-            If a tuple is given, the first two items of the tuple
-            is assumed to be w1flux and w2flux, and the composition
-            rule described in the TargetSelection documentation is used to
-            composite a wflux.
-        objtype: arary_like or None
-            If given, the TYPE column of the catalogue
+        wflux: two-element tuple of w1flux and w2flux
+        objtype: array_like or None
+            If given, the TYPE column of the Tractor catalogue.
+        wise_snr: array_like or None
+            If given, the S/N in the W1 and W2 bands.
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -26,7 +26,7 @@ class TestCuts(unittest.TestCase):
         self.assertTrue(isinstance(t1, np.ndarray))
         t2 = cuts.unextinct_fluxes(Table(targets))
         self.assertTrue(isinstance(t2, Table))
-        for col in ['GFLUX', 'RFLUX', 'ZFLUX', 'W1FLUX', 'W2FLUX', 'WFLUX']:
+        for col in ['GFLUX', 'RFLUX', 'ZFLUX', 'W1FLUX', 'W2FLUX']:
             self.assertIn(col, t1.dtype.names)
             self.assertIn(col, t2.dtype.names)
             self.assertTrue(np.all(t1[col] == t2[col]))

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -62,7 +62,7 @@ class TestCuts(unittest.TestCase):
         rflux = flux['RFLUX']
         zflux = flux['ZFLUX']
         w1flux = flux['W1FLUX']
-        wflux = flux['WFLUX']
+        w2flux = flux['W2FLUX']
         primary = targets['BRICK_PRIMARY']
         lrg1 = cuts.isLRG(rflux, zflux, w1flux, primary=None)
         lrg2 = cuts.isLRG(rflux, zflux, w1flux, primary=primary)
@@ -73,12 +73,14 @@ class TestCuts(unittest.TestCase):
         self.assertTrue(np.all(elg1==elg2))
 
         psftype = targets['TYPE']
-        bgs1 = cuts.isBGS(rflux, type=psftype, primary=primary)
-        bgs2 = cuts.isBGS(rflux, type=None, primary=None)
+        bgs1 = cuts.isBGS(rflux, objtype=psftype, primary=primary)
+        bgs2 = cuts.isBGS(rflux, objtype=None, primary=None)
         self.assertTrue(np.all(bgs1==bgs2))
 
-        qso1 = cuts.isQSO(gflux, rflux, zflux, wflux, type=psftype, primary=primary)
-        qso2 = cuts.isQSO(gflux, rflux, zflux, wflux, type=None, primary=None)
+        qso1 = cuts.isQSO(gflux, rflux, zflux, w1flux, w2flux,
+                          objtype=psftype, primary=primary)
+        qso2 = cuts.isQSO(gflux, rflux, zflux, w1flux, w2flux,
+                          objtype=None, primary=None)
         self.assertTrue(np.all(qso1==qso2))
 
         fstd1 = cuts.isFSTD_colors(gflux, rflux, zflux, primary=None)


### PR DESCRIPTION
This PR attempts (hopefully successfully) to update the color cuts to match the latest cuts documented in Chapter 3 of the [Final Design Report](http://desi.lbl.gov/tdr) and on the [Target Selection wiki](https://desi.lbl.gov/trac/wiki/TargetSelectionWG/TargetSelection).

I need to make some QA plots to make sure there aren't any sign errors (closing #21 will be very useful in this regard) and if there are other suggested tests to increase coverage it would be great to incorporate them before merging.

@nathalieGit could you please take a look at the quasar cuts when you get a chance? In particular, note that the WFLUX and GRZ composite fluxes are now defined in desitarget.cuts.isQSO() rather than desitarget.cuts.unextinct_fluxes(), among other changes.