### PR TITLE
color-cuts (targeting) functions now take all fluxes as input

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -18,7 +18,7 @@ A collection of helpful (static) methods to check whether an object's
 flux passes a given selection criterion (e.g. LRG, ELG or QSO).
 """
 
-def isLRG(gflux, rflux, zflux, w1flux, w2flux, primary=None):
+def isLRG(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, primary=None):
     """Target Definition of LRG. Returning a boolean array.
 
     Args:
@@ -47,7 +47,7 @@ def isLRG(gflux, rflux, zflux, w1flux, w2flux, primary=None):
 
     return lrg
 
-def isELG(gflux, rflux, zflux, w1flux, w2flux, primary=None):
+def isELG(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, primary=None):
     """Target Definition of ELG. Returning a boolean array.
 
     Args:
@@ -77,7 +77,7 @@ def isELG(gflux, rflux, zflux, w1flux, w2flux, primary=None):
 
     return elg
 
-def isFSTD_colors(gflux, rflux, zflux, w1flux, w2flux, primary=None):
+def isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, primary=None):
     """Select FSTD targets just based on color cuts. Returns a boolean array. 
 
     Args:
@@ -108,7 +108,7 @@ def isFSTD_colors(gflux, rflux, zflux, w1flux, w2flux, primary=None):
 
     return fstd
 
-def isMWSSTAR_colors(gflux, rflux, zflux, w1flux, w2flux, primary=None):
+def isMWSSTAR_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, primary=None):
     """Select a reasonable range of g-r colors for MWS targets. Returns a boolean array. 
 
     Args:
@@ -148,7 +148,7 @@ def psflike(psftype):
     psflike = ((psftype == 'PSF') | (psftype == 'PSF '))
     return psflike
 
-def isBGS(gflux, rflux, zflux, w1flux, w2flux, objtype=None, primary=None):
+def isBGS(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, objtype=None, primary=None):
     """Target Definition of BGS. Returning a boolean array.
 
     Args:
@@ -173,7 +173,7 @@ def isBGS(gflux, rflux, zflux, w1flux, w2flux, objtype=None, primary=None):
         bgs &= ~psflike(objtype)
     return bgs
 
-def isQSO(gflux, rflux, zflux, w1flux, w2flux, objtype=None,
+def isQSO(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, objtype=None,
           wise_snr=None, primary=None):
     """Target Definition of QSO. Returning a boolean array.
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -18,12 +18,12 @@ A collection of helpful (static) methods to check whether an object's
 flux passes a given selection criterion (e.g. LRG, ELG or QSO).
 """
 
-def isLRG(rflux, zflux, w1flux, primary=None):
+def isLRG(gflux, rflux, zflux, w1flux, w2flux, primary=None):
     """Target Definition of LRG. Returning a boolean array.
 
     Args:
-        rflux, zflux, w1flux : array_like
-            The flux in nano-maggies of r, z, and w1 band.
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, w1, and w2 bands.
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
 
@@ -47,12 +47,12 @@ def isLRG(rflux, zflux, w1flux, primary=None):
 
     return lrg
 
-def isELG(gflux, rflux, zflux, primary=None):
+def isELG(gflux, rflux, zflux, w1flux, w2flux, primary=None):
     """Target Definition of ELG. Returning a boolean array.
 
     Args:
-        gflux, rflux, zflux : array_like
-            The flux in nano-maggies of g, r, and z band.
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, w1, and w2 bands.
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
 
@@ -77,12 +77,12 @@ def isELG(gflux, rflux, zflux, primary=None):
 
     return elg
 
-def isFSTD_colors(gflux, rflux, zflux, primary=None):
+def isFSTD_colors(gflux, rflux, zflux, w1flux, w2flux, primary=None):
     """Select FSTD targets just based on color cuts. Returns a boolean array. 
 
     Args:
-        gflux, rflux, zflux : array_like
-            Flux in nano-maggies of g, r, and z band.
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, w1, and w2 bands.
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
 
@@ -108,12 +108,12 @@ def isFSTD_colors(gflux, rflux, zflux, primary=None):
 
     return fstd
 
-def isMWSSTAR_colors(gflux, rflux, primary=None):
+def isMWSSTAR_colors(gflux, rflux, zflux, w1flux, w2flux, primary=None):
     """Select a reasonable range of g-r colors for MWS targets. Returns a boolean array. 
 
     Args:
-        gflux, rflux, : array_like
-            Flux in nano-maggies of g and r bands.
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, w1, and w2 bands.
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
 
@@ -148,12 +148,12 @@ def psflike(psftype):
     psflike = ((psftype == 'PSF') | (psftype == 'PSF '))
     return psflike
 
-def isBGS(rflux, objtype=None, primary=None):
+def isBGS(gflux, rflux, zflux, w1flux, w2flux, objtype=None, primary=None):
     """Target Definition of BGS. Returning a boolean array.
 
     Args:
-        rflux: array_like
-            The flux in nano-maggies of r band.
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, w1, and w2 bands.
         objtype: array_like or None
             If given, The TYPE column of the catalogue.
         primary: array_like or None

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -18,7 +18,7 @@ A collection of helpful (static) methods to check whether an object's
 flux passes a given selection criterion (e.g. LRG, ELG or QSO).
 """
 
-def isLRG(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, primary=None):
+def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, primary=None):
     """Target Definition of LRG. Returning a boolean array.
 
     Args:
@@ -47,7 +47,7 @@ def isLRG(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, p
 
     return lrg
 
-def isELG(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, primary=None):
+def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, primary=None):
     """Target Definition of ELG. Returning a boolean array.
 
     Args:
@@ -77,7 +77,7 @@ def isELG(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, p
 
     return elg
 
-def isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, primary=None):
+def isFSTD_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, primary=None):
     """Select FSTD targets just based on color cuts. Returns a boolean array. 
 
     Args:
@@ -108,7 +108,7 @@ def isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w
 
     return fstd
 
-def isMWSSTAR_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, primary=None):
+def isMWSSTAR_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, primary=None):
     """Select a reasonable range of g-r colors for MWS targets. Returns a boolean array. 
 
     Args:
@@ -148,7 +148,7 @@ def psflike(psftype):
     psflike = ((psftype == 'PSF') | (psftype == 'PSF '))
     return psflike
 
-def isBGS(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, objtype=None, primary=None):
+def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, objtype=None, primary=None):
     """Target Definition of BGS. Returning a boolean array.
 
     Args:
@@ -173,7 +173,7 @@ def isBGS(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, o
         bgs &= ~psflike(objtype)
     return bgs
 
-def isQSO(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, objtype=None,
+def isQSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, objtype=None,
           wise_snr=None, primary=None):
     """Target Definition of QSO. Returning a boolean array.
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -63,27 +63,27 @@ class TestCuts(unittest.TestCase):
         w1flux = flux['W1FLUX']
         w2flux = flux['W2FLUX']
         primary = targets['BRICK_PRIMARY']
-        lrg1 = cuts.isLRG(rflux, zflux, w1flux, primary=None)
-        lrg2 = cuts.isLRG(rflux, zflux, w1flux, primary=primary)
+        lrg1 = cuts.isLRG(rflux=rflux, zflux=zflux, w1flux=w1flux, primary=None)
+        lrg2 = cuts.isLRG(rflux=rflux, zflux=zflux, w1flux=w1flux, primary=primary)
         self.assertTrue(np.all(lrg1==lrg2))
 
-        elg1 = cuts.isELG(gflux, rflux, zflux, primary=primary)
-        elg2 = cuts.isELG(gflux, rflux, zflux, primary=None)
+        elg1 = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux, primary=primary)
+        elg2 = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)
         self.assertTrue(np.all(elg1==elg2))
 
         psftype = targets['TYPE']
-        bgs1 = cuts.isBGS(rflux, objtype=psftype, primary=primary)
-        bgs2 = cuts.isBGS(rflux, objtype=None, primary=None)
+        bgs1 = cuts.isBGS(rflux=rflux, objtype=psftype, primary=primary)
+        bgs2 = cuts.isBGS(rflux=rflux, objtype=None, primary=None)
         self.assertTrue(np.all(bgs1==bgs2))
 
-        qso1 = cuts.isQSO(gflux, rflux, zflux, w1flux, w2flux,
+        qso1 = cuts.isQSO(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
                           objtype=psftype, primary=primary)
-        qso2 = cuts.isQSO(gflux, rflux, zflux, w1flux, w2flux,
+        qso2 = cuts.isQSO(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
                           objtype=None, primary=None)
         self.assertTrue(np.all(qso1==qso2))
 
-        fstd1 = cuts.isFSTD_colors(gflux, rflux, zflux, primary=None)
-        fstd2 = cuts.isFSTD_colors(gflux, rflux, zflux, primary=primary)
+        fstd1 = cuts.isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)
+        fstd2 = cuts.isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=primary)
         self.assertTrue(np.all(fstd1==fstd2))
 
     #- cuts should work with tables from several I/O libraries


### PR DESCRIPTION
Simple change to the low-level target-selection functions in ```desitarget.cuts``` (e.g., ```isLRG```, ```isFSTD```, etc.) so that they now take all the grzW1W2 fluxes as input, even though not all the fluxes are used.  This is needed for a major refactoring happening in https://github.com/desihub/desisim/pull/132.

The only update needed that I could find was to ```desisim.test.test_cuts```.