### PR TITLE
Fixes bug in whitespace_fits_read

### DIFF
--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -281,7 +281,7 @@ def whitespace_fits_read(filename, **kwargs):
     #ADM if the header=True option was passed then
     #ADM the output is the header and the data
     data = fitout
-    if len(fitout) == 2:
+    if 'header' in kwargs:
         data, header = fitout
 
     #ADM guard against the zero-th extension being read by fitsio
@@ -292,7 +292,7 @@ def whitespace_fits_read(filename, **kwargs):
             if kind == 'U' or kind == 'S':
                 data[colname] = np.char.rstrip(data[colname])
 
-    if len(fitout) == 2:
+    if 'header' in kwargs:
         return data, header
 
     return data


### PR DESCRIPTION
When len(data) == 2 and no header was requested, the second element of data was treated as the header; now check directly for 'header' in kwargs.

Although perhaps there was a reason for not checking explictly for the header keyword?