### PR TITLE
Clean version of the quasar Random Forest selection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.17
         - ASTROPY_VERSION=1.1.1
-        - DESIUTIL_VERSION=1.4.0
+        - DESIUTIL_VERSION=1.9.0
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES='pyyaml qt=4'

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -6,7 +6,7 @@ import os, sys
 import numpy as np
 
 from desitarget import io
-from desitarget.cuts import select_targets
+from desitarget.cuts import select_targets, qso_selection_options
 
 import warnings
 warnings.simplefilter('error')
@@ -19,6 +19,8 @@ ap = ArgumentParser()
 ap.add_argument("src", help="Tractor file or root directory with tractor files")
 ap.add_argument("dest", help="Output target selection file")
 ap.add_argument('-v', "--verbose", action='store_true')
+ap.add_argument('--qsoselection',choices=qso_selection_options,default='randomforest',
+                help="QSO target selection method")
 ### ap.add_argument('-b', "--bricklist", help='filename with list of bricknames to include')
 ap.add_argument("--numproc", type=int,
     help='number of concurrent processes to use [{}]'.format(nproc),
@@ -32,9 +34,10 @@ if len(infiles) == 0:
     print('FATAL: no sweep or tractor files found')
     sys.exit(1)
 
-targets = select_targets(infiles, numproc=ns.numproc, verbose=ns.verbose)
+targets = select_targets(infiles, numproc=ns.numproc, verbose=ns.verbose, 
+                         qso_selection=ns.qsoselection)
 
-io.write_targets(ns.dest, targets, indir=ns.src)
+io.write_targets(ns.dest, targets, indir=ns.src, qso_selection=ns.qsoselection)
 
 print('{} targets written to {}'.format(len(targets), ns.dest))
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.7.0 (unreleased)
 ------------------
 
+* Added functionality for Random Forest into quasar selection
 * Updates to be compatible with python 3.5
 * refactor of merged target list (mtl) code
 * Update template module file to DESI+Anaconda standard.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1,10 +1,13 @@
 import warnings
 from time import time
 import os.path
+
 import numbers
+import sys
 
 import numpy as np
 from astropy.table import Table, Row
+from pkg_resources import resource_filename
 
 from desitarget.internal import sharedmem
 import desitarget.targets
@@ -235,8 +238,116 @@ def isQSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, objtype=
 
     if deltaChi2 is not None:
         qso &= deltaChi2>40.
+
+    return qso
+
+
+def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, objtype=None,
+         deltaChi2=None, primary=None):
+    """Target Definition of QSO using a random forest returning a boolean array.
+
+    Args:
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, W1, and W2 bands.
+        objtype: array_like or None
+            If given, the TYPE column of the Tractor catalogue.
+        deltaChi2: array_like or None
+             If given, difference of chi2 bteween PSF and SIMP morphology
+        primary: array_like or None
+            If given, the BRICK_PRIMARY column of the catalogue.
+
+    Returns:
+        mask : array_like. True if and only the object is a QSO
+            target.
+
+    """
+    #----- Quasars
+    if primary is None:
+        primary = np.ones_like(gflux, dtype='?')
+
+    # build variables for random forest    
+    nfeatures=11 # number of variables in random forest
+    nbEntries=rflux.size
+    colors, r, DECaLSOK = getColors(nbEntries,nfeatures,gflux,rflux,zflux,w1flux,w2flux)
+
+    #Preselection to speed up the process, store the indexes
+    rMax = 22.7  # r<22.7
+    preSelection = (r<rMax) &  psflike(objtype) & DECaLSOK 
+    colorsCopy = colors.copy()
+    colorsReduced = colorsCopy[preSelection]
+    colorsIndex =  np.arange(0,nbEntries,dtype=np.int64)
+    colorsReducedIndex =  colorsIndex[preSelection]
+
+    #Path to random forest files
+    pathToRF = resource_filename('desitarget', "data")
+
+    # Compute random forest probability
+    from desitarget.myRF import myRF
+    prob = np.zeros(nbEntries)  
+   
+    if (colorsReducedIndex.any()) :
+        rf = myRF(colorsReduced,pathToRF)
+        fileName = pathToRF + '/rf_model_dr3.npz'
+        rf.loadForest(fileName)
+        objects_rf = rf.predict_proba()
+        # add random forest probability to preselected objects
+        j=0
+        for i in colorsReducedIndex :
+            prob[i]=objects_rf[j]
+            j += 1
+
+    #define pcut, relaxed cut for faint objects
+    pcut = np.where(r>20.0,0.95 - (r-20.0)*0.08,0.95)
+
+    qso = primary.copy()
+    qso &= r<rMax  
+    qso &= DECaLSOK  
+      
+    if objtype is not None:
+        qso &= psflike(objtype)
+
+    if deltaChi2 is not None:
+        qso &= deltaChi2>30.
+
+    if nbEntries==1 : # for call of a single object
+        qso &= prob[0]>pcut
+    else :
+        qso &= prob>pcut        
         
     return qso
+
+
+def getColors(nbEntries,nfeatures,gflux,rflux,zflux,w1flux,w2flux):
+ 
+    limitInf=1.e-04
+    gflux = gflux.clip(limitInf)
+    rflux = rflux.clip(limitInf)
+    zflux = zflux.clip(limitInf)
+    w1flux = w1flux.clip(limitInf)
+    w2flux = w2flux.clip(limitInf)
+
+    g=np.where( gflux>limitInf,22.5-2.5*np.log10(gflux), 0.)
+    r=np.where( rflux>limitInf,22.5-2.5*np.log10(rflux), 0.)
+    z=np.where( zflux>limitInf,22.5-2.5*np.log10(zflux), 0.)
+    W1=np.where( w1flux>limitInf, 22.5-2.5*np.log10(w1flux), 0.)
+    W2=np.where( w2flux>limitInf, 22.5-2.5*np.log10(w2flux), 0.)
+
+    DECaLSOK = (g>0.) & (r>0.) & (z>0.) & (W1>0.) & (W2>0.)
+
+    colors  = np.zeros((nbEntries,nfeatures))
+    colors[:,0]=g-r
+    colors[:,1]=r-z
+    colors[:,2]=g-z
+    colors[:,3]=g-W1
+    colors[:,4]=r-W1
+    colors[:,5]=z-W1
+    colors[:,6]=g-W2
+    colors[:,7]=r-W2
+    colors[:,8]=z-W2
+    colors[:,9]=W1-W2
+    colors[:,10]=r
+
+    return colors, r, DECaLSOK
 
 def _is_row(table):
     '''Return True/False if this is a row of a table instead of a full table
@@ -271,12 +382,18 @@ def unextinct_fluxes(objects):
     else:
         result = np.zeros(len(objects), dtype=dtype)
 
-    dered_decam_flux = objects['DECAM_FLUX'] / objects['DECAM_MW_TRANSMISSION']
+#ADM Hack for DR3 because of some corrupt sweeps/Tractor files REMOVE ONCE SWEEPS ARE FIXED!!!
+#    dered_decam_flux = objects['DECAM_FLUX'] / objects['DECAM_MW_TRANSMISSION']
+    dered_decam_flux = np.divide(objects['DECAM_FLUX'] , objects['DECAM_MW_TRANSMISSION'], 
+                                 where=objects['DECAM_MW_TRANSMISSION']!=0)
     result['GFLUX'] = dered_decam_flux[..., 1]
     result['RFLUX'] = dered_decam_flux[..., 2]
     result['ZFLUX'] = dered_decam_flux[..., 4]
 
-    dered_wise_flux = objects['WISE_FLUX'] / objects['WISE_MW_TRANSMISSION']
+#ADM Hack for DR3 because of some corrupt sweeps/Tractor files REMOVE ONCE SWEEPS ARE FIXED!!!
+#    dered_wise_flux = objects['WISE_FLUX'] / objects['WISE_MW_TRANSMISSION']
+    dered_wise_flux =  np.divide(objects['WISE_FLUX'] , objects['WISE_MW_TRANSMISSION'],
+                                 where=objects['WISE_MW_TRANSMISSION']!=0)
     result['W1FLUX'] = dered_wise_flux[..., 0]
     result['W2FLUX'] = dered_wise_flux[..., 1]
 
@@ -285,12 +402,16 @@ def unextinct_fluxes(objects):
     else:
         return result
 
-def apply_cuts(objects):
+def apply_cuts(objects,qso_selection='randomforest'):
     """Perform target selection on objects, returning target mask arrays
 
     Args:
         objects: numpy structured array with UPPERCASE columns needed for
             target selection, OR a string tractor/sweep filename
+
+    Options:
+        qso_selection : algorithm to use for QSO selection; valid options
+            are 'colorcuts' and 'randomforest'
             
     Returns:
         (desi_target, bgs_target, mws_target) where each element is
@@ -344,10 +465,16 @@ def apply_cuts(objects):
     elg = isELG(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux)
 
     bgs = isBGS(primary=primary, rflux=rflux, objtype=objtype)
-
-    qso = isQSO(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
+    
+    if qso_selection=='colorcuts' :
+        qso = isQSO(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                 w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2, objtype=objtype,
                 wise_snr=wise_snr)
+    elif qso_selection == 'randomforest':
+        qso = isQSO_randomforest(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
+                w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2, objtype=objtype)
+    else:
+        raise ValueError('Unknown qso_selection {}; valid options are {}'.format(qso_selection, qso_selection_options))
 
     #----- Standard stars
     fstd = isFSTD_colors(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux)
@@ -395,10 +522,13 @@ def apply_cuts(objects):
 
     return desi_target, bgs_target, mws_target
 
-def select_targets(infiles, numproc=4, verbose=False):
+qso_selection_options = ['colorcuts', 'randomforest']
+
+def select_targets(infiles, numproc=4, verbose=False, qso_selection='randomforest'):
     """
     Process input files in parallel to select targets
     
+
     Args:
         infiles: list of input filenames (tractor or sweep files),
             OR a single filename
@@ -406,6 +536,8 @@ def select_targets(infiles, numproc=4, verbose=False):
     Optional:
         numproc: number of parallel processes to use
         verbose: if True, print progress messages
+        qso_selection : algorithm to use for QSO selection; valid options
+            are 'colorcuts' and 'randomforest'
         
     Returns:
         targets numpy structured array: the subset of input targets which
@@ -423,14 +555,14 @@ def select_targets(infiles, numproc=4, verbose=False):
     for filename in infiles:
         if not os.path.exists(filename):
             raise ValueError("{} doesn't exist".format(filename))
-    
+
     #- function to run on every brick/sweep file
     def _select_targets_file(filename):
         '''Returns targets in filename that pass the cuts'''
         from desitarget import io
         objects = io.read_tractor(filename)
-        desi_target, bgs_target, mws_target = apply_cuts(objects)
-        
+        desi_target, bgs_target, mws_target = apply_cuts(objects,qso_selection)
+
         #- desi_target includes BGS_ANY and MWS_ANY, so we can filter just
         #- on desi_target != 0
         keep = (desi_target != 0)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -15,6 +15,8 @@ import os, re
 from . import __version__ as desitarget_version
 from . import gitversion
 
+from desiutil import depend
+
 tscolumns = [
     'BRICKID', 'BRICKNAME', 'OBJID', 'TYPE',
     'RA', 'RA_IVAR', 'DEC', 'DEC_IVAR',
@@ -104,7 +106,7 @@ def fix_tractor_dr1_dtype(objects):
         return objects.astype(np.dtype(dt))
 
 
-def write_targets(filename, data, indir=None):
+def write_targets(filename, data, indir=None, qso_selection=None):
     """Write a target catalogue.
 
     Args:
@@ -116,14 +118,16 @@ def write_targets(filename, data, indir=None):
 
     #- Create header to include versions, etc.
     hdr = fitsio.FITSHDR()
-    hdr['DEPNAM00'] = 'desitarget'
-    hdr.add_record(dict(name='DEPVER00', value=desitarget_version, comment='desitarget version'))
-    hdr['DEPNAM01'] = 'desitarget-git'
-    hdr.add_record(dict(name='DEPVER01', value=gitversion().decode('utf-8'), comment='git revision'))
-
+    depend.setdep(hdr, 'desitarget', desitarget_version)
+    depend.setdep(hdr, 'desitarget-git', gitversion().decode('utf-8'))
     if indir is not None:
-        hdr['DEPNAM02'] = 'tractor-files'
-        hdr['DEPVER02'] = indir
+        depend.setdep(hdr, 'tractor-files', indir)
+
+    if qso_selection is None:
+        print('ERROR: qso_selection method not specified for output file')
+        depend.setdep(hdr, 'qso-selection', 'unknown')
+    else:
+        depend.setdep(hdr, 'qso-selection', qso_selection)
 
     fitsio.write(filename, data, extname='TARGETS', header=hdr, clobber=True)
 

--- a/py/desitarget/myRF.py
+++ b/py/desitarget/myRF.py
@@ -13,7 +13,6 @@ class myRF :
 
     def loadTree(self,treeFile,answerFile):
     # loads one tree and checks that the recursion limit is enough
-        print(self.treeInfo)
         self.treeInfo   = np.load(treeFile)
         self.treeAnswer = np.load(answerFile)
         if len(self.treeAnswer)>sys.getrecursionlimit() :

--- a/py/desitarget/myRF.py
+++ b/py/desitarget/myRF.py
@@ -1,0 +1,104 @@
+import numpy as np
+import sys
+
+class myRF :
+    
+    def __init__(self,data,modelDir,version=1):
+    # loads the data once and initializes arrays
+        self.data  = data.copy()
+        self.proba = np.zeros(len(data))
+        self.bdtOutput = np.zeros(len(data))
+        self.modelDir = modelDir
+        self.version = version
+
+    def loadTree(self,treeFile,answerFile):
+    # loads one tree and checks that the recursion limit is enough
+        self.treeInfo   = np.load(treeFile)
+        self.treeAnswer = np.load(answerFile)
+        if len(self.treeAnswer)>sys.getrecursionlimit() :
+            sys.setrecursionlimit(int(len(self.treeAnswer)*1.2))
+            #print "WARNING recursion limit set to length(tree)*1.2 :",sys.getrecursionlimit()
+
+    def unloadTree(self):
+    # delete the current tree information to avoid memory leaks
+        del self.treeInfo
+        del self.treeAnswer
+
+    def searchNodes(self,indices,nodeId=0) :
+    # recursively navigates in the tree and calculate the tree response
+        nodeInfo=self.treeInfo[nodeId]
+#        print nodeInfo
+        if nodeInfo[0]==-1 :
+            if self.treeAnswer[nodeId,0,0]<self.treeAnswer[nodeId,0,1] :
+                score=1.
+            else :
+                score=0.
+            self.proba[indices]=score
+            return
+
+        leftChildId  = nodeInfo[0]
+        rightChildId = nodeInfo[1]
+        feature      = nodeInfo[2]
+        threshold    = nodeInfo[3]
+            
+        leftCond = (self.data[indices,feature] <= threshold)
+        leftChildIndices  = indices[leftCond]
+#        rightCond = (self.data[indices,feature] > threshold)
+        rightChildIndices = indices[leftCond==False]
+
+        self.searchNodes(leftChildIndices,nodeId=leftChildId)
+        self.searchNodes(rightChildIndices,nodeId=rightChildId)
+        return
+
+    def predict_proba(self,nTrees=200) :
+    # calculate the forest response using the average response of the trees in the forest
+
+        for iTree in np.arange(nTrees) :
+            #if iTree%10 == 0 : print ("tree=",iTree)
+            self.loadTreeFromForest(iTree)
+            self.searchNodes(np.arange(len(self.data)))
+            self.bdtOutput+=self.proba
+        
+        self.bdtOutput/=nTrees
+        return self.bdtOutput
+
+    def loadForest(self,forestFileName,nTrees=200,version=1) :
+    # loads forest
+        t = np.load(forestFileName,encoding='bytes')
+        self.forest = t['arr_0']
+        return
+
+    def loadTreeFromForest(self,iTree):
+    # loads one tree from the forest file and checks that the recursion limit is enough
+        self.treeInfo   = self.forest[iTree*2]
+        self.treeAnswer = self.forest[iTree*2+1]
+        if len(self.treeAnswer)>sys.getrecursionlimit() :
+            sys.setrecursionlimit(int(len(self.treeAnswer)*1.2))
+            #print "WARNING recursion limit set to length(tree)*1.2 :",sys.getrecursionlimit()
+
+    def saveForest(self,forestFileName,nTrees=200,version=1) :
+    # reads trees useful information and stores them in forestFileName
+
+        if self.version==1:
+            filesPerTree = 4 # for models-decals-dr3, (was 5 for models-decals)
+        else :
+            print ("unsupported version=",self.version)
+            sys.exit()
+
+        forest = []
+
+        for iTree in np.arange(nTrees) :
+            if iTree%10 == 0 : print ("tree=",iTree)
+            fileNumber = (iTree*filesPerTree+4)
+            if iTree<2 :
+                treeFile   = self.modelDir+"bdt.pkl_"+str(fileNumber).zfill(2)+".npy"
+                answerFile = self.modelDir+"bdt.pkl_"+str(fileNumber-1).zfill(2)+".npy"
+            else :
+                treeFile   = self.modelDir+"bdt.pkl_"+str(fileNumber)+".npy"
+                answerFile = self.modelDir+"bdt.pkl_"+str(fileNumber-1)+".npy"
+
+            forest.append(np.load(treeFile))
+            forest.append(np.load(answerFile))
+        np.savez_compressed(forestFileName,forest)
+        return
+

--- a/py/desitarget/myRF.py
+++ b/py/desitarget/myRF.py
@@ -13,6 +13,7 @@ class myRF :
 
     def loadTree(self,treeFile,answerFile):
     # loads one tree and checks that the recursion limit is enough
+        print(self.treeInfo)
         self.treeInfo   = np.load(treeFile)
         self.treeAnswer = np.load(answerFile)
         if len(self.treeAnswer)>sys.getrecursionlimit() :

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -133,6 +133,14 @@ class TestCuts(unittest.TestCase):
 
                 self.assertTrue(np.all(t1[col][notNaN]==t2[col][notNaN]))
 
+    def test_qso_selection_options(self):
+        targetfile = self.tractorfiles[0]
+        for qso_selection in cuts.qso_selection_options:
+            results = cuts.select_targets(targetfile, qso_selection=qso_selection)
+            
+        with self.assertRaises(ValueError):
+            results = cuts.select_targets(targetfile, numproc=1, qso_selection='blatfoo')
+
     def test_missing_files(self):
         with self.assertRaises(ValueError):
             targets = cuts.select_targets(['blat.foo1234',], numproc=1)


### PR DESCRIPTION
This PR supersedes https://github.com/desihub/desitarget/pull/80. It is a full version of the quasar Random Forest selection but Python 2/3 changes have been merged self-consistently. It addresses all of the requests in https://github.com/desihub/desitarget/pull/80 but ensures

* Python 2 and 3 compatibility
* Unit tests are passed and new code has coverage
* Non-standard file formats are somewhat circumvented (there are no tar or pickle files, the RF is stored as a numpy instance, which is not ideal but is better than previous options)

Note that the training code has deliberately been left out of this PR, but could be included if @sbailey thinks it prudent. The training code would require some documentation to be useful to a general user.

Once this is merged https://github.com/desihub/desitarget/pull/80 can be closed (without merging).

h/t Christophe Yeche and Etienne Burtin