### PR TITLE
mock truth file TRUETYPE to match SPECTYPE, not sourcetype

### DIFF
--- a/doc/mock_example/input.yaml
+++ b/doc/mock_example/input.yaml
@@ -1,6 +1,12 @@
 #mock target configuration file
 output_dir: /tmp
 run_label:  GX_100PC_MXXL_JT2P4Y_JULY16_B
+subset:
+    ra_dec_cut: False
+    min_ra: 200
+    max_ra: 220
+    min_dec: 0
+    max_dec: 20
 sources:
     SKY: {
         number_density: 1400.0,

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -213,16 +213,6 @@ def read_galaxia(mock_dir, target_type, mock_name=None):
 
     # Read each file
     print('Reading individual mock files')
-    # target_list = list()
-    # file_list   = list()
-    # nfiles      = 0
-    # for mock_file in iter_mock_files:
-    #     nfiles += 1
-    #     data_this_file = _load_mock_mws_file(mock_file)
-    #     target_list.append(data_this_file)
-    #     file_list.append(mock_file)
-    #     print('read file {} {}'.format(nfiles, mock_file))
-
     file_list = list(iter_mock_files)
     nfiles = len(file_list)
     import multiprocessing

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -62,7 +62,7 @@ def _load_mock_mws_file(filename):
         'SDSS[grz]_obs': :class: `numpy.ndarray`
              Apparent magnitudes in SDSS grz bands, including extinction.
     """
-
+    print('Reading '+filename)
     C_LIGHT = 299792.458
     desitarget.io.check_fitsio_version()
     data = fitsio.read(filename,
@@ -213,15 +213,23 @@ def read_galaxia(mock_dir, target_type, mock_name=None):
 
     # Read each file
     print('Reading individual mock files')
-    target_list = list()
-    file_list   = list()
-    nfiles      = 0
-    for mock_file in iter_mock_files:
-        nfiles += 1
-        data_this_file = _load_mock_mws_file(mock_file)
-        target_list.append(data_this_file)
-        file_list.append(mock_file)
-        print('read file {} {}'.format(nfiles, mock_file))
+    # target_list = list()
+    # file_list   = list()
+    # nfiles      = 0
+    # for mock_file in iter_mock_files:
+    #     nfiles += 1
+    #     data_this_file = _load_mock_mws_file(mock_file)
+    #     target_list.append(data_this_file)
+    #     file_list.append(mock_file)
+    #     print('read file {} {}'.format(nfiles, mock_file))
+
+    file_list = list(iter_mock_files)
+    nfiles = len(file_list)
+    import multiprocessing
+    ncpu = max(1, multiprocessing.cpu_count() // 2)
+    print('using {} parallel readers'.format(ncpu))
+    p = multiprocessing.Pool(ncpu)
+    target_list = p.map(_load_mock_mws_file, file_list)
 
     print('Read {} files'.format(nfiles))
 


### PR DESCRIPTION
This PR updates the truth table output to have TRUETYPE match what a redshift fitter should report in SPECTYPE, i.e. 'GALAXY', 'QSO', or 'STAR' instead of 'ELG, 'LRG', 'MWS_WD', etc.  The original source type is stored as a column 'SOURCETYPE', which we may or may not need.

Other changes that came along for the ride:
* Added example for how to subset by RA,dec boundaries to doc/mock_example/input.yaml
* Updated subsetting to be at the beginning while reading in mocks rather than just before writing the final results out.  This is for speed, to avoid calculating a bunch of things for targets that will be discarded anyway.
* Parallelized reading the 300 input galaxia mock files

I tested this with a quick_survey loop over 8 epochs and verified that all target types are still observed.  It turns out that this did not require any changes to quickcat since that already supported TRUETYPE='GALAXY' (plus DESI_TARGET bits) vs. TRUETYPE='ELG', 'LRG', 'QSO', etc.
