### PR TITLE
target bits and MTL logic for bright object masks

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,6 +2,12 @@
 desitarget Change Log
 =====================
 
+0.7.1 (unreleased)
+------------------
+
+* Adds DESI_TARGET bits for bright object masking
+* MTL sets priority=-1 for any target with IN_BRIGHT_OBJECT set
+
 0.7.0 (2016-10-12)
 ------------------
 

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -25,6 +25,14 @@ desi_mask:
     - [STD_BRIGHT,  35, "F-type standard for BRIGHT conditions",
         {obsconditions: BRIGHT}]
 
+    #- Related to bright object masking
+    - [BRIGHT_OBJECT,       50, "Known bright object to avoid", {obsconditions: APOCALYPSE}]
+    - [IN_BRIGHT_OBJECT,    51, "Too near a bright object; DO NOT OBSERVE", {obsconditions: APOCALYPSE}]
+    - [NEAR_BRIGHT_OBJECT,  52, "Near a bright object but ok to observe",
+            {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [SAFE,                53, "Safe location near bright object to be used if needed",
+            {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+
     #- A bit for another survey is set
     - [BGS_ANY,             60, "Any BGS bit is set", {obsconditions: BRIGHT}]
     - [MWS_ANY,             61, "Any MWS bit is set", {obsconditions: BRIGHT}]
@@ -157,6 +165,8 @@ priorities:
         LRG_SOUTH: SAME_AS_LRG
         ELG_SOUTH: SAME_AS_ELG
         QSO_SOUTH: SAME_AS_QSO
+        #- Lowest positive priority of all
+        SAFE: {UNOBS: 1, OBS: 1, DONE: 1, MORE_ZWARN: 1, MORE_ZGOOD: 1}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FSTAR:  -1
         STD_WD:     -1
@@ -164,6 +174,9 @@ priorities:
         STD_BRIGHT: -1
         #- placeholders to show we haven't forgotten these bits, but the
         #- exact bits in the other sections define the priorities
+        BRIGHT_OBJECT: -1
+        IN_BRIGHT_OBJECT: -1
+        NEAR_BRIGHT_OBJECT: -1
         BGS_ANY: -1
         MWS_ANY: -1
         ANCILLARY_ANY: -1

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -151,7 +151,7 @@ obsmask:
 #- -1 means the concept of priority doesn't really apply to this target class
 #- Every target bit must define priority for "UNOBS"
 #- Default priority for "MORE_ZGOOD" is same as "UNOBS"
-#- Other states are default 0 unless specified here
+#- Other states are default 1 unless specified here
 #- -1 means that the concept of priority doesn't apply to this bit
 priorities:
     #- Dark Survey: priorities 3000 - 3999
@@ -165,8 +165,7 @@ priorities:
         LRG_SOUTH: SAME_AS_LRG
         ELG_SOUTH: SAME_AS_ELG
         QSO_SOUTH: SAME_AS_QSO
-        #- Lowest positive priority of all
-        SAFE: {UNOBS: 1, OBS: 1, DONE: 1, MORE_ZWARN: 1, MORE_ZGOOD: 1}
+        SAFE: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FSTAR:  -1
         STD_WD:     -1

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -64,9 +64,9 @@ def make_mtl(targets, zcat=None, trim=False):
     # Assign priorities
     mtl['PRIORITY'] = calc_priority(ztargets)
 
-    # If priority went to 0, then NUMOBS_MORE should also be 0
+    # If priority went to 0 or 1, then NUMOBS_MORE should also be 0
     ### mtl['NUMOBS_MORE'] = ztargets['NUMOBS_MORE']
-    ii = (mtl['PRIORITY'] == 0)
+    ii = (mtl['PRIORITY'] <= 1)
     print('{:d} of {:d} targets have priority zero, setting N_obs=0.'.format(np.sum(ii),len(mtl)))
 
     mtl['NUMOBS_MORE'][ii] = 0

--- a/py/desitarget/targetmask.py
+++ b/py/desitarget/targetmask.py
@@ -26,10 +26,10 @@ for maskname, priorities in _bitdefs['priorities'].items():
             if 'MORE_ZGOOD' not in priorities[bitname]:
                 priorities[bitname]['MORE_ZGOOD'] = priorities[bitname]['UNOBS']
 
-            #- fill in other states as 0 priority
+            #- fill in other states as priority=1
             for state, blat, foo in _bitdefs['obsmask']:
                 if state not in priorities[bitname]:
-                    priorities[bitname][state] = 0
+                    priorities[bitname][state] = 1
         else:
             priorities[bitname] = dict()
 

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -229,6 +229,10 @@ def calc_priority(targets):
             priority[ii & zgood] = np.maximum(priority[ii & zgood], mws_mask[name].priorities['MORE_ZGOOD'])
             priority[ii & zwarn] = np.maximum(priority[ii & zwarn], mws_mask[name].priorities['MORE_ZWARN'])
 
+    # Special case: IN_BRIGHT_OBJECT means priority=-1 no matter what
+    ii = (targets['DESI_TARGET'] & desi_mask.IN_BRIGHT_OBJECT) != 0
+    priority[ii] = -1
+
     return priority
 
 ############################################################

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -14,8 +14,8 @@ class TestMTL(unittest.TestCase):
         self.types = np.array(['ELG', 'LRG', 'QSO', 'QSO', 'ELG'])
         self.priorities = [Mx[t].priorities['UNOBS'] for t in self.types]
         self.post_prio = [Mx[t].priorities['MORE_ZGOOD'] for t in self.types]
-        self.post_prio[0] = 0  #- ELG
-        self.post_prio[2] = 0  #- low-z QSO
+        self.post_prio[0] = 1  #- ELG
+        self.post_prio[2] = 1  #- low-z QSO
         self.targets['DESI_TARGET'] = [Mx[t].mask for t in self.types]
         self.targets['BGS_TARGET'] = np.zeros(len(self.types), dtype=np.int64)
         self.targets['MWS_TARGET'] = np.zeros(len(self.types), dtype=np.int64)
@@ -51,7 +51,13 @@ class TestMTL(unittest.TestCase):
         mtl.sort(keys='TARGETID')
         self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [0, 1, 0, 3, 1]))
         self.assertTrue(np.all(mtl['PRIORITY'] == self.post_prio))
-
+        
+        #- change one target to a SAFE target and confirm priority=0 not 1
+        self.targets['DESI_TARGET'][0] = Mx.SAFE
+        mtl = make_mtl(self.targets, self.zcat, trim=False)
+        mtl.sort(keys='TARGETID')
+        self.assertEqual(mtl['PRIORITY'][0], 0)
+ 
     def test_mtl_io(self):
         mtl = make_mtl(self.targets, self.zcat, trim=True)
         testfile = 'test-aszqweladfqwezceas.fits'

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -55,11 +55,22 @@ class TestPriorities(unittest.TestCase):
         self.assertEqual(p[2], bgs_mask.BGS_BRIGHT.priorities['DONE'])
         ### BGS_BRIGHT: {UNOBS: 2100, MORE_ZWARN: 2200, MORE_ZGOOD: 2300}
 
+    def test_bright_mask(self):
+        t = self.targets
+        t['DESI_TARGET'][0] = desi_mask.ELG
+        t['DESI_TARGET'][1] = desi_mask.ELG | desi_mask.NEAR_BRIGHT_OBJECT
+        t['DESI_TARGET'][2] = desi_mask.ELG | desi_mask.IN_BRIGHT_OBJECT
+        p = calc_priority(t)
+        self.assertEqual(p[0], p[1], "NEAR_BRIGHT_OBJECT shouldn't impact priority but {} != {}".format(p[0], p[1]))
+        self.assertEqual(p[2], -1, "IN_BRIGHT_OBJECT priority not -1")
+
     def test_mask_priorities(self):
         for mask in [desi_mask, bgs_mask, mws_mask]:
             for name in mask.names():
                 if name == 'SKY' or name.startswith('STD') \
-                    or name in ['BGS_ANY', 'MWS_ANY', 'ANCILLARY_ANY']:
+                    or name in ['BGS_ANY', 'MWS_ANY', 'ANCILLARY_ANY',
+                                'IN_BRIGHT_OBJECT', 'NEAR_BRIGHT_OBJECT',
+                                'BRIGHT_OBJECT']:
                     self.assertEqual(mask[name].priorities, {}, 'mask.{} has priorities?'.format(name))
                 else:
                     for state in obsmask.names():


### PR DESCRIPTION
This PR resolves #102 (define target bits for bright object masks) and #105 (MTL override priority for IN_BRIGHT_OBJECT)

This also implements one other idea based on a conversation with Adam and David S a few months ago:
* priority<0 means it is actually harmful to observe that target
* priority=0 is for SAFE locations that are ok to observe but otherwise junk
* priority=1 is unnecessary but harmless to observe (i.e. the object is done)
* priority>1 are objects of interest for observing

This allows us to designate SAFE junk locations around bright objects that get used by fiber assignment as a location of last resort (priority=0), but it will still take an otherwise done science target if one is available (priority=1).  i.e. we'd rather re-observe an ELG than throw away a fiber by assigning it to a SAFE location near a bright object instead.

Note: priority is type i8 not u8, so negative priorities are allowed.
