### PR TITLE
splits BGS bright vs. faint

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,11 +2,13 @@
 desitarget Change Log
 =====================
 
-0.7.1 (unreleased)
+0.8.0 (unreleased)
 ------------------
 
 * Adds DESI_TARGET bits for bright object masking
 * MTL sets priority=-1 for any target with IN_BRIGHT_OBJECT set
+* Many updates for reading and manipulating mock targets
+* Adds BGS_FAINT target selection
 
 0.7.0 (2016-10-12)
 ------------------

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -181,9 +181,10 @@ priorities:
         ANCILLARY_ANY: -1
 
     #- Bright Galaxy Survey: priorities 2000-2999
+    #- reobserving successes has lower priority than MWS
     bgs_mask:
-        BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2200, MORE_ZGOOD: 2300}
-        BGS_BRIGHT: {UNOBS: 2100, MORE_ZWARN: 2200, MORE_ZGOOD: 2300}
+        BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2000, MORE_ZGOOD: 1000}
+        BGS_BRIGHT: {UNOBS: 2100, MORE_ZWARN: 2100, MORE_ZGOOD: 1000}
         BGS_FAINT_SOUTH: SAME_AS_BGS_FAINT
         BGS_FAINT_NORTH: SAME_AS_BGS_FAINT
         BGS_BRIGHT_SOUTH: SAME_AS_BGS_BRIGHT

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -78,8 +78,12 @@ class TestCuts(unittest.TestCase):
         self.assertTrue(np.all(elg1==elg2))
 
         psftype = targets['TYPE']
-        bgs1 = cuts.isBGS(rflux=rflux, objtype=psftype, primary=primary)
-        bgs2 = cuts.isBGS(rflux=rflux, objtype=None, primary=None)
+        bgs1 = cuts.isBGS_bright(rflux=rflux, objtype=psftype, primary=primary)
+        bgs2 = cuts.isBGS_bright(rflux=rflux, objtype=None, primary=None)
+        self.assertTrue(np.all(bgs1==bgs2))
+
+        bgs1 = cuts.isBGS_faint(rflux=rflux, objtype=psftype, primary=primary)
+        bgs2 = cuts.isBGS_faint(rflux=rflux, objtype=None, primary=None)
         self.assertTrue(np.all(bgs1==bgs2))
 
         #- Test that objtype and primary are optional


### PR DESCRIPTION
This fixes #114 by splitting `cuts.isBGS` into `cuts.isBGS_bright` and `cuts.isBGS_faint`, and updating the reobservations priorities based upon the baseline target selection wiki page https://desi.lbl.gov/trac/wiki/TargetSelectionWG/TargetSelection .  In particular, failures are reobserved at the same priority as unobserved targets (I question that choice and MWS may scream, but that is the current baseline...), while successes are reobserved at a lower priority than MWS to build up more S/N if the fiber happens to be available.

I need this for a tag + DR3.1 target selection catalog leading up to the OSU meeting, so I'll throw it out there for a brief review but I'll self merge on Wednesday whether or not I have comments.  As always, if I self-merge but you have after-the-fact comments go ahead and make them and we can mop up as needed.