### PR TITLE
Mock flux shape

### DIFF
--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -9,6 +9,7 @@ import yaml
 parser = argparse.ArgumentParser()
 parser.add_argument('--config','-c',default='input.yaml')
 parser.add_argument("--output_dir", "-O", help="Path to write the outputs", type=str, default="./")
+parser.add_argument("--realtargets", "-r", help="Path to real target catalog", type=str)
 args = parser.parse_args()
 
 if not os.path.exists(args.config):
@@ -21,8 +22,15 @@ print('')
 with open(args.config,'r') as pfile:
     params = yaml.load(pfile)
 
+if args.realtargets is not None:
+    from astropy.io import fits
+    print('Loading real targets from {}'.format(args.realtargets))
+    realtargets = fits.getdata(args.realtargets)
+else:
+    realtargets = None
+
 # Construct Targets and Truth files
-desitarget.mock.build.targets_truth(params, args.output_dir)
+desitarget.mock.build.targets_truth(params, args.output_dir, realtargets=realtargets)
 
 print('done!')
 

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -131,31 +131,35 @@ def _load_mock_mws_file(filename):
         'SDSS[grz]_obs': :class: `numpy.ndarray`
              Apparent magnitudes in SDSS grz bands, including extinction.
     """
+    import desitarget.photo
     print('Reading '+filename)
     C_LIGHT = 299792.458
     desitarget.io.check_fitsio_version()
     data = fitsio.read(filename,
                        columns= ['objid','RA','DEC','v_helio','d_helio', 'SDSSr_true',
-                                 'SDSSr_obs', 'SDSSg_obs', 'SDSSz_obs'])
-
-
+                                 'SDSSg_obs', 'SDSSr_obs', 'SDSSi_obs', 'SDSSz_obs'])
+ 
     objid       = data['objid'].astype('i8')
     ra          = data['RA'].astype('f8') % 360.0 #enforce 0 < ra < 360
     dec         = data['DEC'].astype('f8')
-    v_helio     = data['v_helio'].astype('f8')
-    d_helio     = data['d_helio'].astype('f8')
-    SDSSr_true  = data['SDSSr_true'].astype('f8')
-    SDSSg_obs   = data['SDSSg_obs'].astype('f8')
-    SDSSr_obs   = data['SDSSr_obs'].astype('f8')
-    SDSSz_obs   = data['SDSSz_obs'].astype('f8')
+    v_helio     = data['v_helio'].astype('f4')
+    d_helio     = data['d_helio'].astype('f4')
+    SDSSr_true  = data['SDSSr_true'].astype('f4')
+    SDSSg_obs   = data['SDSSg_obs'].astype('f4')
+    SDSSr_obs   = data['SDSSr_obs'].astype('f4')
+    SDSSi_obs   = data['SDSSi_obs'].astype('f4')
+    SDSSz_obs   = data['SDSSz_obs'].astype('f4')
 
-    return {'objid':objid,
+    DECAMg_obs, DECAMr_obs, DECAMz_obs = \
+        desitarget.photo.sdss2decam(SDSSg_obs, SDSSr_obs, SDSSi_obs, SDSSz_obs)
+
+    return {'objid': objid,
             'RA':ra, 'DEC':dec, 'Z': v_helio/C_LIGHT,
             'd_helio': d_helio,
-            'SDSSr_true': SDSSr_true, 'SDSSr_obs': SDSSr_obs,
-            'SDSSg_obs' : SDSSg_obs, 'SDSSz_obs' : SDSSz_obs}
-
-
+            'SDSSr_true': DECAMr_obs,
+            'DECAMr_obs': DECAMr_obs,
+            'DECAMg_obs': DECAMg_obs,
+            'DECAMz_obs': DECAMz_obs }
 
 ############################################################
 def _load_mock_lya_file(filename):
@@ -324,7 +328,7 @@ def read_galaxia(mock_dir, target_type, mock_name=None):
             Heliocentric radial velocity divided by the speed of light.
         'SDSSr_true': :class: `numpy.ndarray`
             Apparent magnitudes in SDSS bands, including extinction.
-        'SDSSr_obs': :class: `numpy.ndarray`
+        'DECAMr_obs': :class: `numpy.ndarray`
              Apparent magnitudes in SDSS bands, including extinction.
     """
     # Build iterator of all desi_galfast files
@@ -382,7 +386,7 @@ def read_galaxia(mock_dir, target_type, mock_name=None):
         # Count number of points per file
         k          = list(target_list[0])[0] # pick the first available column
         n_per_file = [len(target_list[itarget][k]) for itarget in file_order]
-        odered_file_list = [file_list[itarget] for itarget in file_order]
+        ordered_file_list = [file_list[itarget] for itarget in file_order]
 
     print('Read {} objects'.format(np.sum(n_per_file)))
 
@@ -521,7 +525,7 @@ def read_durham_mxxl_hdf5(mock_dir, target_type, mock_name=None):
         RA          : RA positions for the objects in the mock.
         DEC         : DEC positions for the objects in the mock.
         Z           : Heliocentric radial velocity divided by the speed of light.
-        SDSSr_true  : Apparent magnitudes in SDSS r band.
+        DECAMr_true  : Apparent magnitudes in SDSS r band.
     """
 
     filename = os.path.join(mock_dir, target_type+'.hdf5')
@@ -532,6 +536,9 @@ def read_durham_mxxl_hdf5(mock_dir, target_type, mock_name=None):
     zred   = f["Data/z_obs"][...].astype('f8')
     f.close()
 
+    #- Convert SDSSr to DECAMr for a typical BGS target with (r-i)=0.4
+    DECAMr_true = SDSSr_true - 0.03587 - 0.14144*0.4  #- DESI-1788v1 eqn 5
+
     print('read {} lines from {}'.format(len(ra), filename))
 
     files = list()
@@ -539,8 +546,9 @@ def read_durham_mxxl_hdf5(mock_dir, target_type, mock_name=None):
     n_per_file = list()
     n_per_file.append(len(ra))
 
-    return {'RA':ra, 'DEC':dec, 'Z': zred ,
-            'SDSSr_true':SDSSr_true, 'FILES': files, 'N_PER_FILE': n_per_file}
+    return {'RA':ra, 'DEC':dec, 'Z': zred,
+            'DECAMr_true': DECAMr_true,
+            'FILES': files, 'N_PER_FILE': n_per_file}
 
 ############################################################
 def read_mock_durham(core_filename, photo_filename):

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -363,6 +363,9 @@ def read_galaxia(mock_dir, target_type, mock_name=None):
         file_list.append(mock_file)
         print('read file {} {}'.format(nfiles, mock_file))
 
+    if nfiles == 0:
+        raise ValueError('Unable to find files in {}'.format(mock_dir))
+
     print('Read {} files'.format(nfiles))
 
     # Concatenate all the dictionaries into a single dictionary, in an order

--- a/py/desitarget/mock/selection.py
+++ b/py/desitarget/mock/selection.py
@@ -114,11 +114,11 @@ def mag_select(data, sourcename, targetname, truthname, brick_info=None, density
         grcolor    = kwargs['grcolor']
         rzcolor    = kwargs['rzcolor']
         colortol   = kwargs['colortol']
-
-        SELECTION_MAG_NAME = 'SDSSr_obs'
-        COLOR_G_NAME       = 'SDSSg_obs'
-        COLOR_R_NAME       = 'SDSSr_obs'
-        COLOR_Z_NAME       = 'SDSSz_obs'
+ 
+        SELECTION_MAG_NAME = 'DECAMr_obs'
+        COLOR_G_NAME       = 'DECAMg_obs'
+        COLOR_R_NAME       = 'DECAMr_obs'
+        COLOR_Z_NAME       = 'DECAMz_obs'
 
         # Will populate this array with the bitmask values of each target class
         target_class = np.zeros(len(data[SELECTION_MAG_NAME]),dtype=np.int64) - 1
@@ -140,7 +140,7 @@ def mag_select(data, sourcename, targetname, truthname, brick_info=None, density
         mag_faint_filler = kwargs['mag_faint_filler']
 
         # Parameters
-        SELECTION_MAG_NAME = 'SDSSr_obs'
+        SELECTION_MAG_NAME = 'DECAMr_obs'
 
         # Will populate this array with the bitmask values of each target class
         target_class = np.zeros(len(data[SELECTION_MAG_NAME]),dtype=np.int64) - 1
@@ -196,7 +196,7 @@ def mag_select(data, sourcename, targetname, truthname, brick_info=None, density
         dec = data['DEC']
 
         # Parameters
-        SELECTION_MAG_NAME = 'SDSSr_true'
+        SELECTION_MAG_NAME = 'DECAMr_true'
         DEPTH_MAG_NAME = 'GALDEPTH_R'
 
         # Will populate this array with the bitmask values of each target class
@@ -224,7 +224,7 @@ def mag_select(data, sourcename, targetname, truthname, brick_info=None, density
                     warnings.warn("Tile is on the border. Extinction = 99.0. Depth = 0.0", RuntimeWarning)
                 else:
                     depth = brick_info[DEPTH_MAG_NAME][id_binfo]
-                    extinction = brick_info['EBV'][id_binfo] * extinctions['SDSSr']            
+                    extinction = brick_info['EBV'][id_binfo] * extinctions['DESr']            
                 # print('DEPTH {} Ext {}'.format(depth, extinction))
 
                 tmp  = data[SELECTION_MAG_NAME][in_brick] + extinction

--- a/py/desitarget/photo.py
+++ b/py/desitarget/photo.py
@@ -1,0 +1,58 @@
+'''
+Implements the photometric transforms between SDSS and DECam using g,r,z
+documented in DESI-1788v1
+https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1788
+'''
+
+def sdss2decam(g_sdss, r_sdss, i_sdss, z_sdss):
+    '''
+    Converts SDSS magnitudes to DECam magnitudes
+    
+    Args:
+        [griz]_sdss: SDSS magnitudes (float or arrays of floats)
+    
+    Returns:
+        g_decam, r_decam, z_decam
+    
+    Note: SDSS griz are inputs, but only grz (no i) are output
+    '''
+    gr = g_sdss - r_sdss
+    ri = r_sdss - i_sdss
+    iz = i_sdss - z_sdss
+
+    #- DESI-1788v1 equations 4-6
+    g_decals = g_sdss + 0.01684 - 0.11169*gr
+    r_decals = r_sdss - 0.03587 - 0.14114*ri
+    z_decals = z_sdss - 0.00756 - 0.07692*iz
+
+    return g_decals, r_decals, z_decals
+
+def cfht2decam(g_cfht, r_cfht, i_cfht, z_cfht):
+    '''
+    Converts CFHT magnitudes to DECam magnitudes
+    
+    Args:
+        [griz]_cfht: CFHT magnitudes (float or arrays of floats)
+    
+    Returns:
+        g_decam, r_decam, z_decam
+
+    Note: CFHT griz are inputs, but only grz (no i) are output
+    '''
+    gr = g_cfht - r_cfht
+    ri = r_cfht - i_cfht
+    iz = i_cfht - z_cfht
+
+    #- DESI-1788v1 equations 1-3
+    g_decals = g_cfht - 0.03926 + 0.05736*gr
+    r_decals = r_cfht - 0.07371 - 0.13004*ri
+    z_decals = z_cfht - 0.08165 - 0.20494*iz
+
+def decam2sdss(g_decam, r_decam, z_decam):
+    '''Not yet implemented'''
+    raise NotImplementedError
+
+def decam2cfht(g_decam, r_decam, z_decam):
+    '''Not yet implemented'''
+    raise NotImplementedError
+

--- a/py/desitarget/test/test_mock_build.py
+++ b/py/desitarget/test/test_mock_build.py
@@ -1,0 +1,44 @@
+'''
+Testing desitarget.mock.build, but only add_mock_shapes_and_fluxes for now
+'''
+
+import unittest
+import numpy as np
+from astropy.table import Table
+
+from desitarget.mock.build import add_mock_shapes_and_fluxes
+from desitarget import desi_mask, bgs_mask, mws_mask
+
+class TestMockBuild(unittest.TestCase):
+    
+    def setUp(self):
+        pass
+            
+    def test_shapes_and_fluxes(self):
+        nreal = 40
+        real = Table()
+        real['DESI_TARGET'] = 2**np.random.randint(0,3,size=nreal)
+        real['BGS_TARGET'] = np.zeros(nreal, dtype=int)
+        real['BGS_TARGET'][0:5] = bgs_mask.BGS_BRIGHT
+        real['BGS_TARGET'][5:10] = bgs_mask.BGS_FAINT
+        real['DESI_TARGET'][0:10] = 0
+        
+        real['DECAM_FLUX'] = np.random.uniform(size=(nreal,6))
+        real['SHAPEDEV_R'] = np.random.uniform(size=nreal)
+        real['SHAPEEXP_R'] = np.random.uniform(size=nreal)
+        
+        nmock = 45
+        mock = Table()
+        mock['DESI_TARGET'] = 2**np.random.randint(0,3,size=nmock)
+        mock['BGS_TARGET'] = np.zeros(nmock, dtype=int)
+        mock['BGS_TARGET'][10:15] = bgs_mask.BGS_BRIGHT
+        mock['BGS_TARGET'][15:20] = bgs_mask.BGS_FAINT
+        mock['DESI_TARGET'][10:20] = 0
+        
+        add_mock_shapes_and_fluxes(mock, real)
+        self.assertTrue('DECAM_FLUX' in mock.colnames)
+        self.assertTrue('SHAPEDEV_R' in mock.colnames)
+        self.assertTrue('SHAPEEXP_R' in mock.colnames)
+                
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR partially addresses the needs of desihub/desisim#191, which needs DECAM_FLUX and OIIFLUX info in the mocks as part of the quickcat redshift efficiency model.  It adds a `select_mock_targets ... --realtargets {targetcatalog}` option to point it to a real data target catalog to use for getting the distributions, e.g. /project/projectdirs/desi/target/catalogs/targets-dr3.1-0.8.1.fits .  

* If provided, it uses those for DECAM_FLUX for ELG, LRG, and QSO targets.
* TODO: It does not yet fill in anything for DECAM_FLUX for BGS or MWS targets, which do provide some magnitudes in their mocks
* It also propagates `SHAPEDEV_R` and `SHAPEEXP_R` since we have those in the real target catalogs even though we don't use them yet.

HACK: the quickcat model also needs [OII] flux for the ELG model, which isn't present in the current mocks or the real data target catalog.  I add this to the truth file for the ELGs following a made up model of the maximum [OII] flux vs. r-band flux.  Below shows the distribution of [OII] flux vs. r flux for templates from desisim.templates.ELG.  The red curve is my toy model of maximum [OII] flux vs. r flux, and I randomly distribute [OII] flux underneath the red curve given the r flux.

![oii_vs_r](https://cloud.githubusercontent.com/assets/218471/20693041/9e65655e-b590-11e6-9491-5b9e5332ea10.png)

Or in code:
```python
rflux = targets['DECAM_FLUX'][isELG][:,2]
maxflux = np.clip(3e-16*rflux, 0, 7e-16)
truth['OIIFLUX'][isELG] = maxflux * np.random.uniform(0,1.0,size=nELG)
```
This is wrong but it might not be crazy wrong for the purposes of quick simulations for the OSU meeting, and I'm not sure what else could be done given the short timescale.  Complaints are welcome if they come with code for an alternate way to assign [OII] flux that correlates with photometry that are randomly assigned from real data to a mock catalog that didn't have fluxes in the first place...