### PR TITLE
select STD_FSTAR and STD_BRIGHT F-type standards via dedicated function

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -113,7 +113,7 @@ def isFSTD_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
     return fstd
 
 def isFSTD(gflux=None, rflux=None, zflux=None, primary=None, decam_fracflux=None,
-           objtype=None, decam_snr=None, bright=False):
+           objtype=None, decam_snr=None, obs_rflux=None, bright=False):
     """Select FSTD targets using color cuts and photometric quality cuts (PSF-like
     and fracflux).  See isFSTD_colors() for additional info.
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -574,9 +574,11 @@ def apply_cuts(objects, qso_selection='randomforest'):
                                                                                  qso_selection_options))
 
     fstd = isFSTD(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
-                  decam_fracflux=decam_fracflux, obs_rflux=obs_rflux)
+                  decam_fracflux=decam_fracflux, decam_snr=decam_snr,
+                  obs_rflux=obs_rflux)
     fstd_bright = isFSTD(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
-                  decam_fracflux=decam_fracflux, obs_rflux=obs_rflux, bright=True)
+                  decam_fracflux=decam_fracflux, decam_snr=decam_snr,
+                  obs_rflux=obs_rflux, bright=True)
                   
     # Construct the targetflag bits; currently our only cuts are DECam based
     # (i.e. South).  This should really be refactored into a dedicated function.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -149,11 +149,10 @@ def isFSTD(gflux=None, rflux=None, zflux=None, primary=None, decam_fracflux=None
     if obs_rflux is None:
         obs_rflux = rflux
 
+    rbright = 16.0
     if bright:
-        rbright = 15.0
         rfaint = 18.0
     else:
-        rbright = 16.0
         rfaint = 19.0
         
     fstd &= obs_rflux < 10**((22.5 - rbright)/2.5)
@@ -253,7 +252,7 @@ def isBGS_bright(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, o
     bgs = primary.copy()
     bgs &= rflux > 10**((22.5-19.5)/2.5)
     if objtype is not None:
-        bgs &= ~psflike(objtype)
+        bgs &= ~_psflike(objtype)
     return bgs
 
 def isQSO_colors(gflux, rflux, zflux, w1flux, w2flux):
@@ -332,7 +331,7 @@ def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, wise_snr, deltaChi2,
         qso &= primary
 
     if objtype is not None:
-        qso &= psflike(objtype)
+        qso &= _psflike(objtype)
 
     return qso
 
@@ -367,7 +366,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
 
     #Preselection to speed up the process, store the indexes
     rMax = 22.7  # r<22.7
-    preSelection = (r<rMax) &  psflike(objtype) & DECaLSOK 
+    preSelection = (r<rMax) & _psflike(objtype) & DECaLSOK 
     colorsCopy = colors.copy()
     colorsReduced = colorsCopy[preSelection]
     colorsIndex =  np.arange(0,nbEntries,dtype=np.int64)
@@ -399,7 +398,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
     qso &= DECaLSOK  
       
     if objtype is not None:
-        qso &= psflike(objtype)
+        qso &= _psflike(objtype)
 
     if deltaChi2 is not None:
         qso &= deltaChi2>30.
@@ -411,7 +410,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
         
     return qso
 
-def getColors(nbEntries,nfeatures,gflux,rflux,zflux,w1flux,w2flux):
+def getColors(nbEntries, nfeatures, gflux, rflux, zflux, w1flux, w2flux):
  
     limitInf=1.e-04
     gflux = gflux.clip(limitInf)
@@ -611,7 +610,6 @@ def apply_cuts(objects,qso_selection='randomforest'):
     desi_target |= (mws_target != 0) * desi_mask.MWS_ANY
 
     return desi_target, bgs_target, mws_target
-
 
 def check_input_files(infiles, numproc=4, verbose=False):
     """


### PR DESCRIPTION
This refactor creates a new cuts.isFSTD() function which selects both/either STD_FSTAR and STD_BRIGHT standard stars.  The magnitude cuts for STD_FSTAR were set to 16<r<19 (observed r-band) while the STD_BRIGHT cuts were semi-arbitrarily set to 16<r<18, and the documentation on the [target selection page](https://desi.lbl.gov/trac/wiki/TargetSelectionWG/TargetSelection#SpectrophotometricStandardStarsFSTD) was updated.  

I also did a bit of cleanup of the code for style and organization.

This refactor was needed as part of #136.  

Tests are still running but creating the PR now anyway. 