### PR TITLE
update FSTD_BRIGHT flux limits

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -155,10 +155,11 @@ def isFSTD(gflux=None, rflux=None, zflux=None, primary=None, decam_fracflux=None
     if obs_rflux is None:
         obs_rflux = rflux
 
-    rbright = 16.0
     if bright:
-        rfaint = 18.0
+        rbright = 14.0
+        rfaint = 17.0
     else:
+        rbright = 16.0
         rfaint = 19.0
         
     fstd &= obs_rflux < 10**((22.5 - rbright)/2.5)


### PR DESCRIPTION
This PR updates the flux limits for the bright-time F-type standard stars, based on input from the MWS group (see [desi-milkyway 399] and https://desi.lbl.gov/trac/wiki/TargetSelectionWG/TargetSelection#STD_BRIGHT].