### PR TITLE
Update standards to match @callendeprieto's new color range (issue https://github.com/desihub/desitarget/issues/162)

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desitarget Change Log
 -------------------
 
 * New cuts for standards [`PR #167`_]
-* Ensured objtype was being passed to :func:`~desitarget.cuts.FSTD`.
+* Ensured objtype was being passed to :func:`~desitarget.cuts.isFSTD`.
 
 .. _`PR #167`: https://github.com/desihub/desitarget/pull/167
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desitarget Change Log
 0.10.1 (unreleased)
 -------------------
 
-* No changes yet
+* New cuts for standards [`PR #167`_]
+* Ensured objtype was being passed to :func:`~desitarget.cuts.FSTD`.
+
+.. _`PR #167`: https://github.com/desihub/desitarget/pull/167
 
 0.10.0 (2017-03-27)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -410,6 +410,12 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
 
 def _psflike(psftype):
     """ If the object is PSF """
+    #ADM explicitly checking for NoneType. I can't see why we'd ever want to
+    #ADM run this test on empty information. In the past we have had bugs where
+    #ADM we forgot to pass objtype=objtype in, e.g., isFSTD
+    if psftype is None:
+        raise ValueError("NoneType submitted to _psfflike function")
+
     #- 'PSF' for astropy.io.fits; 'PSF ' for fitsio (sigh)
     #ADM fixed this in I/O.
     psftype = np.asarray(psftype)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -113,7 +113,7 @@ def isFSTD_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
         warnings.simplefilter('ignore')
         grcolor = 2.5 * np.log10(rflux / gflux)
         rzcolor = 2.5 * np.log10(zflux / rflux)
-        fstd &= (grcolor - 0.32)**2 + (rzcolor - 0.13)**2 < 0.06**2
+        fstd &= (grcolor - 0.26)**2 + (rzcolor - 0.13)**2 < 0.06**2
 
     return fstd
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -581,13 +581,14 @@ def apply_cuts(objects, qso_selection='randomforest'):
     else:
         raise ValueError('Unknown qso_selection {}; valid options are {}'.format(qso_selection,
                                                                                  qso_selection_options))
-
+    #ADM Make sure to pass all of the needed columns! At one point we stopped
+    #ADM passing objtype, which meant no standards were being returned.
     fstd = isFSTD(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                   decam_fracflux=decam_fracflux, decam_snr=decam_snr,
-                  obs_rflux=obs_rflux)
+                  obs_rflux=obs_rflux, objtype=objtype)
     fstd_bright = isFSTD(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                   decam_fracflux=decam_fracflux, decam_snr=decam_snr,
-                  obs_rflux=obs_rflux, bright=True)
+                  obs_rflux=obs_rflux, objtype=objtype, bright=True)
 
     # Construct the targetflag bits; currently our only cuts are DECam based
     # (i.e. South).  This should really be refactored into a dedicated function.


### PR DESCRIPTION
@moustakas, @callendeprieto: I compared the old cut

`fstd &= (grcolor - 0.32)**2 + (rzcolor - 0.13)**2 < 0.06**2`

to the new cut:

`fstd &= (grcolor - 0.26)**2 + (rzcolor - 0.13)**2 < 0.06**2`

using the dr3.1 sweeps and found that the number of faint standards dropped by a factor of 4 and that the number of bright standards dropped by a factor of 7. 

This is a significantly greater drop than initially suggested by @callendeprieto. Given that the old cuts were just placeholders, though, I think we should merge this now and work further to address what is the "correct" cut.