### PR TITLE
fix repeating spectra bug 

### DIFF
--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -19,7 +19,7 @@ parser.add_argument('--realtargets', '-r', help='Path to real target catalog', t
 parser.add_argument('--seed', '-s', help='Seed for random number generation', type=int, default=None)
 parser.add_argument('--bricksize', '-b', help='Size of the imaging bricks (deg)',
                     type=float, default=0.25)
-parser.add_argument('--outbricksize', '-o', help='Desired size of the output bricks', type=float, default=2.0)
+parser.add_argument('--outbricksize', '-o', help='Desired size of the output bricks', type=float, default=0.25)
 parser.add_argument('--nproc', type=int, help='number of concurrent processes to use [{}]'.format(nproc), default=nproc)
 
 parser.add_argument('-v','--verbose', action='store_true', help='Enable verbose output.')

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -444,7 +444,7 @@ def write_onebrick(thisbrick, targets, truth, trueflux, truthhdr, wave, output_d
     hdu = fits.ImageHDU(wave.astype(np.float32), name='WAVE', header=truthhdr)
     hx.append(hdu)
 
-    hdu = fits.ImageHDU(trueflux.astype(np.float32), name='FLUX')
+    hdu = fits.ImageHDU(trueflux[onbrick, :].astype(np.float32), name='FLUX')
     hdu.header['BUNIT'] = '1e-17 erg/s/cm2/A'
     hx.append(hdu)
 

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -456,7 +456,7 @@ def write_onebrick(thisbrick, targets, truth, trueflux, truthhdr, wave, output_d
     write_bintable(truthfile, truth[onbrick], extname='TRUTH')
 
 def targets_truth(params, output_dir, realtargets=None, seed=None, verbose=True,
-                  bricksize=0.25, outbricksize=5.0, nproc=4):
+                  bricksize=0.25, outbricksize=0.25, nproc=4):
     """
     Write
 


### PR DESCRIPTION
Fixes the bug identified in #168 and makes the default outbricksize equal to bricksize (0.25 deg), to avoid the (problematic) mismatch between the imaging bricks and the "true spectra/targets" bricks.