### PR TITLE
reduce the memory usage of the mock-->spectra code

### DIFF
--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -22,6 +22,7 @@ parser.add_argument('--bricksize', '-b', help='Size of the imaging bricks (deg)'
 parser.add_argument('--outbricksize', '-o', help='Desired size of the output bricks', type=float, default=0.25)
 parser.add_argument('--nproc', type=int, help='number of concurrent processes to use [{}]'.format(nproc), default=nproc)
 
+parser.add_argument('--clobber', action='store_true', help='Remove intermediate files.')
 parser.add_argument('-v','--verbose', action='store_true', help='Enable verbose output.')
 args = parser.parse_args()
 
@@ -50,7 +51,7 @@ else:
 # Construct Targets and Truth files
 targets_truth(params, args.output_dir, realtargets=realtargets, seed=args.seed,
               verbose=args.verbose, nproc=args.nproc, bricksize=args.bricksize,
-              outbricksize=args.outbricksize)
+              outbricksize=args.outbricksize, clobber=args.clobber)
 
 log.info('All done!')
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,15 +5,16 @@ desitarget Change Log
 0.12.0 (Unreleased)
 -------------------
 
-* Significant expansion of the mocks-to-targets code [`PR #173`_]:
+* Significant expansion of the mocks-to-targets code [`PR #173`_ and `PR #177`_]:
   * Better and more graceful error handling.
   * Now includes contaminants.
-  * Much better memory handling (by cutting on RA,Dec boundaries).
+  * Much better memory usage.
   * Updated QA notebook.
 * Add Random Forest selection for ELG in the sandbox [`PR #174`_].
 
 .. _`PR #173`: https://github.com/desihub/desitarget/pull/173
 .. _`PR #174`: https://github.com/desihub/desitarget/pull/174
+.. _`PR #177`: https://github.com/desihub/desitarget/pull/177
 
 0.11.0 (2017-04-14)
 -------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -20,6 +20,7 @@ from scipy.optimize import leastsq
 from . import __version__ as desitarget_version
 
 from desiutil import depend
+from desiutil.log import get_logger, DEBUG
 import warnings
 
 def generate_fluctuations(brickfilename, targettype, depthtype, depthorebvarray, random_state=None):
@@ -49,6 +50,8 @@ def generate_fluctuations(brickfilename, targettype, depthtype, depthorebvarray,
     """
     if random_state is None:
         random_state = np.random.RandomState()
+        
+    log = get_logger()
 
     #ADM check some impacts are as expected
     dts = ["DEPTH_G","GALDEPTH_G","DEPTH_R","GALDEPTH_R","DEPTH_Z","GALDEPTH_Z","EBV"]
@@ -69,7 +72,7 @@ def generate_fluctuations(brickfilename, targettype, depthtype, depthorebvarray,
     if not targettype in tts:
         fluc = np.ones(nbricks)
         mess = "fluctuations for targettype {} are set to one".format(targettype)
-        warnings.warn(mess, RuntimeWarning)
+        log.warning(mess)
         return fluc
 
     #ADM the target fluctuations are actually called FLUC_* in the model dictionary

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -570,12 +570,8 @@ def _create_raslices(output_dir, ioutput_dir, brickname):
             except:
                 os.makedirs(thisradir)
                 
-try:
-    from memory_profiler import profile
-except:
-    pass
-
-@profile
+#from memory_profiler import profile
+#@profile
 def targets_truth(params, output_dir, realtargets=None, seed=None, verbose=True,
                   clobber=False, bricksize=0.25, outbricksize=0.25, nproc=1):
     """

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -59,11 +59,11 @@ def print_all_mocks_info(params):
     """
     log.info('Paths and targets:')
     for source_name in params['sources'].keys():
-        source_format = params['sources'][source_name]['format']
+        mockformat = params['sources'][source_name]['format']
         source_path = params['sources'][source_name]['mock_dir_name']
         target_name = params['sources'][source_name]['target_name']
         log.info('source_name: {}\n format: {} \n target_name {} \n path: {}'.format(source_name,
-                                                                                  source_format,
+                                                                                  mockformat,
                                                                                   target_name,
                                                                                   source_path))
 
@@ -95,7 +95,7 @@ def load_all_mocks(params, rand=None, bricksize=0.25, nproc=1):
     for source_name in sorted(params['sources'].keys()):
 
         target_name = params['sources'][source_name]['target_name']
-        source_format = params['sources'][source_name]['format']
+        mockformat = params['sources'][source_name]['format']
         mock_dir_name = params['sources'][source_name]['mock_dir_name']
         bounds = params['sources'][source_name]['bounds']
 
@@ -104,9 +104,9 @@ def load_all_mocks(params, rand=None, bricksize=0.25, nproc=1):
         else:
             magcut = None
 
-        read_function = 'read_{}'.format(source_format)
+        read_function = 'read_{}'.format(mockformat)
 
-        log.info('Source: {}, target: {}, format: {}'.format(source_name, target_name.upper(), source_format))
+        log.info('Source: {}, target: {}, format: {}'.format(source_name, target_name.upper(), mockformat))
         log.info('Reading {} with mock.io.{}'.format(mock_dir_name, read_function))
 
         func = globals()[read_function]

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -557,18 +557,14 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
     dec = radec['DEC'][cut].astype('f8')
     del radec
         
-    if target_name == 'SKY':
-        zz = np.zeros(nobj, dtype='f4')
-    else:
+    if target_name != 'SKY':
         data = fitsio.read(mockfile, columns=['Z_COSMO', 'DZ_RSD'], upper=True, ext=1, rows=cut)
         zz = (data['Z_COSMO'].astype('f8') + data['DZ_RSD'].astype('f8')).astype('f4')
+        mag = np.zeros_like(zz) - 1 # placeholder
         del data
-    
-    mag = np.repeat(-1, nobj) # placeholder
 
     # Combine the QSO and Lyman-alpha samples.
     if target_name == 'QSO' and lya:
-
         log.info('  Adding Lya QSOs.')
 
         mockfile_lya = lya['mock_dir_name']
@@ -619,7 +615,7 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
     seed = rand.randint(2**32, size=nobj)
 
     # Create a basic dictionary for SKY.
-    out = {'OBJID': objid, 'MOCKID': mockid, 'RA': ra, 'DEC': dec, 'Z': zz,
+    out = {'OBJID': objid, 'MOCKID': mockid, 'RA': ra, 'DEC': dec, 
            'BRICKNAME': brickname, 'SEED': seed, 'FILES': files,
            'N_PER_FILE': n_per_file}
 
@@ -631,7 +627,7 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
         GMM = SampleGMM(random_state=rand)
         mags = GMM.sample(target_name, nobj) # [g, r, z, w1, w2, w3, w4]
 
-        out.update({'GR': mags['g']-mags['r'], 'RZ': mags['r']-mags['z'],
+        out.update({'Z': zz, 'GR': mags['g']-mags['r'], 'RZ': mags['r']-mags['z'],
                     'RW1': mags['r']-mags['w1'], 'W1W2': mags['w1']-mags['w2']})
 
         if target_name in ('ELG', 'LRG'):

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -213,7 +213,8 @@ def make_mockid(objid, n_per_file):
     return encode_rownum_filenum(objid, filenum)
 
 def read_100pc(mock_dir_name, target_name='STAR', rand=None, bricksize=0.25,
-               bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=None):
+               bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=None,
+               lya=None):
     """Read a single-file GUMS-based mock of nearby (d<100 pc) normal stars (i.e.,
     no white dwarfs).
 
@@ -327,7 +328,8 @@ def read_100pc(mock_dir_name, target_name='STAR', rand=None, bricksize=0.25,
             'FILES': files, 'N_PER_FILE': n_per_file}
 
 def read_wd(mock_dir_name, target_name='WD', rand=None, bricksize=0.25,
-               bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=None):
+               bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=None,
+               lya=None):
     """Read a single-file GUMS-based mock of white dwarfs.
 
     Parameters
@@ -450,8 +452,8 @@ def _sample_vdisp(logvdisp_meansig, nmodel=1, rand=None):
     return vdisp
 
 def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
-                       lya=None, bounds=(0.0, 360.0, -90.0, 90.0), magcut=None,
-                       nproc=None):
+                       bounds=(0.0, 360.0, -90.0, 90.0), magcut=None,
+                       nproc=None, lya=None):
     """Reads the GaussianRandomField mocks for ELGs, LRGs, and QSOs.
 
     Parameters
@@ -668,7 +670,8 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
     return out
 
 def read_durham_mxxl_hdf5(mock_dir_name, target_name='BGS', rand=None, bricksize=0.25,
-                          bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=None):
+                          bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=None,
+                          lya=None):
     """ Reads the MXXL mock of BGS galaxies.
 
     Parameters
@@ -855,7 +858,8 @@ def load_galaxia_file(target_name, mockfile, bounds):
             'LOGG': logg, 'FEH': feh, 'FILES': files, 'N_PER_FILE': n_per_file}
 
 def read_galaxia(mock_dir_name, target_name='STAR', rand=None, bricksize=0.25,
-                 bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=1):
+                 bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=1,
+                 lya=None):
     """ Read and concatenate the MWS_MAIN mock files.
 
     Parameters
@@ -1117,7 +1121,8 @@ def _load_lya_file(mockfile):
     return {'OBJID': objid, 'RA': ra, 'DEC': dec, 'Z': zz, 'MAG_G': mag_g}
 
 def read_lya(mock_dir_name, target_name='QSO', rand=None, bricksize=0.25,
-             bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=1):
+             bounds=(0.0, 360.0, -90.0, 90.0), magcut=None, nproc=1,
+             lya=None):
     """ Read and concatenate the LYA mock files.
 
     Parameters

--- a/py/desitarget/mock/selection.py
+++ b/py/desitarget/mock/selection.py
@@ -352,8 +352,8 @@ class SelectTargets(object):
 
                 frac_keep = desired_density / mock_density
                 if frac_keep > 1.0:
-                    self.log.warning('Brick {}: mock density {:.0f}/deg2 lower than desired {:.0f}/deg2; keeping all targets.'.format(
-                        thisbrick, mock_density, desired_density))
+                    self.log.warning('{} density {:.0f}/deg2 lower than desired {:.0f}/deg2 on brick {}.'.format(
+                        target_name.upper(), mock_density, desired_density, thisbrick))
 
                 else:
                     self.log.debug('Downsampling {}s from {:.0f} to {:.0f} targets/deg2.'.format(source_name,
@@ -389,8 +389,8 @@ class SelectTargets(object):
 
                     frac_keep = desired_density / contam_density
                     if frac_keep > 1.0:
-                        self.log.warning('Brick {}: contaminant density {:.0f}/deg2 lower than desired {:.0f}/deg2; keeping all contaminants.'.format(
-                            thisbrick, contam_density, desired_density))
+                        self.log.warning('{} contaminant density {:.0f}/deg2 lower than desired {:.0f}/deg2 on brick {}.'.format(
+                            target_name.upper(), contam_density, desired_density, thisbrick))
 
                     else:
                         self.log.debug('Downsampling {}/{} contaminants from {:.0f} to {:.0f} targets/deg2.'.format(target_name,

--- a/py/desitarget/mock/spectra.py
+++ b/py/desitarget/mock/spectra.py
@@ -448,6 +448,6 @@ class MockSpectra(object):
         for inkey, datakey in zip(('SEED', 'REDSHIFT'),
                                   ('SEED', 'Z')):
             meta[inkey] = data[datakey][index]
-        flux = np.zeros((nobj, len(self.wave)), dtype='f4')
+        flux = np.zeros((nobj, len(self.wave)), dtype='i1')
 
         return flux, meta


### PR DESCRIPTION
This is a follow-up to #173 in which `desitarget.mock.targets_truth` is now approximately 5%-15% faster than what's in master and should use significantly less memory.

This speed-up is accomplished largely by being smarter about (not) simulating the FAINTSTAR contaminants until the end.  Specifically, I use the stellar templates themselves to figure out which faint stars are going to pass target selection cuts (on a given brick with the simulated noisy photometry) and only generate spectra for those that do.  

In addition, I've reduced the memory usage *significantly* by applying target selection on each individual brick rather than keeping all the targets (and spectra!) until all the bricks were done. I also don't bother creating any (empty!) sky spectra, and I only load one mock at a time rather than holding them all in memory simultaneously.  This should allow us to scale over a much larger chunk of sky than what we're currently doing.  

Some other notes:
* The output directory is required to be empty and the user must explicitly set `--clobber` in `select_mock_targets` if it isn't.  This is to make sure old files don't mix in with new ones, especially since we're calling this code over different patches of sky.
* I toyed with the idea of writing out intermediate files/spectra and then gathering them up at the end but in the end this wasn't necessary.
* `map_id_filename.txt` isn't being written because the connection back to the mocks is broken anyway.  I'll fix this in a separate PR (or here, if requested).