### PR TITLE
Mocks without spectra

### DIFF
--- a/bin/mpi_select_mock_targets
+++ b/bin/mpi_select_mock_targets
@@ -18,7 +18,7 @@ import argparse
 from astropy.table import Table
 import desimodel.footprint
 from desiutil.log import get_logger, DEBUG
-from desitarget.mock.build import targets_truth
+from desitarget.mock.build import targets_truth, targets_truth_no_spectra
 import desitarget.mock.io as mockio
 
 import multiprocessing
@@ -32,6 +32,7 @@ parser.add_argument('-n', '--nproc', type=int, help='number of concurrent proces
 parser.add_argument('--nside', help='Divide the DESI footprint into this healpix resolution', type=int, default=64)
 parser.add_argument('--tiles', help='Path to file with tiles to cover', type=str)
 parser.add_argument('--healpixels', help='Integer list of healpix pixels (corresponding to nside) to process.', type=int, nargs='*', default=None)
+parser.add_argument('--no-spectra', action='store_true')
 parser.add_argument('--realtargets', '-r', help='Path to real target catalog', type=str)
 parser.add_argument('-v','--verbose', action='store_true', help='Enable verbose output.')
 parser.add_argument('--no-check-env', action='store_true', help="Don't check NERSC environment variables")
@@ -42,6 +43,12 @@ if args.verbose:
     log = get_logger(DEBUG)
 else:
     log = get_logger()
+
+
+if args.no_spectra:
+    log.info('This run is NOT  going to generate mock spectra')
+else:
+    log.info('This run is going to generate mock spectra')
 
 if args.tiles is not None and args.healpixels is not None:
     if rank == 0:
@@ -136,6 +143,11 @@ if len(rankpix) > 0:
     #- we use less memory.
     n = 1
     for i in range(0, len(rankpix), n):
-        targets_truth(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
-                      nproc=args.nproc, verbose=args.verbose,
-                      healpixels=rankpix[i:i+n])
+        if args.no_spectra:
+            targets_truth_no_spectra(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
+                                     nproc=args.nproc, verbose=args.verbose,
+                                     healpixels=rankpix[i:i+n])
+        else:
+            targets_truth(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
+                          nproc=args.nproc, verbose=args.verbose,
+                          healpixels=rankpix[i:i+n])

--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -12,7 +12,7 @@ import yaml
 import healpy as hp
 from astropy.table import Table
 
-from desitarget.mock.build import targets_truth
+from desitarget.mock.build import targets_truth, targets_truth_no_spectra
 from desispec.log import get_logger, DEBUG
 from desimodel.footprint import tiles2pix
 
@@ -31,6 +31,8 @@ parser.add_argument('--realtargets', '-r', help='Path to real target catalog', t
 parser.add_argument('--join', action='store_true', help='Join the target and truth files in output_dir.')
 parser.add_argument('--qa', action='store_true', help='Generate QA plots from the joined target and truth files in output_dir.')
 parser.add_argument('-v','--verbose', action='store_true', help='Enable verbose output.')
+parser.add_argument('--no-spectra', action='store_true')
+
 args = parser.parse_args()
 
 if args.verbose:
@@ -94,9 +96,16 @@ with open(args.config, 'r') as pfile:
     params = yaml.load(pfile)
 
 log.info('Calling targets_truth at {}'.format(time.asctime()))
-targets_truth(params, args.output_dir, realtargets=realtargets, seed=args.seed,
+
+if args.no_spectra:
+    targets_truth_no_spectra(params, args.output_dir, realtargets=realtargets, seed=args.seed,
               verbose=args.verbose, nproc=args.nproc, nside=args.nside,
               healpixels=healpixels)
+else:
+    targets_truth(params, args.output_dir, realtargets=realtargets, seed=args.seed,
+              verbose=args.verbose, nproc=args.nproc, nside=args.nside,
+              healpixels=healpixels)
+
 
 log.info('All done at {}'.format(time.asctime()))
 

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -583,14 +583,14 @@ def get_magnitudes_onebrick(target_name, mockformat, thisbrick, brick_info, Magn
                 'OIIFLUX', 'HBETAFLUX', 'TEFF', 'LOGG', 'FEH'):
         truth[key][:] = meta[key]
 
-    # Perturb the photometry based on the variance on this brick and apply
+    # We don't perturb the photometry based on the variance on this brick and apply
     # target selection.
     for band in (0, 1):
-        targets['WISE_FLUX'][:, band] = truth['WISE_FLUX'][:, band] + \
-          rand.normal(scale=wise_onesigma[band], size=nobj)
+        targets['WISE_FLUX'][:, band] = truth['WISE_FLUX'][:, band] 
+          # + rand.normal(scale=wise_onesigma[band], size=nobj)
     for band in (1, 2, 4):
-        targets['DECAM_FLUX'][:, band] = truth['DECAM_FLUX'][:, band] + \
-          rand.normal(scale=decam_onesigma[band], size=nobj)
+        targets['DECAM_FLUX'][:, band] = truth['DECAM_FLUX'][:, band] 
+          # + rand.normal(scale=decam_onesigma[band], size=nobj)
 
         
     if 'BOSS_STD' in source_data.keys():

--- a/py/desitarget/mock/selection.py
+++ b/py/desitarget/mock/selection.py
@@ -142,9 +142,9 @@ class SelectTargets(object):
         from desitarget.cuts import isBGS_bright, isBGS_faint
 
         rflux = targets['DECAM_FLUX'][..., 2]
-
         # Select BGS_BRIGHT targets.
         bgs_bright = isBGS_bright(rflux=rflux)
+
         targets['BGS_TARGET'] |= (bgs_bright != 0) * self.bgs_mask.BGS_BRIGHT
         targets['BGS_TARGET'] |= (bgs_bright != 0) * self.bgs_mask.BGS_BRIGHT_SOUTH
         targets['DESI_TARGET'] |= (bgs_bright != 0) * self.desi_mask.BGS_ANY
@@ -153,6 +153,7 @@ class SelectTargets(object):
 
         # Select BGS_FAINT targets.
         bgs_faint = isBGS_faint(rflux=rflux)
+
         targets['BGS_TARGET'] |= (bgs_faint != 0) * self.bgs_mask.BGS_FAINT
         targets['BGS_TARGET'] |= (bgs_faint != 0) * self.bgs_mask.BGS_FAINT_SOUTH
         targets['DESI_TARGET'] |= (bgs_faint != 0) * self.desi_mask.BGS_ANY

--- a/py/desitarget/mock/spectra.py
+++ b/py/desitarget/mock/spectra.py
@@ -260,16 +260,17 @@ class MockMagnitudes(object):
 
         meta['TEMPLATEID'][:] = -1
         meta['OIIFLUX'][:] = 0.0
-        meta['WISE_FLUX'][:,:] = 0.0
+        meta['WISE_FLUX'][:,:] = -1.0
         meta['HBETAFLUX'][:]= 0.0
         meta['TEFF'][:] = 0.0
         meta['LOGG'][:] = 0.0
         meta['FEH'][:] = 0.0
-        meta['DECAM_FLUX'][:,:] = 0.0
+        meta['DECAM_FLUX'][:,:] = -1.0
         meta['DECAM_FLUX'][:, 2] = 10**((22.5 - data['MAG'][index])/2.5) # r-band flux
-        meta['DECAM_FLUX'][:, 1] = meta['DECAM_FLUX'][:,2] + 10**((22.5-data['SDSS_01gr'][index])/2.5) # g-band flux
+        meta['DECAM_FLUX'][:, 1] = 10**((22.5-(data['SDSS_01gr'][index] + data['MAG'][index]))/2.5) # g-band flux
         return meta
     
+
     def mws(self, data, index=None, mockformat='galaxia'):
         """Generate magnitudes for the MWS_NEARBY and MWS_MAIN samples.
 
@@ -288,12 +289,12 @@ class MockMagnitudes(object):
 
         meta['TEMPLATEID'][:] = -1
         meta['OIIFLUX'][:] = 0.0
-        meta['WISE_FLUX'][:,:] = 0.0
+        meta['WISE_FLUX'][:,:] = -1.0
         meta['HBETAFLUX'][:]= 0.0
         meta['TEFF'][:] = 0.0
         meta['LOGG'][:] = 0.0
         meta['FEH'][:] = 0.0
-        meta['DECAM_FLUX'][:,:] = -1.0 # Negative fluxes should break code that use colors for the selection
+        meta['DECAM_FLUX'][:,:] = -1.0 
         meta['DECAM_FLUX'][:, 2] = 10**((22.5 - data['MAG'][index])/2.5) # r-band flux
         return meta
                 
@@ -318,6 +319,118 @@ class MockMagnitudes(object):
         meta = self.mws(data, index=index, mockformat=mockformat)
         return meta
         
+    def elg(self, data, index=None, mockformat='gaussianfield'):
+        """Generate magnitudes for the ELG sample.
+
+        Currently only the GaussianField mock sample is supported.  DATA needs
+        to have Z, GR, RZ, VDISP, and SEED, which are assigned in
+        mock.io.read_gaussianfield.  
+
+        """
+        objtype = 'ELG'
+        if index is None:
+            index = np.arange(len(data['Z']))
+
+        meta = empty_metatable(nmodel=len(index), objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT', 'VDISP'),
+                                  ('SEED', 'MAG', 'Z', 'VDISP')):
+            meta[inkey] = data[datakey][index]
+
+        if mockformat.lower() != 'gaussianfield':
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+      
+        meta['TEMPLATEID'][:] = -1
+        meta['OIIFLUX'][:] = 0.0
+        meta['WISE_FLUX'][:,:] = -1.0
+        meta['HBETAFLUX'][:]= 0.0
+        meta['TEFF'][:] = 0.0
+        meta['LOGG'][:] = 0.0
+        meta['FEH'][:] = 0.0
+        meta['DECAM_FLUX'][:,:] = -1.0 
+        
+        meta['DECAM_FLUX'][:, 1] = 10**((22.5 - (data['GR'][index] + data['MAG'][index]))/2.5) # g-band flux
+        meta['DECAM_FLUX'][:, 2] = 10**((22.5 - data['MAG'][index])/2.5) # r-band flux
+        meta['DECAM_FLUX'][:, 4] = 10**((22.5 - (data['MAG'][index] - data['RZ'][index]))/2.5) # z-band flux
+        return meta
+    
+    def lrg(self, data, index=None, mockformat='gaussianfield'):
+        """Generate magnitudes for the LRG sample.
+
+        Currently only the GaussianField mock sample is supported.  DATA needs
+        to have Z, GR, RZ, VDISP, and SEED, which are assigned in
+        mock.io.read_gaussianfield.  
+
+        """
+        objtype = 'LRG'
+        if index is None:
+            index = np.arange(len(data['Z']))
+        nobj = len(index)
+
+        meta = empty_metatable(nmodel=len(index), objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT', 'VDISP'),
+                                  ('SEED', 'MAG', 'Z', 'VDISP')):
+            meta[inkey] = data[datakey][index]
+
+        if mockformat.lower() != 'gaussianfield':
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+
+        
+        meta['TEMPLATEID'][:] = -1
+        meta['OIIFLUX'][:] = 0.0
+        meta['WISE_FLUX'][:,:] = -1.0
+        meta['HBETAFLUX'][:]= 0.0
+        meta['TEFF'][:] = 0.0
+        meta['LOGG'][:] = 0.0
+        meta['FEH'][:] = 0.0
+        meta['DECAM_FLUX'][:,:] = -1.0 
+        
+        meta['DECAM_FLUX'][:, 1] = 10**((22.5 - (data['GR'][index] + data['RZ'][index] + data['MAG'][index]))/2.5) # g-band flux  
+        meta['DECAM_FLUX'][:, 2] =  10**((22.5 - (data['MAG'][index] + data['RZ'][index]))/2.5) # r-band flux
+        meta['DECAM_FLUX'][:, 4] = 10**((22.5 - data['MAG'][index])/2.5) # z-band flux
+        meta['WISE_FLUX'][:, 0] = 10**((22.5 - (data['RZ'][index] + data['MAG'][index] - data['RW1'][index]))/2.5)# wise flux 1
+        meta['WISE_FLUX'][:, 1] = 10**((22.5 - (data['RZ'][index] + data['MAG'][index] - data['RW1'][index] - data['W1W2'][index]))/2.5)# wise flux 2
+        
+        return meta
+    
+    def qso(self, data, index=None, mockformat='gaussianfield'):
+        """Generate magnitudes for the QSO or QSO/LYA samples.
+
+        """
+        from desisim.lya_spectra import get_spectra
+        
+        objtype = 'QSO'
+        if index is None:
+            index = np.arange(len(data['Z']))
+        nobj = len(index)
+
+        if mockformat.lower() != 'gaussianfield':
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+        meta = empty_metatable(nmodel=nobj, objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT'),
+                                      ('SEED', 'MAG', 'Z')):
+            meta[inkey] = data[datakey][index]
+        meta['TEMPLATEID'][:] = -1
+        meta['OIIFLUX'][:] = 0.0
+        meta['WISE_FLUX'][:,:] = -1.0
+        meta['HBETAFLUX'][:]= 0.0
+        meta['TEFF'][:] = 0.0
+        meta['LOGG'][:] = 0.0
+        meta['FEH'][:] = 0.0
+        meta['DECAM_FLUX'][:,:] = -1.0 
+
+        meta['DECAM_FLUX'][:, 1] = 10**((22.5 - data['MAG'][index])/2.5) # g-band flux
+        meta['DECAM_FLUX'][:, 2] = 10**((22.5 - (data['MAG'][index] - data['GR'][index]))/2.5) # r-band flux
+        meta['DECAM_FLUX'][:, 4] = 10**((22.5 - (data['MAG'][index] - data['GR'][index] - data['RZ'][index]))/2.5) # z-band flux
+        meta['WISE_FLUX'][:, 0] = 10**((22.5 - (data['MAG'][index] - data['GR'][index] - data['RW1'][index]))/2.5)# wise flux 1
+        meta['WISE_FLUX'][:, 1] = 10**((22.5 - (data['MAG'][index] - data['GR'][index] - data['RW1'][index] - data['W1W2'][index]))/2.5)# wise flux 2
+        
+        lya = np.where( data['TEMPLATESUBTYPE'][index] == 'LYA' )[0]                 
+        if len(lya) > 0:
+            meta['SUBTYPE'][lya] = 'LYA'
+                                       
+        return meta
+
+    
 class MockSpectra(object):
     """Generate spectra for each type of mock.  Currently just choose the closest
     template; we can get fancier later.

--- a/py/desitarget/mock/spectra.py
+++ b/py/desitarget/mock/spectra.py
@@ -247,9 +247,6 @@ class MockMagnitudes(object):
         assigned in mock.io.read_durham_mxxl_hdf5.  
 
         """
-#['TEMPLATEID', 'MAG', 'DECAM_FLUX', 'WISE_FLUX',
-#                'OIIFLUX', 'HBETAFLUX', 'TEFF', 'LOGG', 'FEH']
- 
         objtype = 'BGS'
         if index is None:
             index = np.arange(len(data['Z']))
@@ -269,10 +266,58 @@ class MockMagnitudes(object):
         meta['LOGG'][:] = 0.0
         meta['FEH'][:] = 0.0
         meta['DECAM_FLUX'][:,:] = 0.0
-        meta['DECAM_FLUX'][:, 1] = 10**((22.5 - data['MAG'][index])/2.5) + 10**((22.5-data['SDSS_01gr'][index])/2.5) # g-band flux
         meta['DECAM_FLUX'][:, 2] = 10**((22.5 - data['MAG'][index])/2.5) # r-band flux
+        meta['DECAM_FLUX'][:, 1] = meta['DECAM_FLUX'][:,2] + 10**((22.5-data['SDSS_01gr'][index])/2.5) # g-band flux
         return meta
     
+    def mws(self, data, index=None, mockformat='galaxia'):
+        """Generate magnitudes for the MWS_NEARBY and MWS_MAIN samples.
+
+        """
+        objtype = 'STAR'
+        if index is None:
+            index = np.arange(len(data['Z']))
+
+        meta = empty_metatable(nmodel=len(index), objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT', 'TEFF', 'LOGG', 'FEH'),
+                                  ('SEED', 'MAG', 'Z', 'TEFF', 'LOGG', 'FEH')):
+            meta[inkey] = data[datakey][index]
+
+        if not (mockformat.lower() in ['100pc','galaxia']):
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+
+        meta['TEMPLATEID'][:] = -1
+        meta['OIIFLUX'][:] = 0.0
+        meta['WISE_FLUX'][:,:] = 0.0
+        meta['HBETAFLUX'][:]= 0.0
+        meta['TEFF'][:] = 0.0
+        meta['LOGG'][:] = 0.0
+        meta['FEH'][:] = 0.0
+        meta['DECAM_FLUX'][:,:] = -1.0 # Negative fluxes should break code that use colors for the selection
+        meta['DECAM_FLUX'][:, 2] = 10**((22.5 - data['MAG'][index])/2.5) # r-band flux
+        return meta
+                
+    def mws_nearby(self, data, index=None, mockformat='100pc'):
+        """Generate magnitudes for the MWS_NEARBY sample.
+
+        """
+        meta = self.mws(data, index=index, mockformat=mockformat)
+        return meta
+
+    def mws_main(self, data, index=None, mockformat='galaxia'):
+        """Generate magnitudes for the MWS_MAIN sample.
+
+        """
+        meta = self.mws(data, index=index, mockformat=mockformat)
+        return meta
+
+    def faintstar(self, data, index=None, mockformat='galaxia'):
+        """Generate magnitudes for the FAINTSTAR (faint stellar) sample.
+
+        """
+        meta = self.mws(data, index=index, mockformat=mockformat)
+        return meta
+        
 class MockSpectra(object):
     """Generate spectra for each type of mock.  Currently just choose the closest
     template; we can get fancier later.


### PR DESCRIPTION
This PR implements the option `--no-spectra` into `mpi_build_mock_targets` to avoid generating spectra on the fly. 

The code works but I think I found some problems. 
It seems to me that helpixels trace can be seen in the catalogs. See [this notebook](https://github.com/desihub/quicksurvey_example/blob/without_spectra/nospectra.ipynb). The first two plots there come from the `--no-spectra` option, the next two plots come from the version generating the full spectra. In both cases there are some overdensities piling up on the healpix boundaries. 
This is more evident with `n_side=32` or `n_side=16`. I will post those plots later. In the meantime I will start looking into what is causing the problem.

You can use [this `quicksurvey_example` branch](https://github.com/desihub/quicksurvey_example/tree/without_spectra) to test the `--no-spectra` option. All the required input files are there. 