### PR TITLE
Mocks without spectra in the new target model.

### DIFF
--- a/bin/mpi_select_mock_targets
+++ b/bin/mpi_select_mock_targets
@@ -18,7 +18,7 @@ import argparse
 from astropy.table import Table
 import desimodel.footprint
 from desiutil.log import get_logger, DEBUG
-from desitarget.mock.build import targets_truth
+from desitarget.mock.build import targets_truth, targets_truth_no_spectra
 import desitarget.mock.io as mockio
 
 import multiprocessing
@@ -36,6 +36,8 @@ parser.add_argument('--realtargets', '-r', help='Path to real target catalog', t
 parser.add_argument('-v','--verbose', action='store_true', help='Enable verbose output.')
 parser.add_argument('--no-check-env', action='store_true', help="Don't check NERSC environment variables")
 parser.add_argument('--sort-pixels', action='store_true', help="Sort pixels by galactic latitude")
+parser.add_argument('--no-spectra', action='store_true')
+
 args = parser.parse_args()
 
 if args.verbose:
@@ -136,6 +138,12 @@ if len(rankpix) > 0:
     #- we use less memory.
     n = 1
     for i in range(0, len(rankpix), n):
-        targets_truth(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
-                      nproc=args.nproc, verbose=args.verbose,
-                      healpixels=rankpix[i:i+n])
+        if args.no_spectra:
+            targets_truth_no_spectra(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
+                                     nproc=args.nproc, verbose=args.verbose,
+                                     healpixels=rankpix[i:i+n])
+        else:
+            targets_truth(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
+                          nproc=args.nproc, verbose=args.verbose,
+                          healpixels=rankpix[i:i+n])
+ 

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -613,7 +613,7 @@ def targets_truth(params, output_dir='.', realtargets=None, seed=None, verbose=F
                               brick_info=brick_info)
     print()
 
-    current_brick_ID = 0 
+    current_pixel_ID = 0 
     # Loop over each source / object type.
     alltargets = list()
     alltruth = list()
@@ -763,9 +763,9 @@ def targets_truth(params, output_dir='.', realtargets=None, seed=None, verbose=F
 
         #rewrite the target ID to be sure that it is unique in this brick
         if len(targets):
-            new_brick_ID = current_brick_ID + len(targets)
-            targets['BRICK_OBJID'][:]= np.arange(current_brick_ID,new_brick_ID)
-            current_brick_ID = new_brick_ID
+            new_pixel_ID = current_pixel_ID + len(targets)
+            targets['BRICK_OBJID'][:]= np.arange(current_pixel_ID,new_pixel_ID)
+            current_pixel_ID = new_pixel_ID
             
         if target_name.upper() == 'SKY':
             skytruth = truth.copy()
@@ -828,10 +828,8 @@ def targets_truth(params, output_dir='.', realtargets=None, seed=None, verbose=F
 
     #compute target healpixel number
     targpix = radec2pix(nside, targets['RA'], targets['DEC'])
-    targets['BRICK_OBJID'] = np.argsort(targets['RA']) + targpix
-    
     targetid = encode_targetid(objid=targets['BRICK_OBJID'],
-                               brickid=targets['BRICKID'], mock=1)
+                               brickid=targpix, mock=1)
     truth['TARGETID'][:] = targetid
     targets['TARGETID'][:] = targetid
     del targetid
@@ -840,9 +838,8 @@ def targets_truth(params, output_dir='.', realtargets=None, seed=None, verbose=F
     
     if nsky > 0:
         skypix = radec2pix(nside, skytargets['RA'], skytargets['DEC'])
-        skytargets['BRICK_OBJID'] = np.argsort(skytargets['RA']) + skypix
         skytargets['TARGETID'][:] = encode_targetid(objid=skytargets['BRICK_OBJID'],
-                                                    brickid=skytargets['BRICKID'], mock=1, sky=1)
+                                                    brickid=skypix, mock=1, sky=1)
 
     subpriority = rand.uniform(0.0, 1.0, size=ntarget + nsky)
     targets['SUBPRIORITY'][:] = subpriority[:ntarget]
@@ -983,9 +980,9 @@ def merge_file_tables(fileglob, ext, outfile=None, comm=None):
         tmpout = outfile + '.tmp'
         
         # Remove duplicates
-        vals, idx_start, count = np.unique(data['TARGETID'], return_index=True, return_counts=True)
-        if len(vals)!=len(data):
-            data = data[idx_start[count==1]]
+        #vals, idx_start, count = np.unique(data['TARGETID'], return_index=True, return_counts=True)
+        #if len(vals)!=len(data):
+        #    data = data[idx_start[count==1]]
         
         fitsio.write(tmpout, data, header=header, extname=ext, clobber=True)
         os.rename(tmpout, outfile)
@@ -1264,7 +1261,7 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
     Selection = SelectTargets(logger=log, rand=rand,
                               brick_info=brick_info)
     print()
-    current_brick_ID = 0
+    current_pixel_ID = 0
     # Loop over each source / object type.
     alltargets = list()
     alltruth = list()
@@ -1407,9 +1404,9 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
 
         # rewrite the target ID to be sure that it is unique in this brick
         if len(targets):
-            new_brick_ID = current_brick_ID + len(targets)
-            targets['BRICK_OBJID'][:] = np.arange(current_brick_ID,new_brick_ID)
-            current_brick_ID = new_brick_ID
+            new_pixel_ID = current_pixel_ID + len(targets)
+            targets['BRICK_OBJID'][:] = np.arange(current_pixel_ID,new_pixel_ID)
+            current_pixel_ID = new_pixel_ID
                 
         if target_name.upper() == 'SKY':
             skytruth = truth.copy()
@@ -1469,11 +1466,11 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
         nsky = 0
 
     #compute target healpixel number
-    targpix = radec2pix(nside, targets['RA'], targets['DEC'])
 
-    targets['BRICK_OBJID'] = np.argsort(targets['RA']) + targpix
+    #targets['BRICK_OBJID'] = np.random.randint(2**targetid_mask.OBJID.nbits, size=ntarget)
+    targpix = radec2pix(nside, targets['RA'], targets['DEC'])
     targetid = encode_targetid(objid=targets['BRICK_OBJID'],
-                               brickid=targets['BRICKID'], mock=1)
+                               brickid=targpix, mock=1)
     
     truth['TARGETID'][:] = targetid
     targets['TARGETID'][:] = targetid
@@ -1481,9 +1478,8 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
 
     if nsky > 0:
         skypix = radec2pix(nside, skytargets['RA'], skytargets['DEC'])
-        skytargets['BRICK_OBJID'] = np.argsort(skytargets['RA']) + skypix
         skytargets['TARGETID'][:] = encode_targetid(objid=skytargets['BRICK_OBJID'],
-                                                    brickid=skytargets['BRICKID'], mock=1, sky=1)
+                                                    brickid=skypix, mock=1, sky=1)
 
     subpriority = rand.uniform(0.0, 1.0, size=ntarget + nsky)
     targets['SUBPRIORITY'][:] = subpriority[:ntarget]
@@ -1505,10 +1501,10 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
     depend.setdep(targetshdr, 'HPXNSIDE', nside)
     depend.setdep(targetshdr, 'HPXNEST', True)
 
+    targpix = radec2pix(nside, targets['RA'], targets['DEC'])
     targets['HPXPIXEL'][:] = targpix
 
     if nsky > 0:
-        skypix = radec2pix(nside, skytargets['RA'], skytargets['DEC'])
         skytargets['HPXPIXEL'][:] = skypix
 
     for pixnum in healpixels:

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -983,7 +983,7 @@ def merge_file_tables(fileglob, ext, outfile=None, comm=None):
         
         # Find duplicates
         vals, idx_start, count = np.unique(data['TARGETID'], return_index=True, return_counts=True)
-        assert len(vals) == len(data):
+        assert len(vals) == len(data)
         
         fitsio.write(tmpout, data, header=header, extname=ext, clobber=True)
         os.rename(tmpout, outfile)

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -613,6 +613,7 @@ def targets_truth(params, output_dir='.', realtargets=None, seed=None, verbose=F
                               brick_info=brick_info)
     print()
 
+    current_brick_ID = 0 
     # Loop over each source / object type.
     alltargets = list()
     alltruth = list()
@@ -760,6 +761,12 @@ def targets_truth(params, output_dir='.', realtargets=None, seed=None, verbose=F
                 if target_name.upper() != 'SKY':
                     trueflux = trueflux[keep, :]
 
+        #rewrite the target ID to be sure that it is unique in this brick
+        if len(targets):
+            new_brick_ID = current_brick_ID + len(targets)
+            targets['BRICK_OBJID'][:]= np.arange(current_brick_ID,new_brick_ID)
+            current_brick_ID = new_brick_ID
+            
         if target_name.upper() == 'SKY':
             skytruth = truth.copy()
             skytargets = targets.copy()
@@ -778,6 +785,7 @@ def targets_truth(params, output_dir='.', realtargets=None, seed=None, verbose=F
         log.info('No targets; all done.')
         return
 
+    
     targets = vstack(alltargets)
     truth = vstack(alltruth)
     trueflux = np.concatenate(alltrueflux)
@@ -1243,6 +1251,7 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
     Selection = SelectTargets(logger=log, rand=rand,
                               brick_info=brick_info)
     print()
+    current_brick_ID = 0
     # Loop over each source / object type.
     alltargets = list()
     alltruth = list()
@@ -1342,6 +1351,7 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
             truth = truth[keep]
         del out
 
+        
         # Finally downsample based on the desired number density.
         if 'density' in params['sources'][source_name].keys():
             density = params['sources'][source_name]['density']
@@ -1382,6 +1392,12 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
                 targets = targets[keep]
                 truth = truth[keep]
 
+        # rewrite the target ID to be sure that it is unique in this brick
+        if len(targets):
+            new_brick_ID = current_brick_ID + len(targets)
+            targets['BRICK_OBJID'][:] = np.arange(current_brick_ID,new_brick_ID)
+            current_brick_ID = new_brick_ID
+                
         if target_name.upper() == 'SKY':
             skytruth = truth.copy()
             skytargets = targets.copy()
@@ -1389,6 +1405,8 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
             alltargets.append(targets)
             alltruth.append(truth)
         print()
+        
+      
 
     del brick_info # memory clean-up
 

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -981,10 +981,9 @@ def merge_file_tables(fileglob, ext, outfile=None, comm=None):
         header = fitsio.read_header(infiles[0], ext)
         tmpout = outfile + '.tmp'
         
-        # Remove duplicates
-        #vals, idx_start, count = np.unique(data['TARGETID'], return_index=True, return_counts=True)
-        #if len(vals)!=len(data):
-        #    data = data[idx_start[count==1]]
+        # Find duplicates
+        vals, idx_start, count = np.unique(data['TARGETID'], return_index=True, return_counts=True)
+        assert len(vals) == len(data):
         
         fitsio.write(tmpout, data, header=header, extname=ext, clobber=True)
         os.rename(tmpout, outfile)

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -15,7 +15,7 @@ import numpy as np
 from astropy.table import Table, Column, vstack, hstack
 
 from desiutil.log import get_logger, DEBUG
-from desitarget import desi_mask, bgs_mask, mws_mask, contam_mask, targetid_mask
+from desitarget import desi_mask, bgs_mask, mws_mask, contam_mask, targetid_mask, obsconditions
 import desitarget.mock.io as mockio
 from desitarget.mock import sfdmap
 
@@ -323,6 +323,8 @@ def empty_targets_table(nobj=1):
     targets.add_column(Column(name='MWS_TARGET', length=nobj, dtype='i8'))
     targets.add_column(Column(name='HPXPIXEL', length=nobj, dtype='i8'))
     targets.add_column(Column(name='SUBPRIORITY', length=nobj, dtype='f8'))
+    targets.add_column(Column(name='OBSCONDITIONS', length=nobj, dtype='f8'))
+
 
     return targets
 
@@ -1402,12 +1404,13 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
                 targets = targets[keep]
                 truth = truth[keep]
 
-        # rewrite the target ID to be sure that it is unique in this brick
+        # rewrite the target ID to be sure that it is unique in this pixel
         if len(targets):
             new_pixel_ID = current_pixel_ID + len(targets)
             targets['BRICK_OBJID'][:] = np.arange(current_pixel_ID,new_pixel_ID)
             current_pixel_ID = new_pixel_ID
                 
+            
         if target_name.upper() == 'SKY':
             skytruth = truth.copy()
             skytargets = targets.copy()
@@ -1506,7 +1509,8 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
 
     if nsky > 0:
         skytargets['HPXPIXEL'][:] = skypix
-
+        skytargets['OBSCONDITIONS'][:] = obsconditions.DARK|obsconditions.GRAY|obsconditions.BRIGHT 
+        
     for pixnum in healpixels:
         # healsuffix = '{}-{}.fits'.format(nside, pixnum)
         outdir = mockio.get_healpix_dir(nside, pixnum, basedir=output_dir)

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -323,7 +323,7 @@ def empty_targets_table(nobj=1):
     targets.add_column(Column(name='MWS_TARGET', length=nobj, dtype='i8'))
     targets.add_column(Column(name='HPXPIXEL', length=nobj, dtype='i8'))
     targets.add_column(Column(name='SUBPRIORITY', length=nobj, dtype='f8'))
-    targets.add_column(Column(name='OBSCONDITIONS', length=nobj, dtype='f8'))
+    targets.add_column(Column(name='OBSCONDITIONS', length=nobj, dtype='i8'))
 
 
     return targets
@@ -1509,7 +1509,6 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
 
     if nsky > 0:
         skytargets['HPXPIXEL'][:] = skypix
-        skytargets['OBSCONDITIONS'][:] = obsconditions.DARK|obsconditions.GRAY|obsconditions.BRIGHT 
         
     for pixnum in healpixels:
         # healsuffix = '{}-{}.fits'.format(nside, pixnum)

--- a/py/desitarget/mock/selection.py
+++ b/py/desitarget/mock/selection.py
@@ -18,13 +18,14 @@ class SelectTargets(object):
 
     """
     def __init__(self, logger=None, rand=None, brick_info=None):
-        from desitarget import desi_mask, bgs_mask, mws_mask, contam_mask
+        from desitarget import desi_mask, bgs_mask, mws_mask, contam_mask, obsconditions
         
         self.desi_mask = desi_mask
         self.bgs_mask = bgs_mask
         self.mws_mask = mws_mask
         self.contam_mask = contam_mask
-
+        self.obsconditions = obsconditions
+        
         self.log = logger
         self.rand = rand
         self.brick_info = brick_info
@@ -44,7 +45,12 @@ class SelectTargets(object):
         targets['BGS_TARGET'] |= (bgs_faint != 0) * self.bgs_mask.BGS_FAINT
         targets['BGS_TARGET'] |= (bgs_faint != 0) * self.bgs_mask.BGS_FAINT_SOUTH
         targets['DESI_TARGET'] |= (bgs_faint != 0) * self.desi_mask.BGS_ANY
-            
+        
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * obsconditions.mask(bgs_mask[BGS_FAINT].obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * obsconditions.mask(bgs_mask[BGS_FAINT_SOUTH].obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * obsconditions.mask(desi_mask[BGS_ANY].obsconditions)
+
+        
         truth['CONTAM_TARGET'] |= (bgs_faint != 0) * self.contam_mask.BGS_IS_STAR
         truth['CONTAM_TARGET'] |= (bgs_faint != 0) * self.contam_mask.BGS_CONTAM
 
@@ -52,7 +58,11 @@ class SelectTargets(object):
         elg = isELG(gflux=gflux, rflux=rflux, zflux=zflux)
         targets['DESI_TARGET'] |= (elg != 0) * self.desi_mask.ELG
         targets['DESI_TARGET'] |= (elg != 0) * self.desi_mask.ELG_SOUTH
+        
+        targets['OBSCONDITIONS'] |= (elg != 0) * obsconditions.mask(desi_mask[ELG].obsconditions)
+        targets['OBSCONDITIONS'] |= (elg != 0) * obsconditions.mask(desi_mask[ELG_SOUTH].obsconditions)
 
+        
         truth['CONTAM_TARGET'] |= (elg != 0) * self.contam_mask.ELG_IS_STAR
         truth['CONTAM_TARGET'] |= (elg != 0) * self.contam_mask.ELG_CONTAM
 
@@ -62,6 +72,9 @@ class SelectTargets(object):
         targets['DESI_TARGET'] |= (lrg != 0) * self.desi_mask.LRG
         targets['DESI_TARGET'] |= (lrg != 0) * self.desi_mask.LRG_SOUTH
 
+        targets['OBSCONDITIONS'] |= (lrg != 0) * obsconditions.mask(desi_mask[LRG].obsconditions)
+        targets['OBSCONDITIONS'] |= (lrg != 0) * obsconditions.mask(desi_mask[LRG_SOUTH].obsconditions)
+        
         truth['CONTAM_TARGET'] |= (lrg != 0) * self.contam_mask.LRG_IS_STAR
         truth['CONTAM_TARGET'] |= (lrg != 0) * self.contam_mask.LRG_CONTAM
 
@@ -71,6 +84,10 @@ class SelectTargets(object):
         targets['DESI_TARGET'] |= (qso != 0) * self.desi_mask.QSO
         targets['DESI_TARGET'] |= (qso != 0) * self.desi_mask.QSO_SOUTH
 
+        targets['OBSCONDITIONS'] |= (qso != 0) * obsconditions.mask(desi_mask[QSO].obsconditions)
+        targets['OBSCONDITIONS'] |= (qso != 0) * obsconditions.mask(desi_mask[QSO_SOUTH].obsconditions)
+
+        
         truth['CONTAM_TARGET'] |= (qso != 0) * self.contam_mask.QSO_IS_STAR
         truth['CONTAM_TARGET'] |= (qso != 0) * self.contam_mask.QSO_CONTAM
 

--- a/py/desitarget/mock/selection.py
+++ b/py/desitarget/mock/selection.py
@@ -46,9 +46,9 @@ class SelectTargets(object):
         targets['BGS_TARGET'] |= (bgs_faint != 0) * self.bgs_mask.BGS_FAINT_SOUTH
         targets['DESI_TARGET'] |= (bgs_faint != 0) * self.desi_mask.BGS_ANY
         
-        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * obsconditions.mask(bgs_mask[BGS_FAINT].obsconditions)
-        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * obsconditions.mask(bgs_mask[BGS_FAINT_SOUTH].obsconditions)
-        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * obsconditions.mask(desi_mask[BGS_ANY].obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * self.obsconditions.mask(self.bgs_mask.BGS_FAINT.obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * self.obsconditions.mask(self.bgs_mask.BGS_FAINT_SOUTH.obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * self.obsconditions.mask(self.desi_mask.BGS_ANY.obsconditions)
 
         
         truth['CONTAM_TARGET'] |= (bgs_faint != 0) * self.contam_mask.BGS_IS_STAR
@@ -59,8 +59,8 @@ class SelectTargets(object):
         targets['DESI_TARGET'] |= (elg != 0) * self.desi_mask.ELG
         targets['DESI_TARGET'] |= (elg != 0) * self.desi_mask.ELG_SOUTH
         
-        targets['OBSCONDITIONS'] |= (elg != 0) * obsconditions.mask(desi_mask[ELG].obsconditions)
-        targets['OBSCONDITIONS'] |= (elg != 0) * obsconditions.mask(desi_mask[ELG_SOUTH].obsconditions)
+        targets['OBSCONDITIONS'] |= (elg != 0) * self.obsconditions.mask(self.desi_mask.ELG.obsconditions)
+        targets['OBSCONDITIONS'] |= (elg != 0) * self.obsconditions.mask(self.desi_mask.ELG_SOUTH.obsconditions)
 
         
         truth['CONTAM_TARGET'] |= (elg != 0) * self.contam_mask.ELG_IS_STAR
@@ -72,8 +72,8 @@ class SelectTargets(object):
         targets['DESI_TARGET'] |= (lrg != 0) * self.desi_mask.LRG
         targets['DESI_TARGET'] |= (lrg != 0) * self.desi_mask.LRG_SOUTH
 
-        targets['OBSCONDITIONS'] |= (lrg != 0) * obsconditions.mask(desi_mask[LRG].obsconditions)
-        targets['OBSCONDITIONS'] |= (lrg != 0) * obsconditions.mask(desi_mask[LRG_SOUTH].obsconditions)
+        targets['OBSCONDITIONS'] |= (lrg != 0) * self.obsconditions.mask(self.desi_mask.LRG.obsconditions)
+        targets['OBSCONDITIONS'] |= (lrg != 0) * self.obsconditions.mask(self.desi_mask.LRG_SOUTH.obsconditions)
         
         truth['CONTAM_TARGET'] |= (lrg != 0) * self.contam_mask.LRG_IS_STAR
         truth['CONTAM_TARGET'] |= (lrg != 0) * self.contam_mask.LRG_CONTAM
@@ -84,9 +84,8 @@ class SelectTargets(object):
         targets['DESI_TARGET'] |= (qso != 0) * self.desi_mask.QSO
         targets['DESI_TARGET'] |= (qso != 0) * self.desi_mask.QSO_SOUTH
 
-        targets['OBSCONDITIONS'] |= (qso != 0) * obsconditions.mask(desi_mask[QSO].obsconditions)
-        targets['OBSCONDITIONS'] |= (qso != 0) * obsconditions.mask(desi_mask[QSO_SOUTH].obsconditions)
-
+        targets['OBSCONDITIONS'] |= (qso != 0) * self.obsconditions.mask(self.desi_mask.QSO.obsconditions)
+        targets['OBSCONDITIONS'] |= (qso != 0) * self.obsconditions.mask(self.desi_mask.QSO_SOUTH.obsconditions)
         
         truth['CONTAM_TARGET'] |= (qso != 0) * self.contam_mask.QSO_IS_STAR
         truth['CONTAM_TARGET'] |= (qso != 0) * self.contam_mask.QSO_CONTAM
@@ -116,6 +115,7 @@ class SelectTargets(object):
             fstd = boss_std * ( obs_rflux < 10**((22.5 - rbright)/2.5) ) * ( obs_rflux > 10**((22.5 - rfaint)/2.5) )
 
         targets['DESI_TARGET'] |= (fstd != 0) * self.desi_mask.STD_FSTAR
+        targets['OBSCONDITIONS'] |= (fstd != 0) * self.obsconditions.mask(self.desi_mask.STD_FSTAR.obsconditions)
 
         # Select bright-time FSTD targets.  Temporary hack to use the BOSS
         # standard-star selection algorith.
@@ -129,6 +129,8 @@ class SelectTargets(object):
             fstd_bright = boss_std * ( obs_rflux < 10**((22.5 - rbright)/2.5) ) * ( obs_rflux > 10**((22.5 - rfaint)/2.5) )
 
         targets['DESI_TARGET'] |= (fstd_bright != 0) * self.desi_mask.STD_BRIGHT
+        targets['OBSCONDITIONS'] |= (fstd_bright != 0) * self.obsconditions.mask(self.desi_mask.STD_BRIGHT.obsconditions)
+
         
     def bgs_select(self, targets, truth, boss_std=None):
         """Select BGS targets.
@@ -144,11 +146,22 @@ class SelectTargets(object):
         targets['BGS_TARGET'] |= (bgs_bright != 0) * self.bgs_mask.BGS_BRIGHT_SOUTH
         targets['DESI_TARGET'] |= (bgs_bright != 0) * self.desi_mask.BGS_ANY
 
+        targets['OBSCONDITIONS'] |= (bgs_bright != 0) * self.obsconditions.mask(self.bgs_mask.BGS_BRIGHT.obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_bright != 0) * self.obsconditions.mask(self.bgs_mask.BGS_BRIGHT_SOUTH.obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_bright != 0) * self.obsconditions.mask(self.desi_mask.BGS_ANY.obsconditions)
+
+        
         # Select BGS_FAINT targets.
         bgs_faint = isBGS_faint(rflux=rflux)
         targets['BGS_TARGET'] |= (bgs_faint != 0) * self.bgs_mask.BGS_FAINT
         targets['BGS_TARGET'] |= (bgs_faint != 0) * self.bgs_mask.BGS_FAINT_SOUTH
         targets['DESI_TARGET'] |= (bgs_faint != 0) * self.desi_mask.BGS_ANY
+        
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * self.obsconditions.mask(self.bgs_mask.BGS_FAINT.obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * self.obsconditions.mask(self.bgs_mask.BGS_FAINT_SOUTH.obsconditions)
+        targets['OBSCONDITIONS'] |= (bgs_faint != 0) * self.obsconditions.mask(self.desi_mask.BGS_ANY.obsconditions)
+
+
 
     def elg_select(self, targets, truth, boss_std=None):
         """Select ELG targets and contaminants."""
@@ -161,6 +174,9 @@ class SelectTargets(object):
 
         targets['DESI_TARGET'] |= (elg != 0) * self.desi_mask.ELG
         targets['DESI_TARGET'] |= (elg != 0) * self.desi_mask.ELG_SOUTH
+        targets['OBSCONDITIONS'] |= (elg != 0) * self.obsconditions.mask(self.desi_mask.ELG.obsconditions)
+        targets['OBSCONDITIONS'] |= (elg != 0) * self.obsconditions.mask(self.desi_mask.ELG_SOUTH.obsconditions)
+
 
         # Select ELG contaminants for QSO targets.  There should be a morphology
         # cut here, too, so we're going to overestimate the number of
@@ -170,7 +186,9 @@ class SelectTargets(object):
                            w2flux=w2flux, optical=False) # Note optical=False!
         targets['DESI_TARGET'] |= (qso != 0) * (elg == 0) * self.desi_mask.QSO
         targets['DESI_TARGET'] |= (qso != 0) * (elg == 0) * self.desi_mask.QSO_SOUTH
-            
+        targets['OBSCONDITIONS'] |= (qso != 0) * (elg == 0) * self.obsconditions.mask(self.desi_mask.QSO.obsconditions)
+        targets['OBSCONDITIONS'] |= (qso != 0) * (elg == 0) * self.obsconditions.mask(self.desi_mask.QSO_SOUTH.obsconditions)
+
         truth['CONTAM_TARGET'] |= (qso != 0) * (elg == 0) * self.contam_mask.QSO_IS_ELG
         truth['CONTAM_TARGET'] |= (qso != 0) * (elg == 0) * self.contam_mask.QSO_IS_GALAXY
         truth['CONTAM_TARGET'] |= (qso != 0) * (elg == 0) * self.contam_mask.QSO_CONTAM
@@ -192,7 +210,10 @@ class SelectTargets(object):
 
         targets['DESI_TARGET'] |= (lrg != 0) * self.desi_mask.LRG
         targets['DESI_TARGET'] |= (lrg != 0) * self.desi_mask.LRG_SOUTH
+        targets['OBSCONDITIONS'] |= (lrg != 0) * self.obsconditions.mask(self.desi_mask.LRG.obsconditions)
+        targets['OBSCONDITIONS'] |= (lrg != 0) * self.obsconditions.mask(self.desi_mask.LRG_SOUTH.obsconditions)
 
+        
         # Select LRG contaminants for QSO targets.  There should be a morphology
         # cut here, too, so we're going to overestimate the number of
         # contaminants.  To make sure we don't reduce the number density of true
@@ -201,7 +222,10 @@ class SelectTargets(object):
                            w2flux=w2flux, optical=False) # Note optical=False!
         targets['DESI_TARGET'] |= (qso != 0) * (lrg == 0) * self.desi_mask.QSO
         targets['DESI_TARGET'] |= (qso != 0) * (lrg == 0) * self.desi_mask.QSO_SOUTH
+        targets['OBSCONDITIONS'] |= (qso != 0) * (lrg == 0)  * self.obsconditions.mask(self.desi_mask.QSO.obsconditions)
+        targets['OBSCONDITIONS'] |= (qso != 0) * (lrg == 0)  * self.obsconditions.mask(self.desi_mask.QSO_SOUTH.obsconditions)
 
+        
         truth['CONTAM_TARGET'] |= (qso != 0) * (lrg == 0) * self.contam_mask.QSO_IS_LRG
         truth['CONTAM_TARGET'] |= (qso != 0) * (lrg == 0) * self.contam_mask.QSO_IS_GALAXY
         truth['CONTAM_TARGET'] |= (qso != 0) * (lrg == 0) * self.contam_mask.QSO_CONTAM
@@ -233,10 +257,15 @@ class SelectTargets(object):
         
         targets['MWS_TARGET'] |= (mws_main != 0) * self.mws_mask.mask('MWS_MAIN')
         targets['DESI_TARGET'] |= (mws_main != 0) * self.desi_mask.MWS_ANY
+        targets['OBSCONDITIONS'] |= (mws_main != 0)  * self.obsconditions.mask(self.mws_mask.MWS_MAIN.obsconditions)
+        targets['OBSCONDITIONS'] |= (mws_main != 0)  * self.obsconditions.mask(self.desi_mask.MWS_ANY.obsconditions)
 
+        
         mws_main_very_faint = _isMWS_MAIN_VERY_FAINT(rflux=rflux)
         targets['MWS_TARGET'] |= (mws_main_very_faint != 0) * self.mws_mask.mask('MWS_MAIN_VERY_FAINT')
         targets['DESI_TARGET'] |= (mws_main_very_faint != 0) * self.desi_mask.MWS_ANY
+        targets['OBSCONDITIONS'] |= (mws_main_very_faint != 0)  * self.obsconditions.mask(self.mws_mask.MWS_MAIN_VERY_FAINT.obsconditions)
+        targets['OBSCONDITIONS'] |= (mws_main_very_faint != 0)  * self.obsconditions.mask(self.desi_mask.MWS_ANY.obsconditions)
 
         # Select standard stars.
         self._std_select(targets, truth, boss_std=boss_std)
@@ -254,6 +283,8 @@ class SelectTargets(object):
 
         targets['MWS_TARGET'] |= (mws_nearby != 0) * self.mws_mask.mask('MWS_NEARBY')
         targets['DESI_TARGET'] |= (mws_nearby != 0) * self.desi_mask.MWS_ANY
+        targets['OBSCONDITIONS'] |= (mws_nearby != 0)  * self.obsconditions.mask(self.mws_mask.MWS_NEARBY.obsconditions)
+        targets['OBSCONDITIONS'] |= (mws_nearby != 0)  * self.obsconditions.mask(self.desi_mask.MWS_ANY.obsconditions)
 
     def mws_wd_select(self, targets, truth, boss_std=None):
         """Select MWS_WD and STD_WD targets.  The selection eventually will be done with
@@ -265,10 +296,14 @@ class SelectTargets(object):
 
         targets['MWS_TARGET'] |= (mws_wd != 0) * self.mws_mask.mask('MWS_WD')
         targets['DESI_TARGET'] |= (mws_wd != 0) * self.desi_mask.MWS_ANY
+        targets['OBSCONDITIONS'] |= (mws_wd != 0)  * self.obsconditions.mask(self.mws_mask.MWS_WD.obsconditions)
+        targets['OBSCONDITIONS'] |= (mws_wd != 0)  * self.obsconditions.mask(self.desi_mask.MWS_ANY.obsconditions)
 
         # Select STD_WD; cut just on g-band magnitude (not TEMPLATESUBTYPE!)
         std_wd = (truth['MAG'] <= 19.0) * 1 # SDSS g-band!
         targets['DESI_TARGET'] |= (std_wd !=0) * self.desi_mask.mask('STD_WD')
+        targets['OBSCONDITIONS'] |= (std_wd != 0)  * self.obsconditions.mask(self.desi_mask.STD_WD.obsconditions)
+
 
     def qso_select(self, targets, truth, boss_std=None):
         """Select QSO targets and contaminants."""
@@ -282,12 +317,16 @@ class SelectTargets(object):
 
         targets['DESI_TARGET'] |= (qso != 0) * self.desi_mask.QSO
         targets['DESI_TARGET'] |= (qso != 0) * self.desi_mask.QSO_SOUTH
+        targets['OBSCONDITIONS'] |= (qso != 0)  * self.obsconditions.mask(self.desi_mask.QSO.obsconditions)
+        targets['OBSCONDITIONS'] |= (qso != 0)  * self.obsconditions.mask(self.desi_mask.QSO_SOUTH.obsconditions)
 
         # Select QSO contaminants for ELG targets.  There'd be no morphology cut
         # and we're missing the WISE colors, so the density won't be right.
         elg = isELG(gflux=gflux, rflux=rflux, zflux=zflux)
         targets['DESI_TARGET'] |= (elg != 0) * self.desi_mask.ELG
         targets['DESI_TARGET'] |= (elg != 0) * self.desi_mask.ELG_SOUTH
+        targets['OBSCONDITIONS'] |= (elg != 0)  * self.obsconditions.mask(self.desi_mask.ELG.obsconditions)
+        targets['OBSCONDITIONS'] |= (elg != 0)  * self.obsconditions.mask(self.desi_mask.ELG_SOUTH.obsconditions)
 
         truth['CONTAM_TARGET'] |= (elg != 0) * self.contam_mask.ELG_IS_QSO
         truth['CONTAM_TARGET'] |= (elg != 0) * self.contam_mask.ELG_CONTAM
@@ -296,6 +335,8 @@ class SelectTargets(object):
         """Select SKY targets."""
 
         targets['DESI_TARGET'] |= self.desi_mask.mask('SKY')
+        targets['OBSCONDITIONS'] |= self.obsconditions.mask(self.desi_mask.SKY.obsconditions)
+
 
     def density_select(self, targets, truth, source_name, target_name, density=None, subset=None):
         """Downsample a target sample to a desired number density in targets/deg2."""

--- a/py/desitarget/mock/spectra.py
+++ b/py/desitarget/mock/spectra.py
@@ -645,3 +645,169 @@ class MockMagnitudes(object):
     def __init__(self, nproc=1, rand=None, verbose=False):
         self.rand = rand
         self.verbose = verbose
+    def bgs(self, data, index=None, mockformat='durham_mxxl_hdf5'):
+        """Generate magnitudes for BGS.
+        Currently only the MXXL (durham_mxxl_hdf5) mock is supported.  DATA
+        needs to have Z, SDSS_absmag_r01, SDSS_01gr, VDISP, and SEED, which are
+        assigned in mock.io.read_durham_mxxl_hdf5.  
+        """
+        objtype = 'BGS'
+        if index is None:
+            index = np.arange(len(data['Z']))
+        meta = empty_metatable(nmodel=len(index), objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT', 'VDISP'),
+                                  ('SEED', 'MAG', 'Z', 'VDISP')):
+            meta[inkey] = data[datakey][index]
+
+        if mockformat.lower() != 'durham_mxxl_hdf5':
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+            return meta
+        meta['FLUX_R'][:] = 10**((22.5 - data['MAG'][index])/2.5) # r-band flux
+        meta['FLUX_G'][:] = 10**((22.5-(data['SDSS_01gr'][index] + data['MAG'][index]))/2.5) # g-band flux
+        return meta
+    
+    def mws(self, data, index=None, mockformat='galaxia'):
+        """Generate magnitudes for the MWS_NEARBY and MWS_MAIN samples.
+        """
+        objtype = 'STAR'
+        if index is None:
+            index = np.arange(len(data['Z']))
+
+        meta = empty_metatable(nmodel=len(index), objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT', 'TEFF', 'LOGG', 'FEH'),
+                                  ('SEED', 'MAG', 'Z', 'TEFF', 'LOGG', 'FEH')):
+            meta[inkey] = data[datakey][index]
+
+        if not (mockformat.lower() in ['100pc','galaxia']):
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+            return meta
+
+        meta['FLUX_R'][:] = 10**((22.5 - data['MAG'][index])/2.5) # r-band flux
+        return meta
+                
+    def mws_nearby(self, data, index=None, mockformat='100pc'):
+        """Generate magnitudes for the MWS_NEARBY sample.
+        """
+        meta = self.mws(data, index=index, mockformat=mockformat)
+        return meta
+
+    def mws_main(self, data, index=None, mockformat='galaxia'):
+        """Generate magnitudes for the MWS_MAIN sample.
+        """
+        meta = self.mws(data, index=index, mockformat=mockformat)
+        return meta
+
+    def faintstar(self, data, index=None, mockformat='galaxia'):
+        """Generate magnitudes for the FAINTSTAR (faint stellar) sample.
+        """
+        meta = self.mws(data, index=index, mockformat=mockformat)
+        return meta
+        
+    def elg(self, data, index=None, mockformat='gaussianfield'):
+        """Generate magnitudes for the ELG sample.
+        Currently only the GaussianField mock sample is supported.  DATA needs
+        to have Z, GR, RZ, VDISP, and SEED, which are assigned in
+        mock.io.read_gaussianfield.  
+        """
+        objtype = 'ELG'
+        if index is None:
+            index = np.arange(len(data['Z']))
+
+        meta = empty_metatable(nmodel=len(index), objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT', 'VDISP'),
+                                  ('SEED', 'MAG', 'Z', 'VDISP')):
+            meta[inkey] = data[datakey][index]
+
+        if mockformat.lower() != 'gaussianfield':
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+            return meta
+        
+        meta['FLUX_G'][:] = 10**((22.5 - (data['GR'][index] + data['MAG'][index]))/2.5) # g-band flux
+        meta['FLUX_R'][:] = 10**((22.5 - data['MAG'][index])/2.5) # r-band flux
+        meta['FLUX_Z'][:] = 10**((22.5 - (data['MAG'][index] - data['RZ'][index]))/2.5) # z-band flux
+        return meta
+    
+    def lrg(self, data, index=None, mockformat='gaussianfield'):
+        """Generate magnitudes for the LRG sample.
+        Currently only the GaussianField mock sample is supported.  DATA needs
+        to have Z, GR, RZ, VDISP, and SEED, which are assigned in
+        mock.io.read_gaussianfield.  
+        """
+        objtype = 'LRG'
+        if index is None:
+            index = np.arange(len(data['Z']))
+        nobj = len(index)
+
+        meta = empty_metatable(nmodel=len(index), objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT', 'VDISP'),
+                                  ('SEED', 'MAG', 'Z', 'VDISP')):
+            meta[inkey] = data[datakey][index]
+
+        if mockformat.lower() != 'gaussianfield':
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+            return meta
+        
+        meta['FLUX_G'][:] = 10**((22.5 - (data['GR'][index] + data['RZ'][index] + data['MAG'][index]))/2.5) # g-band flux  
+        meta['FLUX_R'][:] =  10**((22.5 - (data['MAG'][index] + data['RZ'][index]))/2.5) # r-band flux
+        meta['FLUX_Z'][:] = 10**((22.5 - data['MAG'][index])/2.5) # z-band flux
+        meta['FLUX_W1'][:] = 10**((22.5 - (data['RZ'][index] + data['MAG'][index] - data['RW1'][index]))/2.5)# wise flux 1
+        meta['FLUX_W2'][:] = 10**((22.5 - (data['RZ'][index] + data['MAG'][index] - data['RW1'][index] - data['W1W2'][index]))/2.5)# wise flux 2
+        
+        return meta
+    
+    def qso(self, data, index=None, mockformat='gaussianfield'):
+        """Generate magnitudes for the QSO or QSO/LYA samples.
+        """
+        from desisim.lya_spectra import get_spectra
+        
+        objtype = 'QSO'
+        if index is None:
+            index = np.arange(len(data['Z']))
+        nobj = len(index)
+        meta = empty_metatable(nmodel=nobj, objtype=objtype)
+
+        if mockformat.lower() != 'gaussianfield':
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+            return meta
+        
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT'),
+                                      ('SEED', 'MAG', 'Z')):
+            meta[inkey] = data[datakey][index]
+        
+        meta['FLUX_G'][:] = 10**((22.5 - data['MAG'][index])/2.5) # g-band flux
+        meta['FLUX_R'][:] = 10**((22.5 - (data['MAG'][index] - data['GR'][index]))/2.5) # r-band flux
+        meta['FLUX_Z'][:] = 10**((22.5 - (data['MAG'][index] - data['GR'][index] - data['RZ'][index]))/2.5) # z-band flux
+        meta['FLUX_W1'][:] = 10**((22.5 - (data['MAG'][index] - data['GR'][index] - data['RW1'][index]))/2.5)# wise flux 1
+        meta['FLUX_W2'][:] = 10**((22.5 - (data['MAG'][index] - data['GR'][index] - data['RW1'][index] - data['W1W2'][index]))/2.5)# wise flux 2
+        
+        lya = np.where( data['TEMPLATESUBTYPE'][index] == 'LYA' )[0]                 
+        if len(lya) > 0:
+            meta['SUBTYPE'][lya] = 'LYA'
+                                       
+        return meta
+    def mws_wd(self, data, index=None, mockformat='wd'):
+        """Generate magnitudes for the MWS_WD sample.  Deal with DA vs DB white dwarfs
+        separately.
+        """
+        objtype = 'WD'
+        if index is None:
+            index = np.arange(len(data['Z']))
+        nobj = len(index)
+
+        meta = empty_metatable(nmodel=nobj, objtype=objtype)
+        for inkey, datakey in zip(('SEED', 'MAG', 'REDSHIFT', 'TEFF', 'LOGG', 'SUBTYPE'),
+                                  ('SEED', 'MAG', 'Z', 'TEFF', 'LOGG', 'TEMPLATESUBTYPE')):
+            meta[inkey] = data[datakey][index]
+
+        if mockformat.lower() != 'wd':
+            raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
+            return meta
+            
+        for subtype in ('DA', 'DB'):
+            these = np.where(meta['SUBTYPE'] == subtype)[0]
+            if len(these) > 0:
+                meta['SUBTYPE'][these] = subtype    
+                meta['TEMPLATEID'][:] = -1
+    
+        meta['FLUX_G'][:] = 10**((22.5 - data['MAG'][index])/2.5) # g-band flux
+        return meta

--- a/py/desitarget/mock/spectra.py
+++ b/py/desitarget/mock/spectra.py
@@ -637,3 +637,11 @@ class MockSpectra(object):
         flux = np.zeros((nobj, len(self.wave)), dtype='i1')
 
         return flux, meta
+
+class MockMagnitudes(object):
+    """
+    Generate mock magnitudes for each mock.
+    """
+    def __init__(self, nproc=1, rand=None, verbose=False):
+        self.rand = rand
+        self.verbose = verbose


### PR DESCRIPTION
(After PR #207 it was easier to create a new branch an a new PR than fix #206)
This PR implements the option --no-spectra into mpi_build_mock_targets to avoid generating spectra on the fly.

The code works but I think I found one problem and one bug

1. It seems to me that helpixels trace can be seen in the catalogs. [See this notebook](https://github.com/desihub/quicksurvey_example/blob/without_spectra/nospectra.ipynb). The first two plots there come from the --no-spectra option, the next two plots come from the version generating the full spectra. In both cases there are some overdensities piling up on the healpix boundaries.
This is more evident with n_side=32 or n_side=16. I will post those plots later. In the meantime I will start looking into what is causing the problem.

2. `mpi_select_mock_targets` produces non-unique `TARGETIDs` for `targets` and `sky`. This bug will make `fiberassign` crash. This bug was already in master. I tried to fix it [with this](https://github.com/desihub/desitarget/blob/2dfd9bdde8f3aabaa72d99cd312d31f88bbe851a/py/desitarget/mock/build.py#L1396-L1399), but it doesn't cover all cases. It seems that some bricks are covered by two different processors.

You can use this [quicksurvey_example branch](https://github.com/desihub/quicksurvey_example/tree/without_spectra) to test the --no-spectra option. All the required input files are there.