### PR TITLE
Changes BGS reobservation scheme to match BGS spec

### DIFF
--- a/py/desitarget/test/test_numobs.py
+++ b/py/desitarget/test/test_numobs.py
@@ -12,6 +12,7 @@ class TestNumObs(unittest.TestCase):
             ('DESI_TARGET',np.int64),
             ('BGS_TARGET',np.int64),
             ('MWS_TARGET',np.int64),
+            ('NUMOBS',np.int32),
             ('DECAM_FLUX', '>f4', (6,)),
             ('DECAM_MW_TRANSMISSION', '>f4', (6,)),
         ]


### PR DESCRIPTION
Changes to calc_numobs in targets.py to implement the following:

- BGS targets can be reobserved on every epoch, there is no maximum
  number of reobservations (although priorities change on ZGOOD).

- BGS targets should be observed no more than once on a single epoch
  (which can happen in tile overlaps).