### PR TITLE
Changes in mock targets --no-spectra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.17
         - ASTROPY_VERSION=1.2.1
-        # - SPHINX_VERSION=1.3
+        - SPHINX_VERSION=1.5
         - DESIUTIL_VERSION=1.9.5
         - DESISPEC_VERSION=0.11.0
         - DESISIM_VERSION=master

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -1254,11 +1254,30 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
         
     log.info('Writing to output directory {}'.format(output_dir))
     print()
+    
 
+    
     # Default set of healpixels is the whole sky (yikes!)
     if healpixels is None:
         healpixels = np.arange(hp.nside2npix(nside))
 
+        
+    #shortening pixel list if some of them were already computed
+    log.info('pixels to do [before file testing] {}'.format(healpixels))
+    donepix = []
+    for i in range(len(healpixels)):
+        pixnum = healpixels[i]
+        targetsfile = mockio.findfile('targets', nside, pixnum, basedir=output_dir)
+        truthfile = mockio.findfile('truth', nside, pixnum, basedir=output_dir)
+        if os.path.exists(targetsfile) and os.path.exists(truthfile):
+            log.warning('Removing pixel {} from list as files {} and {} already exist'.format(healpixels[i], targetsfile, truthfile))
+            donepix.append(i)
+    if len(donepix)>0:
+        healpixels = np.delete(healpixels, donepix)
+    log.info('pixels to do [after file testing] {}'.format(healpixels))
+    if len(healpixels)==0:
+        return
+        
     areaperpix = hp.nside2pixarea(nside, degrees=True)
     skyarea = len(healpixels) * areaperpix
     log.info('Grouping into {} healpixel(s) (nside = {}, {:.3f} deg2/pixel) spanning {:.3f} deg2.'.format(

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -1262,22 +1262,6 @@ def targets_truth_no_spectra(params, output_dir='.', realtargets=None, seed=None
         healpixels = np.arange(hp.nside2npix(nside))
 
         
-    #shortening pixel list if some of them were already computed
-    log.info('pixels to do [before file testing] {}'.format(healpixels))
-    donepix = []
-    for i in range(len(healpixels)):
-        pixnum = healpixels[i]
-        targetsfile = mockio.findfile('targets', nside, pixnum, basedir=output_dir)
-        truthfile = mockio.findfile('truth', nside, pixnum, basedir=output_dir)
-        if os.path.exists(targetsfile) and os.path.exists(truthfile):
-            log.warning('Removing pixel {} from list as files {} and {} already exist'.format(healpixels[i], targetsfile, truthfile))
-            donepix.append(i)
-    if len(donepix)>0:
-        healpixels = np.delete(healpixels, donepix)
-    log.info('pixels to do [after file testing] {}'.format(healpixels))
-    if len(healpixels)==0:
-        return
-        
     areaperpix = hp.nside2pixarea(nside, degrees=True)
     skyarea = len(healpixels) * areaperpix
     log.info('Grouping into {} healpixel(s) (nside = {}, {:.3f} deg2/pixel) spanning {:.3f} deg2.'.format(

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -608,7 +608,7 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
         lyafiles_qso = np.repeat('', nobj_qso)
         lyahdu_qso = np.repeat([-1], nobj_qso)
         templatetype_qso = np.repeat('QSO', nobj_qso)
-        templatesubtype = np.repeat('', nobj_qso)
+        templatesubtype_qso = np.repeat('', nobj_qso)
 
     # Combine the QSO and Lyman-alpha samples.
     if target_name == 'QSO' and lya:
@@ -642,7 +642,7 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
             lyafiles = lyafiles_qso
             lyahdu = lyahdu_qso
             templatetype = templatetype_qso
-            templatesubtype = templatesubtype
+            templatesubtype = templatesubtype_qso
         else:
             log.info('Trimmed to {} Lya QSOs in healpixels {}'.format(nobj_lya, healpixels))
 

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -642,7 +642,7 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
             lyafiles = lyafiles_qso
             lyahdu = lyahdu_qso
             templatetype = templatetype_qso
-            templatesubtype = templatesubtype_qso
+            templatesubtype = templatesubtype
         else:
             log.info('Trimmed to {} Lya QSOs in healpixels {}'.format(nobj_lya, healpixels))
 

--- a/py/desitarget/mock/selection.py
+++ b/py/desitarget/mock/selection.py
@@ -362,6 +362,8 @@ class SelectTargets(object):
             if density and n_in_brick > 0:
                 mock_density = n_in_brick / brick_area
                 desired_density = float(self.brick_info['FLUC_EBV_{}'.format(source_name)][brickindx] * density)
+                if desired_density < 0.0:
+                    desired_density = 0.0
 
                 frac_keep = desired_density / mock_density
                 if frac_keep > 1.0:
@@ -402,6 +404,8 @@ class SelectTargets(object):
                 if n_in_brick > 0:
                     contam_density = len(onbrick) / brick_area
                     desired_density = float(self.brick_info['FLUC_EBV_{}'.format(source_name)][brickindx] * contam[contam_name])
+                    if desired_density < 0.0:
+                        desired_density = 0.0
 
                     frac_keep = desired_density / contam_density
                     if frac_keep > 1.0:


### PR DESCRIPTION
This PR:
* Allows for a restart from completed pixels.
* Solves a minor bug in completing in lyaqso generation when there is no lyaqso.
* Solves a major bug in the case of negative numbers for `ndens`.