### PR TITLE
stdstar selection without obsconditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.17
         - ASTROPY_VERSION=1.2.1
-        # - SPHINX_VERSION=1.3
+        - SPHINX_VERSION=1.5
         - DESIUTIL_VERSION=1.9.5
         - DESISPEC_VERSION=0.11.0
         - DESISIM_VERSION=master


### PR DESCRIPTION
It appears that we messed up our implementation of stdstar selection in PR #208. The code in master doesn't select or output any targets as standard stars (!).  This PR reverts the logic to just select (STD_FSTAR or STD_WD) for dark/gray time and (STD_BRIGHT or STD_WD) for bright time.  It doesn't explicitly check the target OBSCONDITIONS flag, since it appears that *all* mock standards are flagged as MWS targets anyway and thus are flagged for dark/gray/bright conditions.

Adding BRIGHT to the list of allowable conditions for STD_WD in desitargets.yaml in commit [7a6990](https://github.com/desihub/desitarget/commit/7a69904a1ee2055d0206952288caccb267095d86#diff-0f465bc9b95c5e21ca142c26fcfd2fa8) was still correct for bookkeeping, but for the purposes of stdstar selection, it seems we should just use the targetbits without also checking obsconditions.

Please double check me, @apcooper.
