### PR TITLE
add more uniform than random sky mocks

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -17,11 +17,13 @@ desitarget Change Log
    * Correct random seeds when processing pix in parallel
    * Misc other small bug fixes
 * Added ``mpi_select_mock_targets``
+* Added ``desitarget.mock.sky.random_sky`` [`PR #219`_]
 
 
 .. _`PR #200`: https://github.com/desihub/desitarget/pull/200
 .. _`PR #210`: https://github.com/desihub/desitarget/pull/210
 .. _`PR #214`: https://github.com/desihub/desitarget/pull/214
+.. _`PR #219`: https://github.com/desihub/desitarget/pull/219
 
 0.14.0 (2017-07-10)
 -------------------

--- a/py/desitarget/mock/sky.py
+++ b/py/desitarget/mock/sky.py
@@ -13,7 +13,7 @@ def _random_theta_phi(nside, pix):
 def random_sky(nside=2048, tiles=None, maxiter=20):
     '''
     Returns sky locations within healpixels covering tiles
-    
+
     Options:
         nside (int): healpixel nside; coverage is uniform at this scale
         tiles: DESI tiles to cover, for desimodel.footprint.tiles2pix()

--- a/py/desitarget/mock/sky.py
+++ b/py/desitarget/mock/sky.py
@@ -1,0 +1,51 @@
+import desimodel.io
+import desimodel.footprint
+import numpy as np
+import healpy as hp
+
+def _random_theta_phi(nside, pix):
+    theta, phi = hp.pix2ang(nside, pix, nest=True)
+    dpix = np.sqrt(hp.nside2pixarea(nside))
+    theta += np.random.uniform(-dpix/2, dpix/2, size=len(theta))
+    phi += np.random.uniform(-dpix/2, dpix/2, size=len(phi)) * np.cos(np.pi/2 - theta)
+    return theta % np.pi, phi % (2*np.pi)
+
+def random_sky(nside=2048, tiles=None, maxiter=20):
+    '''
+    Returns sky locations within healpixels covering tiles
+    
+    Options:
+        nside (int): healpixel nside; coverage is uniform at this scale
+        tiles: DESI tiles to cover, for desimodel.footprint.tiles2pix()
+        maxiter (int): maximum number of iterations to ensure coverage
+
+    Generates sky locations that are more uniform than true random,
+    such that every healpixel has a point within it.  Note that this
+    should *not* be used for mock randoms.
+    
+    nside=2048 corresponds to about half of a DESI positioner patrol area
+    and results in ~18M sky locations over the full footprint.
+    '''
+    if tiles is None:
+        tiles = desimodel.io.load_tiles()
+    pix = desimodel.footprint.tiles2pix(nside, tiles)
+    theta, phi = _random_theta_phi(nside, pix)
+
+    #- there is probably a more clever way to do this, but iteratively
+    #- replace points that scatter outside their original healpixel until
+    #- all healpixels are covered
+    for i in range(maxiter):
+        skypix = hp.ang2pix(nside, theta, phi, nest=True)
+        missing = np.in1d(pix, skypix, invert=True)
+        ii = np.where(missing)[0]
+        if len(ii) == 0:
+            break
+
+        tx, px = _random_theta_phi(nside, pix[ii])
+        theta[ii] = tx
+        phi[ii] = px
+
+    ra = np.degrees(phi)
+    dec = 90 - np.degrees(theta)
+
+    return ra, dec

--- a/py/desitarget/test/test_mock_build.py
+++ b/py/desitarget/test/test_mock_build.py
@@ -5,8 +5,12 @@ Testing desitarget.mock.build, but only add_mock_shapes_and_fluxes for now
 import unittest
 import numpy as np
 from astropy.table import Table
+import healpy as hp
+
+import desimodel.footprint
 
 from desitarget.mock.build import add_mock_shapes_and_fluxes
+from desitarget.mock.sky import random_sky
 from desitarget import desi_mask, bgs_mask, mws_mask
 
 class TestMockBuild(unittest.TestCase):
@@ -40,6 +44,16 @@ class TestMockBuild(unittest.TestCase):
         self.assertTrue('DECAM_FLUX' in mock.colnames)
         self.assertTrue('SHAPEDEV_R' in mock.colnames)
         self.assertTrue('SHAPEEXP_R' in mock.colnames)
-                
+
+    def test_sky(self):
+        nside = 256
+        ra, dec = random_sky(nside)
+        self.assertEqual(len(ra), len(dec))
+        surveypix = desimodel.footprint.tiles2pix(nside)
+        theta = np.radians(90 - dec)
+        phi = np.radians(ra)
+        skypix = hp.ang2pix(nside, theta, phi, nest=True)
+        self.assertEqual(set(surveypix), set(skypix))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We are currently using /project/projectdirs/desi/mocks/GaussianRandomField/v0.0.1/2048/random.fits for the sky locations.  These have an appropriate average density, but due to random fluctuations it can happen that a positioner has no science targets, standard stars, or sky locations within its reach.  This PR provides code for generating "more uniform than random" sky locations that are random smaller than some scale but have a guaranteed uniformity above that scale.  The default is healpix nside=2048 which corresponds to about half of a fiber patrol radius, and it guarantees that every nside=2048 pixel that covers the DESI footprint will have one sky location such that every fiber should have two sky options.

The final sky catalog will be more complicated than this and based upon actually avoiding objects while still guaranteeing enough sky locations for every fiber and not just on average, but this code can generate mocks closer to that.

The following plots show a comparison of the current sky locations (left) with the proposed new ones (right)

![newsky](https://user-images.githubusercontent.com/218471/30898487-6af33f8e-a310-11e7-9451-99ec5107f3a8.png)

A histogram of the densities of nside=2048 pixels covering the DESI footprint shows that the current scheme (blue) often has no targets within a pixel, while the new scheme (orange) guarantees one sky fiber per pixel.

![sky-coverage](https://user-images.githubusercontent.com/218471/30898531-a8b468ca-a310-11e7-9cee-6a3c3c6ff0d9.png)

Implementation notes:
* due to the odd shapes of healpixels, the targets aren't exactly random within a pixel and use an iterative algorithm to fill in points that randomly scattered outside of the pixel to which they were assigned.  A more clever algorithm could replace this.
* example file at /project/projectdirs/desi/users/sjbailey/mocks/sky/0.1/uniformsky.fits.  Once vetted this would be moved into the standard DESI project mock directory structure.
* this new catalog needs desihub/desitarget#82 to be addressed to fully make use of the extra uniformity

And to state the obvious (once you've thought about it for a moment): these "more uniform than random" sky locations should *not* be used for random mocks for LSS studies, even for quick-and-dirty checks.  They specifically *aren't* random.

Usage:
```python
from desitarget.mock.sky import random_sky
skyra, skydec = random_sky(nside=2048)
```
There are also options for passing in a subset of the DESI tiles to cover, and a `maxiter` parameter to make sure that the iterative algorithm doesn't go on forever.