### PR TITLE
fixes installs missing GMM mock data

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.15.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Include GMM model data for mocks when installing.
 
 0.15.0 (2017-09-29)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.15.1 (unreleased)
 -------------------
 
-* Include GMM model data for mocks when installing.
+* Include GMM model data for mocks when installing [`PR #222`_].
+
+.. _`PR #222`: https://github.com/desihub/desitarget/pull/222
 
 0.15.0 (2017-09-29)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,9 @@ setup_keywords['test_suite']='{name}.test.{name}_test_suite.{name}_test_suite'.f
 # Add internal data directories
 #
 setup_keywords['package_data'] = {'desitarget': ['data/*',],
-                                  'desitarget.test': ['t/*',]}
+                                  'desitarget.test': ['t/*',],
+                                  'desitarget.mock': ['data/*',],
+                                 }
 #
 # Run setup command.
 #


### PR DESCRIPTION
This PR fixes an installation bug that wasn't copying the mock GMM data into the install location.