### PR TITLE
Mock targets QA and scaling improvements

### DIFF
--- a/bin/mpi_select_mock_targets
+++ b/bin/mpi_select_mock_targets
@@ -4,23 +4,9 @@
 MPI equivalent of select_mock_targets
 """
 
-#- Initialize MPI ASAP, then proceed
+#- Parse args first to enable --help on login nodes where MPI crashes
 from __future__ import absolute_import, division, print_function
-from mpi4py import MPI
-comm = MPI.COMM_WORLD
-rank = comm.Get_rank()
-size = comm.Get_size()
-
-import sys, os
-import numpy as np
 import argparse
-
-from astropy.table import Table
-import desimodel.footprint
-from desiutil.log import get_logger, DEBUG
-from desitarget.mock.build import targets_truth
-import desitarget.mock.io as mockio
-
 import multiprocessing
 nproc = multiprocessing.cpu_count() // 2
 
@@ -31,6 +17,7 @@ parser.add_argument('-s', '--seed', help='Seed for random number generation', ty
 parser.add_argument('-n', '--nproc', type=int, help='number of concurrent processes to use [{}]'.format(nproc), default=nproc)
 parser.add_argument('--nside', help='Divide the DESI footprint into this healpix resolution', type=int, default=64)
 parser.add_argument('--tiles', help='Path to file with tiles to cover', type=str)
+parser.add_argument('--npix', help='Number of healpix per process', type=int, default=1)
 parser.add_argument('--healpixels', help='Integer list of healpix pixels (corresponding to nside) to process.', type=int, nargs='*', default=None)
 parser.add_argument('--realtargets', '-r', help='Path to real target catalog', type=str)
 parser.add_argument('-v','--verbose', action='store_true', help='Enable verbose output.')
@@ -38,6 +25,22 @@ parser.add_argument('--no-check-env', action='store_true', help="Don't check NER
 parser.add_argument('--sort-pixels', action='store_true', help="Sort pixels by galactic latitude")
 
 args = parser.parse_args()
+
+#- Then initialize MPI ASAP before proceeding with other imports
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+import sys, os, time
+import numpy as np
+
+from astropy.table import Table
+import desimodel.footprint
+from desiutil.log import get_logger, DEBUG
+from desitarget.mock.build import targets_truth
+import desitarget.mock.io as mockio
+from desispec.parallel import stdouterr_redirected
 
 if args.verbose:
     log = get_logger(DEBUG)
@@ -84,12 +87,20 @@ if rank == 0:
 
     keep = list()
     for i, pixnum in enumerate(pixels):
-        truthspecfile = mockio.findfile('spectra_truth', args.nside, pixnum, basedir=args.output_dir)
+        truthspecfile = mockio.findfile('truth', args.nside, pixnum,
+                                        basedir=args.output_dir)
         if not os.path.exists(truthspecfile):
             keep.append(i)
 
     log.info('{}/{} pixels remaining to do'.format(len(keep), len(pixels)))
     pixels = pixels[keep]
+
+    #- pre-create output directories
+    for pixnum in pixels:
+        outdir = os.path.dirname(mockio.findfile('blat', args.nside, pixnum,
+                                                 basedir=args.output_dir))
+        if not os.path.isdir(outdir):
+            os.makedirs(outdir, exist_ok=True)  #- belt and suspenders
 
     #- Optionally sort pixels by -|galactic latitude| to do pixels with
     #- lowest star densities first.  When MPI size >> 1 this doesn't work
@@ -130,14 +141,31 @@ iedges = np.linspace(0, len(pixels), size+1, dtype=int)
 rankpix = pixels[iedges[rank]:iedges[rank+1]]
 rankseeds = randseeds[iedges[rank]:iedges[rank+1]]
 log.info('rank {} processes {} pixels {}'.format(rank, iedges[rank+1]-iedges[rank], rankpix))
+sys.stdout.flush()
+comm.barrier()
 
 if len(rankpix) > 0:
     #- Process one pixel at a time to avoid blowing out memory, but structure
     #- it in a way that we could expand to multiple pixels per call if/when
     #- we use less memory.
-    n = 1
+    n = args.npix
     for i in range(0, len(rankpix), n):
-        targets_truth(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
-                    nproc=args.nproc, verbose=args.verbose,
-                    healpixels=rankpix[i:i+n])
- 
+        logfile = mockio.findfile('build', args.nside, rankpix[i], ext='log', basedir=args.output_dir)
+        log.info('Logging pixels {} to {}'.format(rankpix[i:i+n], logfile))
+        t0 = time.time()
+        try:
+            with stdouterr_redirected(to=logfile):
+                targets_truth(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
+                            nproc=args.nproc, verbose=args.verbose,
+                            healpixels=rankpix[i:i+n])
+
+            runtime = (time.time()-t0) / 60
+            log.info('Pixels {} took {:.1f} minutes'.format(rankpix[i:i+n], runtime))
+        except Exception as err:
+            runtime = (time.time()-t0) / 60
+            log.error('Pixels {} failed after {:.1f} minutes'.format(rankpix[i:i+n], runtime))
+            import traceback
+            msg = traceback.format_exc()
+            sys.stdout.flush()
+            sys.stderr.flush()
+

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desitarget Change Log
 0.16.1 (unreleased)
 -------------------
 
-* no changes yet
+* fixes to allow QA to work with mock data
+* cleanup of mpi_select_mock_targets
 
 0.16.0 (2017-11-01)
 -------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -1585,10 +1585,22 @@ def qacolor(cat, objtype, qadir='.', fileprefix="color"):
     plt.xlabel('r - z')
     plt.ylabel('r - W1')
     plt.set_cmap('inferno')
-    plt.hist2d(r-z,r-W1,bins=100,range=[[-1,3],[-1,3]],norm=LogNorm())
-    plt.colorbar()
-    #ADM make the plot
-    pngfile = os.path.join(qadir, '{}-rzW1-{}.png'.format(fileprefix,objtype))
+    counts, xedges, yedges, image = \
+        plt.hist2d(r-z,r-W1,bins=100,range=[[-1,3],[-1,3]],norm=LogNorm())
+    if np.sum(counts) > 0:
+        plt.colorbar()
+    else:
+        log = get_logger()
+        log.error('No data within r-W1 vs. r-z ranges')
+        plt.clf()
+        plt.xlabel('r - z')
+        plt.ylabel('r - W1')
+        plt.xlim([-1,3])
+        plt.ylim([-1,3])
+        plt.text(0, 0, 'No data')
+
+    #ADM save the plot
+    pngfile=os.path.join(qadir, '{}-rzW1-{}.png'.format(fileprefix,objtype))
     plt.savefig(pngfile,bbox_inches='tight')
     plt.close()
 
@@ -1750,7 +1762,10 @@ def make_qa_page(targs, makeplots=True, max_bin_area=1.0, qadir='.', weight=True
 
     #ADM make a DR string based on the RELEASE column
     #ADM potentially there are multiple DRs in a file
-    DRs = ", ".join([ "DR{}".format(release) for release in np.unique(targs["RELEASE"])//1000 ])
+    if 'RELEASE' in targs.dtype.names:
+        DRs = ", ".join([ "DR{}".format(release) for release in np.unique(targs["RELEASE"])//1000 ])
+    else:
+        DRs = "DR Unknown"
 
     #ADM Set up the names of the target classes and their goal densities using
     #ADM the goal target densities for DESI (read from the DESIMODEL defaults)

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -65,7 +65,7 @@ def get_healpix_dir(nside, pixnum, basedir='.'):
     subdir = str(pixnum // 100)
     return os.path.abspath(os.path.join(basedir, subdir, str(pixnum)))
 
-def findfile(filetype, nside, pixnum, basedir='.'):
+def findfile(filetype, nside, pixnum, basedir='.', ext='fits'):
     '''
     Returns standardized filepath
 
@@ -76,10 +76,11 @@ def findfile(filetype, nside, pixnum, basedir='.'):
 
     Optional:
         basedir: (str) base directory
+        ext: (str) file extension
     '''
     path = get_healpix_dir(nside, pixnum, basedir=basedir)
-    filename = '{filetype}-{nside}-{pixnum}.fits'.format(
-        filetype=filetype, nside=nside, pixnum=pixnum)
+    filename = '{filetype}-{nside}-{pixnum}.{ext}'.format(
+        filetype=filetype, nside=nside, pixnum=pixnum, ext=ext)
     return os.path.join(path, filename)
 
 def print_all_mocks_info(params):


### PR DESCRIPTION
This PR has some improvements for working with mock targets:

* updates QA code so that it works on both real data and mock data.  The latter is currently missing RELEASE and W1 fluxes which was crashing the QA code.  This current fix is to let the QA code go on with blank plots, rather than the harder fix of getting those into mock data. 
* updates `mpi_select_mock_targets` for scaling robustness, e.g. logging each rank to a different file instead of N>>1 ranks all blasting the same stderr/stdout.