### PR TITLE
Rebase for Christophe Yeche's updates to the desitarget quasar selection

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -364,7 +364,7 @@ def isQSO_colors(gflux, rflux, zflux, w1flux, w2flux, optical=False):
 
     return qso
 
-def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2, release,
+def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2, release=None,
                objtype=None, primary=None):
     """Cuts based QSO target selection
 
@@ -396,6 +396,10 @@ def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2, rel
 
     qso &= w1snr > 4
     qso &= w2snr > 2
+
+    #ADM default to RELEASE of 5000 if nothing is passed
+    if release is None:
+        release = np.zeros_like(gflux, dtype='?')+5000
 
     qso &= ((deltaChi2>40.) | (release>=5000) )
 
@@ -429,6 +433,10 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
     #----- Quasars
     if primary is None:
         primary = np.ones_like(gflux, dtype='?')
+
+    #ADM default to RELEASE of 5000 if nothing is passed
+    if release is None:
+        release = np.zeros_like(gflux, dtype='?')+5000
 
     # build variables for random forest
     nfeatures=11 # number of variables in random forest

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -364,7 +364,7 @@ def isQSO_colors(gflux, rflux, zflux, w1flux, w2flux, optical=False):
 
     return qso
 
-def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2,
+def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2, release,
                objtype=None, primary=None):
     """Cuts based QSO target selection
 
@@ -397,7 +397,7 @@ def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2,
     qso &= w1snr > 4
     qso &= w2snr > 2
 
-    qso &= deltaChi2>40.
+    qso &= ((deltaChi2>40.) | (release>=5000) )
 
     if primary is not None:
         qso &= primary
@@ -407,7 +407,7 @@ def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2,
 
     return qso
 
-def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, objtype=None,
+def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, objtype=None, release=None,
          deltaChi2=None, primary=None):
     """Target Definition of QSO using a random forest returning a boolean array.
 
@@ -465,6 +465,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
 
     #define pcut, relaxed cut for faint objects
     pcut = np.where(r>20.0,0.95 - (r-20.0)*0.08,0.95)
+    pcut_DR5 = np.where(r>20.0,0.92 - (r-20.0)*0.10,0.92)
 
     qso = primary.copy()
     qso &= r<rMax
@@ -473,13 +474,13 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
     if objtype is not None:
         qso &= _psflike(objtype)
 
-    if deltaChi2 is not None:
-        qso &= deltaChi2>30.
+    if (deltaChi2 is not None) :
+        qso &= ((deltaChi2>30.) | (release>=5000) ) 
 
     if nbEntries==1 : # for call of a single object
         qso &= prob[0]>pcut
     else :
-        qso &= prob>pcut
+        qso &= (((prob>pcut)&(release<5000)) | ((prob>pcut_DR5)&(release>=5000)))
 
     return qso
 
@@ -545,7 +546,8 @@ def _is_row(table):
     else:
         return False
 
-def unextinct_fluxes(objects):
+def unextinct_fluxes(objects
+                     ):
     """
     Calculate unextincted DECam and WISE fluxes
 
@@ -627,6 +629,7 @@ def apply_cuts(objects, qso_selection='randomforest'):
     w1flux = flux['W1FLUX']
     w2flux = flux['W2FLUX']
     objtype = objects['TYPE']
+    release = objects['RELEASE']
 
     gfluxivar = objects['FLUX_IVAR_G']
 
@@ -670,10 +673,10 @@ def apply_cuts(objects, qso_selection='randomforest'):
     if qso_selection=='colorcuts' :
         qso = isQSO_cuts(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                          w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2, objtype=objtype,
-                         w1snr=w1snr, w2snr=w2snr)
+                         w1snr=w1snr, w2snr=w2snr, release=release)
     elif qso_selection == 'randomforest':
         qso = isQSO_randomforest(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
-                                 w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2, objtype=objtype)
+                                 w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2, objtype=objtype, release=release)
     else:
         raise ValueError('Unknown qso_selection {}; valid options are {}'.format(qso_selection,
                                                                                  qso_selection_options))

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -465,7 +465,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
 
     #define pcut, relaxed cut for faint objects
     pcut = np.where(r>20.0,0.95 - (r-20.0)*0.08,0.95)
-    pcut_DR5 = np.where(r>20.0,0.92 - (r-20.0)*0.10,0.92)
+    pcut_DR5 = np.where(r>20.0,0.92 - (r-20.0)*0.08,0.92)
 
     qso = primary.copy()
     qso &= r<rMax

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -558,10 +558,8 @@ def _is_row(table):
     else:
         return False
 
-def unextinct_fluxes(objects
-                     ):
-    """
-    Calculate unextincted DECam and WISE fluxes
+def unextinct_fluxes(objects):
+    """Calculate unextincted DECam and WISE fluxes
 
     Args:
         objects: array or Table with columns FLUX_G, FLUX_R, FLUX_Z, 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -364,19 +364,21 @@ def isQSO_colors(gflux, rflux, zflux, w1flux, w2flux, optical=False):
 
     return qso
 
-def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2, release=None,
-               objtype=None, primary=None):
+def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2, 
+               release=None, objtype=None, primary=None):
     """Cuts based QSO target selection
 
     Args:
         gflux, rflux, zflux, w1flux, w2flux: array_like
             The flux in nano-maggies of g, r, z, W1, and W2 bands.
-        deltaChi2: array_like
-            chi2 difference between PSF and SIMP models,  dchisq_PSF - dchisq_SIMP
         w1snr: array_like[ntargets]
             S/N in the W1 band.
         w2snr: array_like[ntargets]
             S/N in the W2 band.
+        deltaChi2: array_like[ntargets]
+            chi2 difference between PSF and SIMP models,  dchisq_PSF - dchisq_SIMP
+        release: array_like[ntargets]
+            The Legacy Survey imaging RELEASE (e.g. http://legacysurvey.org/release/)
         objtype (optional): array_like or None
             If given, the TYPE column of the Tractor catalogue.
         primary (optional): array_like or None
@@ -411,8 +413,8 @@ def isQSO_cuts(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2, rel
 
     return qso
 
-def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, objtype=None, release=None,
-         deltaChi2=None, primary=None):
+def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+                       objtype=None, release=None, deltaChi2=None, primary=None):
     """Target Definition of QSO using a random forest returning a boolean array.
 
     Args:
@@ -420,8 +422,10 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
             The flux in nano-maggies of g, r, z, W1, and W2 bands.
         objtype: array_like or None
             If given, the TYPE column of the Tractor catalogue.
+        release: array_like[ntargets]
+            The Legacy Survey imaging RELEASE (e.g. http://legacysurvey.org/release/)
         deltaChi2: array_like or None
-             If given, difference of chi2 bteween PSF and SIMP morphology
+             If given, difference in chi2 bteween PSF and SIMP morphology
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -103,11 +103,16 @@ class TestCuts(unittest.TestCase):
         bgs2 = cuts.isBGS_faint(rflux=rflux, objtype=psftype, primary=None)
         self.assertTrue(np.all(bgs1==bgs2))
 
+        #ADM need to include RELEASE for quasar cuts, at least
+        release = targets['RELEASE']
         #- Test that objtype and primary are optional
         qso1 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
-                          deltaChi2=deltaChi2, w1snr=w1snr, w2snr=w2snr, objtype=psftype, primary=primary)
+                          deltaChi2=deltaChi2, w1snr=w1snr, w2snr=w2snr, objtype=psftype, primary=primary,
+                          release=release)
         qso2 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
-                          deltaChi2=deltaChi2, w1snr=w1snr, w2snr=w2snr, objtype=None, primary=None)
+                          deltaChi2=deltaChi2, w1snr=w1snr, w2snr=w2snr, objtype=None, primary=None,
+                          release=release)
+        
         self.assertTrue(np.all(qso1==qso2))
 
         fstd1 = cuts.isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)


### PR DESCRIPTION
This PR rebases @Cyeche's PR:

https://github.com/desihub/desitarget/pull/218

With the rebase, unit tests pass more easily because master contains new test files that include the `RELEASE` column. Passing that column to `isQSO_cuts` was sufficient to pass the unit tests.

This PR therefore:

- updates `cuts.py` to allow different star-galaxy separation for different `RELEASE` numbers

We'll likely need a better refactor to add this capability for *all* target classes (as noted in https://github.com/desihub/desitarget/issues/231)