### PR TITLE
Pixel downsampling for "pure" and "contaminated" mock targets

### DIFF
--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -1461,12 +1461,12 @@ def downsample_pixel(density, zcut, target_name, targets, truth, nside, healpix_
     keep = r <= 1.0
     
     if contam:
-        good_targets = truth['CONTAM_TARGET']!=0
+        good_targets = (truth['CONTAM_TARGET'] & contam_mask.mask(target_name+'_CONTAM')) !=0
     else:
         good_targets = (truth['TEMPLATETYPE']==target_name) & (truth['CONTAM_TARGET']==0)
         
     if contam:
-        log.info('Downsampling the contaminants'.format(target_name))
+        log.info('Downsampling {} contaminants'.format(target_name))
     else:
         log.info('Downsampling pure {} targets'.format(target_name))
         
@@ -1738,15 +1738,20 @@ def targets_truth_no_spectra(params, seed=1, output_dir="./", nproc=1, nside=16,
         if len(alltargets):
             targets = vstack(alltargets)
             truth = vstack(alltruth)
+            
+            # downsample contaminants for each class
+            for source_name in sorted(params['sources'].keys()):
+                if 'contam' in params['sources'][source_name].keys():
+                    # Initialize variables for density subsampling
+                    zcut=[-1000,1000]
+                    density = [params['sources'][source_name]['contam']['density']]
+                    targets, truth = downsample_pixel(density, zcut, source_name, targets, truth,
+                                                  nside, healpix, seed, rand, log, output_dir, contam=True)
         else:
             targets = []
             truth = []
-            
-     # Downsample the number density of contaminants if required
-                #if 'contam' in params['sources'][source_name].keys():
-                #    density = [params['sources'][source_name]['contam']['density']]
-                #    targets, truth = downsample_pixel(density, zcut, source_name, targets, truth,
-                #                                    nside, healpix, seed, rand, log, output_dir, contam=True)
+        
+ 
                     
         if len(allskytargets):
             skytargets = vstack(allskytargets)

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -1362,7 +1362,7 @@ def target_selection(Selection, target_name, targets, truth, nside, healpix_id, 
     selection_function = '{}_select'.format(target_name.lower())
     select_targets_function = getattr(Selection, selection_function)
 
-    select_targets_function(targets, truth)
+    select_targets_function(targets, truth, boss_std=1)
     keep = np.where(targets['DESI_TARGET'] != 0)[0]
 
     targets = targets[keep]

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -1099,13 +1099,14 @@ def read_galaxia(mock_dir_name, target_name='STAR', rand=None, bricksize=0.25,
         else:
             log.warning('Missing file {}'.format(ff))
 
-    file_list = list( np.concatenate(file_list) )
     nfiles = len(file_list)
 
     if nfiles == 0:
         log.warning('No files found in {}!'.format(mock_dir_name))
         return dict()
-
+    
+    file_list = list( np.concatenate(file_list) )
+    
     # Multiprocess the I/O
     mpargs = list()
     for ff in file_list:


### PR DESCRIPTION
This implements the option of having target downsampling separately for the "pure" and the "contaminated" mock targets. This uses the information in the `contammask` mask, looking for `*_CONTAM` the bits in the `truth` file to separate "pure" from "contaminated".  
The input `yaml` file for `select_mock_targets` now accepts the following
```    
LRG: {
        target_name: LRG,
        mock_dir_name: /project/projectdirs/desi/mocks/GaussianRandomField/v0.0.5/LRG.fits,
        format: gaussianfield,
        density: 350,
        contam: {
           density: 0,
        }
    }
```
Meaning that the number density will be set to be `350` for "pure" ELGs and that it will be `0` for the "contaminated" ELGs. (i.e. this will discard all the contaminants).