### PR TITLE
Lya3d

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.16.3 (unreleased)
 -------------------
 
-* no changes yet
+* Support LyA skewers v2.x format [`PR #244`_].
+
+.. _`PR #244`: https://github.com/desihub/desitarget/pull/244
 
 0.16.2 (2017-11-16)
 -------------------

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -614,7 +614,14 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
     # Combine the QSO and Lyman-alpha samples.
     if target_name == 'QSO' and lya:
         log.info('  Adding Lya QSOs.')
-
+        
+        new_format = ("nside" in lya)
+        
+        if new_format :
+            log.info('  Using new format with 2D images in healpix files')
+        else :
+            log.info('  Using old format with 1 HDU per skewer')
+        
         mockfile_lya = lya['mock_dir_name']
         try:
             os.stat(mockfile_lya)
@@ -622,19 +629,41 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
             log.fatal('Mock file {} not found!'.format(mockfile_lya))
             raise IOError
 
-        lyainfo = fitsio.read(mockfile_lya, upper=True, ext=2)
-        radec = fitsio.read(mockfile_lya, columns=['RA', 'DEC', 'MOCKFILEID'], upper=True, ext=1)
-        nobj_lya = len(radec)
-
-        alllyafiles = lyainfo['MOCKFILE'][radec['MOCKFILEID']]
-
-        files.append(alllyafiles)
-        n_per_file.append(nobj_lya)
-
-        objid_lya = np.arange(nobj_lya, dtype='i8')
-        mockid_lya = make_mockid(objid_lya, [n_per_file[1]])
-
-        allpix = radec2pix(nside, radec['RA'], radec['DEC'])
+        
+        if new_format :
+            tmp         = fitsio.read(mockfile_lya, columns=['RA', 'DEC', 'MOCKID' ,'Z','PIXNUM'], upper=True, ext=1)
+            ra_lya      = tmp['RA'].astype('f8') % 360.0 # enforce 0 < ra < 360
+            dec_lya     = tmp['DEC'].astype('f8')            
+            zz_lya      = tmp['Z'].astype('f4')
+            objid_lya   = (tmp['MOCKID'].astype(float)).astype(int) # will change
+            mockpix_lya = tmp['PIXNUM']
+            mockid_lya  = objid_lya.copy() # the logic to read the spectra is in spectra.py, not here            
+            log.warning("FIXED gmag=22 for now, that's where we should use a QSO luminosity function")
+            mag_lya     = 22.*np.ones(zz_lya.size).astype('f4') # g-band
+            del tmp
+        else :
+            
+            tmp = fitsio.read(mockfile_lya, columns=['RA', 'DEC', 'MOCKFILEID', 'MOCKHDUNUM', 'MAG_G', 'Z'], upper=True, ext=1)
+            nobj_lya  = len(tmp)
+            
+            objid_lya = np.arange(nobj_lya, dtype='i8')
+            n_per_file.append(nobj_lya)
+            mockid_lya = make_mockid(objid_lya, [n_per_file[1]])
+            zz_lya      = tmp['Z'].astype('f4')
+            ra_lya      = tmp['RA'].astype('f8') % 360.0 # enforce 0 < ra < 360
+            dec_lya     = tmp['DEC'].astype('f8')
+            
+            mag_lya     = tmp['MAG_G'].astype('f4')
+            mockfileid_lya = tmp['MOCKFILEID']
+            hdu_lya        = tmp['MOCKHDUNUM']
+            del tmp
+            
+            lyainfo   = fitsio.read(mockfile_lya, upper=True, ext=2)
+            files_lya = lyainfo['MOCKFILE'][mockfileid_lya]            
+            
+        
+        # apply sky cut
+        allpix = radec2pix(nside, ra_lya, dec_lya)
         cut = np.where( np.in1d(allpix, healpixels)*1 )[0]
 
         nobj_lya = len(cut)
@@ -645,20 +674,30 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
             templatetype = templatetype_qso
             templatesubtype = templatesubtype_qso
         else:
-            log.info('Trimmed to {} Lya QSOs in healpixels {}'.format(nobj_lya, healpixels))
-
-            objid_lya = objid_lya[cut]
+            log.info('Trimmed to {} Lya QSO skewers in healpixels {}'.format(nobj_lya, healpixels))            
+            objid_lya  = objid_lya[cut]
             mockid_lya = mockid_lya[cut]
-            ra_lya = radec['RA'][cut].astype('f8') % 360.0 # enforce 0 < ra < 360
-            dec_lya = radec['DEC'][cut].astype('f8')
-            del radec
-
-            data = fitsio.read(mockfile_lya, columns=['Z', 'MAG_G', 'MOCKFILEID', 'MOCKHDUNUM'],
-                               upper=True, ext=1, rows=cut)
+            ra_lya     = ra_lya[cut]
+            dec_lya    = dec_lya[cut]
+            zz_lya     = zz_lya[cut]
+            mag_lya    = mag_lya[cut] 
             
-            zz_lya = data['Z'].astype('f4')
-            mag_lya = data['MAG_G'].astype('f4') # g-band
-
+            # adding file path
+            if new_format :
+                mockpix_lya = mockpix_lya[cut]
+                mockdir   = os.path.dirname(mockfile_lya)
+                mocknside = lya["nside"]
+                lyafiles = []
+                for mpix in mockpix_lya :
+                    lyafiles.append("%s/%d/%d/transmission-%d-%d.fits"%(mockdir,mpix/100,mpix,mocknside,mpix))
+                lyafiles = np.hstack((lyafiles_qso,lyafiles))
+                
+            else :
+                mockdir   = os.path.dirname(mockfile_lya)
+                lyafiles = np.hstack( (lyafiles_qso, np.array([os.path.join(
+                    mockdir, ff.decode('utf-8')) for ff in files_lya[cut]])) )
+                lyahdu = np.hstack( (lyahdu_qso, hdu_lya[cut]) )
+                        
             # Join the QSO + Lya samples
             ra = np.hstack((ra, ra_lya))
             dec = np.hstack((dec, dec_lya))
@@ -667,11 +706,7 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
             objid = np.hstack((objid, objid_lya))
             mockid = np.hstack((mockid, mockid_lya))
             nobj = len(ra)
-
-            lyafiles = np.hstack( (lyafiles_qso, np.array([os.path.join(
-                os.path.dirname(mockfile_lya), ff.decode('utf-8')) for ff in alllyafiles[cut]])) )
-            lyahdu = np.hstack( (lyahdu_qso, data['MOCKHDUNUM']) )
-
+            
             templatetype = np.hstack( (templatetype_qso, np.repeat('QSO', nobj_lya)) )
             templatesubtype = np.hstack( (np.repeat('', nobj_qso), np.repeat('LYA', nobj_lya)) )
             
@@ -757,11 +792,17 @@ def read_gaussianfield(mock_dir_name, target_name, rand=None, bricksize=0.25,
             if len(replace) > 0:
                 mag[replace] = mags['g'][replace] # g-band
 
-            out.update({
-                'TRUESPECTYPE': 'QSO', 'TEMPLATETYPE': templatetype, 'TEMPLATESUBTYPE': templatesubtype, 
-                #'TRUESPECTYPE': truespectype, 'TEMPLATETYPE': templatetype, 'TEMPLATESUBTYPE': templatesubtype,
-                'LYAFILES': lyafiles, 'LYAHDU': lyahdu, 
-                'MAG': mag, 'FILTERNAME': 'decam2014-g'}) # Lya is normalized in the g-band
+            if new_format :
+                out.update({
+                    'TRUESPECTYPE': 'QSO', 'TEMPLATETYPE': templatetype, 'TEMPLATESUBTYPE': templatesubtype, 
+                    'LYAFILES': lyafiles,
+                    'MAG': mag, 'FILTERNAME': 'decam2014-g'}) # Lya is normalized in the g-band
+            else :
+                out.update({
+                    'TRUESPECTYPE': 'QSO', 'TEMPLATETYPE': templatetype, 'TEMPLATESUBTYPE': templatesubtype, 
+                    #'TRUESPECTYPE': truespectype, 'TEMPLATETYPE': templatetype, 'TEMPLATESUBTYPE': templatesubtype,
+                    'LYAFILES': lyafiles, 'LYAHDU': lyahdu, 
+                    'MAG': mag, 'FILTERNAME': 'decam2014-g'}) # Lya is normalized in the g-band
 
         else:
             log.fatal('Unrecognized target type {}!'.format(target_name))

--- a/py/desitarget/mock/spectra.py
+++ b/py/desitarget/mock/spectra.py
@@ -646,7 +646,7 @@ class MockSpectra(object):
                         else :
                             # check wavelength is the same for all skewers
                             assert(np.max(np.abs(wave-tmp_wave))<0.001*dw)
-                        print(these.size,skewer_trans.shape,tmp_trans.shape)
+                        
                         skewer_trans[these] = tmp_trans
                         for k in skewer_meta.keys() :
                             skewer_meta[k][these]=tmp_meta[k]

--- a/py/desitarget/mock/spectra.py
+++ b/py/desitarget/mock/spectra.py
@@ -14,6 +14,7 @@ import numpy as np
 import multiprocessing
 
 from desisim.io import read_basis_templates, empty_metatable
+from desiutil.log import get_logger
 
 def _get_colors_onez(args):
     """Filler function to synthesize photometry at a given redshift"""
@@ -556,7 +557,11 @@ class MockSpectra(object):
 
         """
         from desisim.lya_spectra import get_spectra
-        
+        from desisim.lya_spectra import read_lya_skewers,apply_lyman_alpha_transmission
+        import fitsio
+
+        log = get_logger()
+
         objtype = 'QSO'
         if index is None:
             index = np.arange(len(data['Z']))
@@ -584,41 +589,98 @@ class MockSpectra(object):
                 flux[tracer, :] = flux1
 
             if len(lya) > 0:
-                alllyafile = data['LYAFILES'][index][lya]
-                alllyahdu = data['LYAHDU'][index][lya]
+
                 
-                for lyafile in sorted(set(alllyafile)):
-                    these = np.where( lyafile == alllyafile )[0]
+                ilya=index[lya].astype(int)
+                nqso=ilya.size
+                log.info("Generating spectra of %d lya QSOs"%nqso)
+                                
+                if 'LYAHDU' in data : 
+                    # this is the old format with one HDU per spectrum
+                    alllyafile = data['LYAFILES'][ilya]
+                    alllyahdu = data['LYAHDU'][ilya]
 
-                    templateid = alllyahdu[these] - 1 # templateid is 0-indexed
-                    flux1, _, meta1 = get_spectra(lyafile, templateid=templateid, normfilter=data['FILTERNAME'],
-                                                  rand=self.rand, qso=self.lya_templates, nocolorcuts=True)
-                    meta1['SUBTYPE'] = 'LYA'
-                    meta[lya[these]] = meta1
-                    flux[lya[these], :] = flux1
+                    for lyafile in sorted(set(alllyafile)):
+                        these = np.where( lyafile == alllyafile )[0]
 
-        elif mockformat.lower() == 'lya':
-            # Build spectra for Lyman-alpha QSOs. Deprecated!
-            from desisim.lya_spectra import get_spectra
-            from desitarget.mock.io import decode_rownum_filenum
-
-            meta = empty_metatable(nmodel=nobj, objtype=objtype)
-            flux = np.zeros([nobj, len(self.wave)], dtype='f4')
-            
-            rowindx, fileindx = decode_rownum_filenum(data['MOCKID'][index])
-            for indx1 in set(fileindx):
-                lyafile = data['FILES'][indx1]
-                these = np.where(indx1 == fileindx)[0]
-                templateid = rowindx[these].astype('int')
-            
-                flux1, _, meta1 = get_spectra(lyafile, templateid=templateid,
-                                              normfilter=data['FILTERNAME'],
-                                              rand=self.rand, qso=self.lya_templates)
-                meta[these] = meta1
-                flux[these, :] = flux1
+                        templateid = alllyahdu[these] - 1 # templateid is 0-indexed
+                        flux1, _, meta1 = get_spectra(lyafile, templateid=templateid, normfilter=data['FILTERNAME'],
+                                                      rand=self.rand, qso=self.lya_templates, nocolorcuts=True)
+                        meta1['SUBTYPE'] = 'LYA'
+                        meta[lya[these]] = meta1
+                        flux[lya[these], :] = flux1
+                else : # new format
+                                                            
+                    # read skewers
+                    skewer_wave=None
+                    skewer_trans=None
+                    skewer_meta=None
+                    
+                    # all the files that contain at least one QSO skewer
+                    alllyafile = data['LYAFILES'][ilya]
+                    uniquelyafiles = sorted(set(alllyafile))
+                                        
+                    for lyafile in uniquelyafiles :
+                        these = np.where( alllyafile == lyafile )[0]
+                        objid_in_data=data['OBJID'][ilya][these]
+                        objid_in_mock=(fitsio.read(lyafile, columns=['MOCKID'],upper=True,ext=1).astype(float)).astype(int)
+                        o2i=dict()
+                        for i,o in enumerate(objid_in_mock) :
+                            o2i[o]=i
+                        indices_in_mock_healpix=np.zeros(objid_in_data.size).astype(int)
+                        for i,o in enumerate(objid_in_data) :
+                            if not o in o2i :
+                                log.error("No MOCKID={} in {}. It's a bug, should never happen".format(o,lyafile))
+                                raise(KeyError("No MOCKID={} in {}. It's a bug, should never happen".format(o,lyafile)))
+                            indices_in_mock_healpix[i]=o2i[o]
+                        
+                        tmp_wave,tmp_trans,tmp_meta = read_lya_skewers(lyafile,indices=indices_in_mock_healpix) 
+                                                
+                        if skewer_wave is None :
+                            skewer_wave=tmp_wave
+                            dw=skewer_wave[1]-skewer_wave[0] # this is just to check same wavelength
+                            skewer_trans=np.zeros((nqso,skewer_wave.size)) # allocate skewer_array
+                            skewer_meta=dict()
+                            for k in tmp_meta.dtype.names :
+                                skewer_meta[k]=np.zeros(nqso).astype(tmp_meta[k].dtype)
+                        else :
+                            # check wavelength is the same for all skewers
+                            assert(np.max(np.abs(wave-tmp_wave))<0.001*dw)
+                        print(these.size,skewer_trans.shape,tmp_trans.shape)
+                        skewer_trans[these] = tmp_trans
+                        for k in skewer_meta.keys() :
+                            skewer_meta[k][these]=tmp_meta[k]
+                    
+                    # check we matched things correctly
+                    assert(np.max(np.abs(skewer_meta["Z"]-data['Z'][ilya]))<0.000001)
+                    assert(np.max(np.abs(skewer_meta["RA"]-data['RA'][ilya]))<0.000001)
+                    assert(np.max(np.abs(skewer_meta["DEC"]-data['DEC'][ilya]))<0.000001)
+                    
+                    
+                    # now we create a series of QSO spectra all at once
+                    # this is faster than calling each one at a time
+                    # we use the provided QSO template class
+                    
+                    seed = self.rand.randint(2**32)
+                    qso  = self.lya_templates
+                    qso_flux, qso_wave, qso_meta = qso.make_templates(nmodel=nqso,
+                                                                      redshift=data['Z'][ilya],
+                                                                      mag=data['MAG'][ilya],
+                                                                      seed=seed,
+                                                                      lyaforest=False,
+                                                                      nocolorcuts=True)
+                    
+                    # apply transmission to QSOs
+                    qso_flux = apply_lyman_alpha_transmission(qso_wave,qso_flux,skewer_wave,skewer_trans)
+                    
+                    # save this
+                    qso_meta['SUBTYPE'] = 'LYA'
+                    meta[lya] = qso_meta
+                    flux[lya, :] = qso_flux
+                    
         else:
             raise ValueError('Unrecognized mockformat {}!'.format(mockformat))
-
+            
         return flux, meta
 
     def sky(self, data, index=None, mockformat=None):
@@ -759,7 +821,7 @@ class MockMagnitudes(object):
         """Generate magnitudes for the QSO or QSO/LYA samples.
         """
         from desisim.lya_spectra import get_spectra
-        
+                
         objtype = 'QSO'
         if index is None:
             index = np.arange(len(data['Z']))

--- a/py/desitarget/mock/spectra.py
+++ b/py/desitarget/mock/spectra.py
@@ -557,7 +557,7 @@ class MockSpectra(object):
 
         """
         from desisim.lya_spectra import get_spectra
-        from desisim.lya_spectra import read_lya_skewers,apply_lyman_alpha_transmission
+        from desisim.lya_spectra import read_lya_skewers,apply_lya_transmission
         import fitsio
 
         log = get_logger()
@@ -671,7 +671,7 @@ class MockSpectra(object):
                                                                       nocolorcuts=True)
                     
                     # apply transmission to QSOs
-                    qso_flux = apply_lyman_alpha_transmission(qso_wave,qso_flux,skewer_wave,skewer_trans)
+                    qso_flux = apply_lya_transmission(qso_wave,qso_flux,skewer_wave,skewer_trans)
                     
                     # save this
                     qso_meta['SUBTYPE'] = 'LYA'


### PR DESCRIPTION
Implementation of simulations for new Lya mock format (old format still supported)
See the format in https://desi.lbl.gov/trac/wiki/LymanAlphaWG/LyaSpecSim

Modified files mocks.io.py and mocks.spectra.py 

Example section of ```select-mock-targets.yaml``` 
```
    QSO: {
        target_name: QSO,
        mock_dir_name: /global/cscratch1/sd/ioannis/desi/mocks/GaussianRandomField/v0.0.5/QSO.fits,
        format: gaussianfield,
        density: 120,
        contam: {
            GALAXY: 27,
            STAR: 63,
        },
        LYA: {
            mock_dir_name: /project/projectdirs/desi/mocks/lya_forest/v2.0.2/master.fits,
            density: 50,
            zcut: 2.0,
            nside: 16
        }
    }
```
nside is the healpix nside parameter for the mocks.


the idea is that the mock simulation (in desitarget.mock.spectra) calls sequentially

    read_lya_skewers
    QSO.make_template (or any new version of this class)
    apply_lyman_alpha_transmission

An example successful run is in 
```/project/projectdirs/desi/lya/mocks-sim/v2.0.2-mini```
where the mini end-to-end simulation has been rerun using the new mocks.

This PR has to be merged after desisim lya3d PR.
