### PR TITLE
mock HPXNSIDE as keyword, not DEPNAM/DEPVER

### DIFF
--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -862,8 +862,8 @@ def targets_truth(params, output_dir='.', realtargets=None, seed=None, verbose=F
     targetshdr = fitsheader(dict(
         SEED = (seed1, 'initial random seed')
         ))
-    depend.setdep(targetshdr, 'HPXNSIDE', nside)
-    depend.setdep(targetshdr, 'HPXNEST', True)
+    targetshdr['HPXNSIDE'] = (nside, 'HEALPix nside')
+    targetshdr['HPXNEST'] = (True, 'HEALPix nested (not ring) ordering')
 
     targets['HPXPIXEL'][:] = targpix
 
@@ -1587,10 +1587,9 @@ def write_to_disk(targets, truth, skytargets, skytruth, nside, healpix_id, seed,
     targetshdr = fitsheader(dict(
         SEED = (seed1, 'initial random seed')
         ))
-    depend.setdep(targetshdr, 'HPXNSIDE', nside)
-    depend.setdep(targetshdr, 'HPXNEST', True)
+    targetshdr['HPXNSIDE'] = (nside, 'HEALPix nside')
+    targetshdr['HPXNEST'] = (True, 'HEALPix nested (not ring) ordering')
 
-        
     outdir = mockio.get_healpix_dir(nside, healpix_id, basedir=output_dir)
     os.makedirs(outdir, exist_ok=True)
 


### PR DESCRIPTION
This PR updates the mock targets output to match the real data target files where
HPXNSIDE and HPXNEST are header keywords instead of DEPNAMnn/DEPVALnn dependency keyword pairs.

This is simple enough that I plan to self merge once Travis tests pass.

I have not tried to address the underlying issue that we shouldn't have 3 different places in the code that set these keywords (this PR fixes 2 of them to make them consistent with the 3rd). @moustakas is working on a deeper cleanup of the mock making to reduce redundant code and this might get fixed as a byproduct of that cleanup.

