### PR TITLE
open BGS mock read-only; fixes parallel crash

### DIFF
--- a/bin/mpi_select_mock_targets
+++ b/bin/mpi_select_mock_targets
@@ -155,6 +155,13 @@ if len(rankpix) > 0:
         t0 = time.time()
         try:
             with stdouterr_redirected(to=logfile):
+                log.info('Calling targets_truth() with the following options')
+                log.info('  output_dir {}'.format(args.output_dir))
+                log.info('  seed       {}'.format(rankseeds[i]))
+                log.info('  nside      {}'.format(args.nside))
+                log.info('  nproc      {}'.format(args.nproc))
+                log.info('  verbose    {}'.format(args.verbose))
+                log.info('  healpixels {}'.format(rankpix[i:i+n]))
                 targets_truth(params, args.output_dir, seed=rankseeds[i], nside=args.nside,
                             nproc=args.nproc, verbose=args.verbose,
                             healpixels=rankpix[i:i+n])
@@ -166,6 +173,7 @@ if len(rankpix) > 0:
             log.error('Pixels {} failed after {:.1f} minutes'.format(rankpix[i:i+n], runtime))
             import traceback
             msg = traceback.format_exc()
+            log.error(msg)
             sys.stdout.flush()
             sys.stderr.flush()
 

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -884,7 +884,7 @@ def read_durham_mxxl_hdf5(mock_dir_name, target_name='BGS', rand=None, bricksize
 
     # Read the ra,dec coordinates, generate mockid, and then restrict to the
     # desired healpixels.
-    f = h5py.File(mockfile)
+    f = h5py.File(mockfile, mode='r')
     ra  = f['Data/ra'][...].astype('f8') % 360.0 # enforce 0 < ra < 360
     dec = f['Data/dec'][...].astype('f8')
     nobj = len(ra)


### PR DESCRIPTION
This PR fixes a bug discovered while testing a candidate for the desi software 18.2 release.  Previously the BGS mock file in hdf5 format was being opened in read-write mode instead of read-only mode.  Starting with h5py 2.7.1 this attempts to create a writelock and parallel processes from `mpi_select_mock_targets` were colliding with each other and crashing.  This PR updates the BGS mock reader to open the file read-only, which fixes the problem.  It also augments the logging to make it easier to debug any other crashes in the future.

This may create a merge conflict with open PR #264; sorry @moustakas.  You'll want to make sure to make the same `h5py.File(filename, mode='r')` change there too.

I intend to merge as soon as Travis tests pass so that we can move on with testing 18.2.