### PR TITLE
don't crash on warnings

### DIFF
--- a/bin/run_target_qa
+++ b/bin/run_target_qa
@@ -11,9 +11,6 @@ from desitarget.QA import make_qa_page
 from desiutil.log import get_logger
 log = get_logger()
 
-import warnings
-warnings.simplefilter('error')
-
 from argparse import ArgumentParser
 ap = ArgumentParser()
 ap.add_argument("src", help="Input target file (e.g. /project/projectdirs/desi/target/catalogs/targets-dr3.1-dr4.0-all-0.14.0.fits)")

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ desitarget Change Log
 
 * Remove extraneous imports from __init__.py, fix read the docs build
   [`PR #282`_].
+
 .. _`PR #282`: https://github.com/desihub/desitarget/pull/282
 
 0.18.1 (2018-02-23)


### PR DESCRIPTION
Previously `run_target_qa` had turned on warnings as errors (probably leftover from debugging where some warning was coming from), which was causing a crash when used with desiconda 20180130-1.2.4-spec due to a warning related to scipy being compiled with an older version of numpy than the one installed.  This PR removes these two lines to just let warnings be warnings and not crash:
```python
import warnings
warnings.simplefilter('error')
```

The underlying issues about the warning are described at https://stackoverflow.com/questions/40845304/runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility, which claims they are harmless.  When not crashing on that warning, it is being filtered out by some other code and it doesn't appear at all.

This is simple enough that I plan to self-merge after travis tests pass unless someone jumps in with a complaint.

For the searchable record, this was originally reported to the desi-data mailing list on 2018-02-26, with the following traceback (now fixed):
```
Traceback (most recent call last):
  File "/global/common/software/desi/cori/desiconda/current/code/desitarget/0.18.1/bin/run_target_qa", line 4, in <module>
    __import__('pkg_resources').run_script('desitarget==0.18.1', 'run_target_qa')
  File "/global/common/software/desi/cori/desiconda/20180130-1.2.4-spec/conda/lib/python3.6/site-packages/pkg_resources/__init__.py", line 748, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/global/common/software/desi/cori/desiconda/20180130-1.2.4-spec/conda/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1517, in run_script
    exec(code, namespace, namespace)
  File "/global/common/software/desi/cori/desiconda/20180130-1.2.4-spec/code/desitarget/0.18.1/lib/python3.6/site-packages/desitarget-0.18.1-py3.6.egg/EGG-INFO/scripts/run_target_qa", line 35, in <module>
    make_qa_page(ns.src,qadir=ns.dest,mocks=ns.mocks,makeplots=makeplots,max_bin_area=max_bin_area)
  File "/global/common/software/desi/cori/desiconda/current/code/desitarget/0.18.1/lib/python3.6/site-packages/desitarget-0.18.1-py3.6.egg/desitarget/QA.py", line 2397, in make_qa_page
    from desispec.io.util import makepath
  File "/global/common/software/desi/cori/desiconda/current/code/desispec/0.18.0/lib/python3.6/site-packages/desispec-0.18.0-py3.6.egg/desispec/io/__init__.py", line 13, in <module>
    from .fiberflat import read_fiberflat, write_fiberflat
  File "/global/common/software/desi/cori/desiconda/current/code/desispec/0.18.0/lib/python3.6/site-packages/desispec-0.18.0-py3.6.egg/desispec/io/fiberflat.py", line 16, in <module>
    from ..fiberflat import FiberFlat
  File "/global/common/software/desi/cori/desiconda/current/code/desispec/0.18.0/lib/python3.6/site-packages/desispec-0.18.0-py3.6.egg/desispec/fiberflat.py", line 12, in <module>
    from desispec.linalg import cholesky_solve
  File "/global/common/software/desi/cori/desiconda/current/code/desispec/0.18.0/lib/python3.6/site-packages/desispec-0.18.0-py3.6.egg/desispec/linalg.py", line 8, in <module>
    import scipy,scipy.linalg,scipy.interpolate
  File "/global/common/software/desi/cori/desiconda/20180130-1.2.4-spec/conda/lib/python3.6/site-packages/scipy/interpolate/__init__.py", line 175, in <module>
    from .interpolate import *
  File "/global/common/software/desi/cori/desiconda/20180130-1.2.4-spec/conda/lib/python3.6/site-packages/scipy/interpolate/interpolate.py", line 26, in <module>
    from . import fitpack
  File "/global/common/software/desi/cori/desiconda/20180130-1.2.4-spec/conda/lib/python3.6/site-packages/scipy/interpolate/fitpack.py", line 12, in <module>
    from ._bsplines import BSpline
  File "/global/common/software/desi/cori/desiconda/20180130-1.2.4-spec/conda/lib/python3.6/site-packages/scipy/interpolate/_bsplines.py", line 9, in <module>
    from . import _bspl
  File "__init__.pxd", line 155, in init scipy.interpolate._bspl
RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88
```