### PR TITLE
Greatly speed up the module that assigns sky positions (while avoiding targets)

### DIFF
--- a/bin/select_targets
+++ b/bin/select_targets
@@ -27,7 +27,7 @@ ap.add_argument("src", help="Tractor/sweeps file or root directory with tractor/
 ap.add_argument("dest", help="Output target selection file")
 ap.add_argument('-s', "--skies", action='store_true',help="Generate blank sky positions in addition to targets")
 ap.add_argument("--skymaglim",
-                help='Magnitude limits for building avoidance zones from objects in the sweeps (e.g. 20,20,20)',
+                help='Faint (g,r,z) magnitude limits for masks (for building avoidance zones from objects in the sweeps; e.g. "20,20,20")',
                 default="20,20,20")
 ap.add_argument('-c', "--check", action='store_true',help="Process tractor/sweeps files to check for corruption, without running full target selection")
 ap.add_argument('-m', "--mask", help="If sent then mask the targets, the name of the mask file should be supplied")

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -61,8 +61,9 @@ else:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
     if ns.skies:
-        maglim = [ float(ml) for ml in ns.maglim.split(',') ]
-        skies = select_skies(infiles,numproc=ns.numproc)
+        maglim = [ float(ml) for ml in ns.skymaglim.split(',') ]
+        log.info("sky magnitude limits set to {}".format(maglim))
+        skies = select_skies(infiles,numproc=ns.numproc,maglim=maglim)
         ntargs = len(targets)
         nskies = len(skies)
         nobjs = ntargs + nskies

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -16,7 +16,6 @@ warnings.simplefilter('error')
 
 import multiprocessing
 nproc = multiprocessing.cpu_count() // 2
-print(nproc)
 nside = 64 #ADM default HEALPix Nside used throughout desitarget
 
 from desiutil.log import get_logger

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -16,6 +16,7 @@ warnings.simplefilter('error')
 
 import multiprocessing
 nproc = multiprocessing.cpu_count() // 2
+print(nproc)
 nside = 64 #ADM default HEALPix Nside used throughout desitarget
 
 from desiutil.log import get_logger

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -26,6 +26,9 @@ ap = ArgumentParser()
 ap.add_argument("src", help="Tractor/sweeps file or root directory with tractor/sweeps files")
 ap.add_argument("dest", help="Output target selection file")
 ap.add_argument('-s', "--skies", action='store_true',help="Generate blank sky positions in addition to targets")
+ap.add_argument("--skymaglim",
+                help='Magnitude limits for building avoidance zones from objects in the sweeps (e.g. 20,20,20)',
+                default="20,20,20")
 ap.add_argument('-c', "--check", action='store_true',help="Process tractor/sweeps files to check for corruption, without running full target selection")
 ap.add_argument('-m', "--mask", help="If sent then mask the targets, the name of the mask file should be supplied")
 ap.add_argument("--sandbox", action='store_true',help="Apply the sandbox target selection algorithms")
@@ -58,6 +61,7 @@ else:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
     if ns.skies:
+        maglim = [ float(ml) for ml in ns.maglim.split(',') ]
         skies = select_skies(infiles,numproc=ns.numproc)
         ntargs = len(targets)
         nskies = len(skies)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,8 +5,7 @@ desitarget Change Log
 0.19.2 (unreleased)
 -------------------
 
-* Update of sky selection code [`PR #290`_]. This is still not the expected 
-  final algorithm, but this update includes:
+* Update of sky selection code [`PR #290`_]. Includes:
    * Use the :mod:`desitarget.brightmask` formalism to speed calculations.
    * Pass around a magnitude limit on masks from the sweeps (to better
      mask only objects that are genuinely detected in the sweeps).
@@ -147,7 +146,7 @@ to importing target mask bits and how mock spectra are generated.
 0.14.0 (2017-07-10)
 -------------------
 
-* Significant updated to handle transition from pre-DR4 to post-DR4 data model [`PR #189`_]:
+* Significant update to handle transition from pre-DR4 to post-DR4 data model [`PR #189`_]:
    * :mod:`desitarget.io` can now read old DR3-style and new DR4-style tractor and sweeps files
    * :mod:`desitarget.cuts` now always uses DR4-style column names and formats
    * new 60-bit ``TARGETID`` schema that incorporates ``RELEASE`` column from imaging surveys

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,7 +8,7 @@ desitarget Change Log
 * Update of sky selection code [`PR #290`_]. Includes:
    * Use the :mod:`desitarget.brightmask` formalism to speed calculations.
    * Pass around a magnitude limit on masks from the sweeps (to better
-     mask only objects that are genuinely detected in the sweeps).
+     avoid only objects that are genuinely detected in the sweeps).
    * Reduce the default margin to produce ~1700 sky positions per sq. deg.
    
 .. _`PR #288`: https://github.com/desihub/desitarget/pull/290

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,7 +11,7 @@ desitarget Change Log
      avoid only objects that are genuinely detected in the sweeps).
    * Reduce the default margin to produce ~1700 sky positions per sq. deg.
    
-.. _`PR #288`: https://github.com/desihub/desitarget/pull/290
+.. _`PR #290`: https://github.com/desihub/desitarget/pull/290
 
 0.19.1 (2018-03-01)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,14 @@ desitarget Change Log
 0.19.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Update of sky selection code [`PR #290`_]. This is still not the expected 
+  final algorithm, but this update includes:
+   * Use the :mod:`desitarget.brightmask` formalism to speed calculations.
+   * Pass around a magnitude limit on masks from the sweeps (to better
+     mask only objects that are genuinely detected in the sweeps).
+   * Reduce the default margin to produce ~1700 sky positions per sq. deg.
+   
+.. _`PR #288`: https://github.com/desihub/desitarget/pull/290
 
 0.19.1 (2018-03-01)
 -------------------

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -31,7 +31,7 @@ from desitarget.cuts import _psflike
 psfsize = 2.
 
 
-def density_of_sky_fibers(margin=10.):
+def density_of_sky_fibers(margin=1.):
     """Use positioner patrol size to determine sky fiber density for DESI
 
     Parameters
@@ -57,7 +57,7 @@ def density_of_sky_fibers(margin=10.):
     return nskymin
 
 
-def model_density_of_sky_fibers(margin=10.):
+def model_density_of_sky_fibers(margin=1.):
     """Use desihub products to find required density of sky fibers for DESI
 
     Parameters

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -31,7 +31,7 @@ from desitarget.cuts import _psflike
 psfsize = 2.
 
 
-def density_of_sky_fibers(margin=1.5):
+def density_of_sky_fibers(margin=1.):
     """Use positioner patrol size to determine sky fiber density for DESI
 
     Parameters
@@ -57,7 +57,7 @@ def density_of_sky_fibers(margin=1.5):
     return nskymin
 
 
-def model_density_of_sky_fibers(margin=1.5):
+def model_density_of_sky_fibers(margin=1.):
     """Use desihub products to find required density of sky fibers for DESI
 
     Parameters

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -36,7 +36,7 @@ def density_of_sky_fibers(margin=1.5):
 
     Parameters
     ----------
-    margin : :class:`float`, optional, defaults to 10.
+    margin : :class:`float`, optional, defaults to 1.5
         Factor of extra sky positions to generate. So, for margin=10, 10x as
         many sky positions as the default requirements will be generated
 
@@ -62,7 +62,7 @@ def model_density_of_sky_fibers(margin=1.5):
 
     Parameters
     ----------
-    margin : :class:`float`, optional, defaults to 10.
+    margin : :class:`float`, optional, defaults to 1.5
         Factor of extra sky positions to generate. So, for margin=10, 10x as
         many sky positions as the default requirements will be generated
 
@@ -89,7 +89,7 @@ def calculate_separations(objs,navoid=1.):
         numpy structured array with UPPERCASE columns, OR a string
         tractor/sweep filename. Must contain at least the columns
         "RA", "DEC", "SHAPEDEV_R", "SHAPEEXP_R"
-    navoid : :class:`float`, optional, defaults to 2.
+    navoid : :class:`float`, optional, defaults to 1.
         the number of times the galaxy half-light radius (or seeing) to avoid
         objects out to when placing sky fibers
 
@@ -127,7 +127,7 @@ def format_as_mask(objs,navoid=1.):
         "RA", "DEC", "SHAPEDEV_R", "SHAPEDEV_E1", "SHAPEDEV_E2"
         "SHAPEEXP_R", "SHAPEEXP_E1", "SHAPEDEV_E2", "TYPE"
 
-    navoid : :class:`float`, optional, defaults to 2.
+    navoid : :class:`float`, optional, defaults to 1.
         the number of times the galaxy half-light radius (or seeing) to avoid
         objects out to when placing sky fibers
 
@@ -194,14 +194,14 @@ def generate_sky_positions(objs,navoid=1.,nskymin=None,maglim=[20,20,20]):
         tractor/sweep filename. Must contain at least the columns
         "RA", "DEC", "SHAPEDEV_R", "SHAPEDEV_E1", "SHAPEDEV_E2"
         "SHAPEEXP_R", "SHAPEEXP_E1", "SHAPEDEV_E2", "TYPE"
-    navoid : :class:`float`, optional, defaults to 2.
+    navoid : :class:`float`, optional, defaults to 1.
         the number of times the galaxy half-light radius (or seeing) to avoid
         objects out to when placing sky fibers
     nskymin : :class:`float`, optional, defaults to reading from desimodel.io
         the minimum DENSITY of sky fibers to generate
-    maglim : :class:`list`, optional, defaules to [22,22,22]
+    maglim : :class:`list`, optional, defaules to [20,20,20]
         The "upper limit" in each of the three optical DESI selection bands. 
-        Objects fainter than these limits in g, r, z will NOT be masked
+        Objects fainter than these limits in ALL of g, r, z will NOT be masked
 
     Returns
     -------
@@ -371,10 +371,10 @@ def plot_sky_positions(ragood,decgood,rabad,decbad,objs,navoid=1.,maglim=[20,20,
         numpy structured array with UPPERCASE columns, OR a string
         tractor/sweep filename. Must contain at least the columns
         "RA", "DEC", "SHAPEDEV_R", "SHAPEEXP_R"
-    navoid : :class:`float`, optional, defaults to 2.
+    navoid : :class:`float`, optional, defaults to 1.
         the number of times the galaxy half-light radius (or seeing) that
         objects (objs) were avoided out to when generating sky positions
-    maglim : :class:`list`, optional, defaules to [22,22,22]
+    maglim : :class:`list`, optional, defaules to [20,20,20]
         The "upper limit" in each of the three optical DESI selection bands. 
         Masks fainter than these limits in g, r, z will NOT be plotted
     limits : :class:`~numpy.array`, optional, defaults to None
@@ -498,7 +498,7 @@ def plot_sky_positions(ragood,decgood,rabad,decbad,objs,navoid=1.,maglim=[20,20,
     return
 
 
-def make_sky_targets(objs,navoid=1.,nskymin=None):
+def make_sky_targets(objs,navoid=1.,nskymin=None,maglim=[20,20,20]):
     """Generate sky targets and translate them into the typical format for DESI targets
 
     Parameters
@@ -507,11 +507,14 @@ def make_sky_targets(objs,navoid=1.,nskymin=None):
         numpy structured array with UPPERCASE columns, OR a string
         tractor/sweep filename. Must contain at least the columns
         "RA", "DEC", "SHAPEDEV_R", "SHAPEEXP_R"
-    navoid : :class:`float`, optional, defaults to 2.
+    navoid : :class:`float`, optional, defaults to 1.
         the number of times the galaxy half-light radius (or seeing) to avoid
         objects out to when placing sky fibers
     nskymin : :class:`float`, optional, defaults to reading from desimodel.io
         the minimum DENSITY of sky fibers to generate
+    maglim : :class:`list`, optional, defaules to [20,20,20]
+        The "upper limit" in each of the three optical DESI selection bands. 
+        Objects fainter than these limits in ALL of g, r, z will NOT be masked
 
     Returns
     -------
@@ -531,7 +534,8 @@ def make_sky_targets(objs,navoid=1.,nskymin=None):
 
     log.info('Generating sky positions...t = {:.1f}s'.format(time()-start))
     #ADM generate arrays of good and bad objects for this sweeps file (or set)
-    ragood, decgood, rabad, decbad = generate_sky_positions(objs,navoid=navoid,nskymin=nskymin)
+    ragood, decgood, rabad, decbad = generate_sky_positions(objs,navoid=navoid,
+                                                            nskymin=nskymin,maglim=maglim)
     ngood = len(ragood)
     nbad = len(rabad)
     nskies = ngood + nbad
@@ -579,7 +583,7 @@ def make_sky_targets(objs,navoid=1.,nskymin=None):
     return skies
 
 
-def select_skies(infiles, numproc=4):
+def select_skies(infiles, numproc=4, maglim=[20,20,20]):
     """Process input files in parallel to select blank sky positions
 
     Parameters
@@ -589,6 +593,9 @@ def select_skies(infiles, numproc=4):
             OR a single filename
     numproc : :class:`int`, optional, defaults to 4 
         number of parallel processes to use. Pass numproc=1 to run in serial
+    maglim : :class:`list`, optional, defaules to [20,20,20]
+        The "upper limit" in each of the three optical DESI selection bands. 
+        Objects fainter than these limits in ALL of g, r, z will NOT be masked
 
     Returns
     -------
@@ -619,7 +626,7 @@ def select_skies(infiles, numproc=4):
     #ADM function to run file-by-file for each sweeps file
     def _select_skies_file(filename):
         '''Returns targets in filename that pass the cuts'''
-        return make_sky_targets(filename,navoid=1.,nskymin=None)
+        return make_sky_targets(filename,navoid=1.,nskymin=None,maglim=maglim)
 
     #ADM to count the number of files that have been processed
     #ADM use of a numpy scalar is for backwards-compatability with Python 2

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -200,8 +200,8 @@ def generate_sky_positions(objs,navoid=1.,nskymin=None,maglim=[20,20,20]):
     nskymin : :class:`float`, optional, defaults to reading from desimodel.io
         the minimum DENSITY of sky fibers to generate
     maglim : :class:`list`, optional, defaules to [20,20,20]
-        The "upper limit" in each of the three optical DESI selection bands. 
-        Objects fainter than these limits in ALL of g, r, z will NOT be masked
+        The "upper limit" in the three optical DESI selection bands. Objects 
+        fainter than these limits in ALL of g, r, z will NOT be used as masks.
 
     Returns
     -------
@@ -375,8 +375,8 @@ def plot_sky_positions(ragood,decgood,rabad,decbad,objs,navoid=1.,maglim=[20,20,
         the number of times the galaxy half-light radius (or seeing) that
         objects (objs) were avoided out to when generating sky positions
     maglim : :class:`list`, optional, defaules to [20,20,20]
-        The "upper limit" in each of the three optical DESI selection bands. 
-        Masks fainter than these limits in g, r, z will NOT be plotted
+        The "upper limit" in the three optical DESI selection bands. Objects 
+        fainter than these limits in ALL of g, r, z will NOT be used as masks.
     limits : :class:`~numpy.array`, optional, defaults to None
         plot limits in the form [ramin, ramax, decmin, decmax] if None
         is passed, then the entire area is plotted
@@ -514,7 +514,7 @@ def make_sky_targets(objs,navoid=1.,nskymin=None,maglim=[20,20,20]):
         the minimum DENSITY of sky fibers to generate
     maglim : :class:`list`, optional, defaules to [20,20,20]
         The "upper limit" in each of the three optical DESI selection bands. 
-        Objects fainter than these limits in ALL of g, r, z will NOT be masked
+        Masks fainter than these limits in g, r, z will NOT be plotted
 
     Returns
     -------
@@ -594,8 +594,8 @@ def select_skies(infiles, numproc=4, maglim=[20,20,20]):
     numproc : :class:`int`, optional, defaults to 4 
         number of parallel processes to use. Pass numproc=1 to run in serial
     maglim : :class:`list`, optional, defaules to [20,20,20]
-        The "upper limit" in each of the three optical DESI selection bands. 
-        Objects fainter than these limits in ALL of g, r, z will NOT be masked
+        The "upper limit" in the three optical DESI selection bands. Objects 
+        fainter than these limits in ALL of g, r, z will NOT be used as masks.
 
     Returns
     -------

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -22,7 +22,7 @@ from desitarget.targetmask import desi_mask, targetid_mask
 from desitarget.targets import encode_targetid, finalize
 from desitarget.internal import sharedmem
 from desitarget.geomask import ellipse_matrix, ellipse_boundary, is_in_ellipse_matrix
-from desitarget.brightmask import is_in_bright_mask, max_objid_bricks
+from desitarget.brightmask import is_in_bright_mask
 from desitarget.cuts import _psflike
 
 from collections import defaultdict

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -297,10 +297,13 @@ def generate_sky_positions(objs,navoid=1.,nskymin=None,maglim=[22,22,22]):
         skies["RA"] = np.random.uniform(ramin,ramax,nchunk)
         skies["DEC"] = np.degrees(np.arcsin(1.-np.random.uniform(1-sindecmax,1-sindecmin,nchunk)))        
 
-        #ADM determine which of the sky positions are in an object (mask)
-        #ADM first for the small objects
-        is_in_bright_mask(skies,smallmask)
+        #ADM set up a list of skies that don't match an object
+        goodskies = np.ones(len(skies),dtype=bool)
 
+        #ADM determine which of the sky positions are in an object (mask)
+        #ADM first for the big objects
+        isin, _ = is_in_bright_mask(skies,smallmask)
+        goodskies = 
 
 
         #ADM good sky positions we found

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -31,7 +31,7 @@ from desitarget.cuts import _psflike
 psfsize = 2.
 
 
-def density_of_sky_fibers(margin=1.):
+def density_of_sky_fibers(margin=1.5):
     """Use positioner patrol size to determine sky fiber density for DESI
 
     Parameters
@@ -57,7 +57,7 @@ def density_of_sky_fibers(margin=1.):
     return nskymin
 
 
-def model_density_of_sky_fibers(margin=1.):
+def model_density_of_sky_fibers(margin=1.5):
     """Use desihub products to find required density of sky fibers for DESI
 
     Parameters
@@ -260,7 +260,7 @@ def generate_sky_positions(objs,navoid=1.,nskymin=None,maglim=[20,20,20]):
 
     #ADM format the passed objects as a mask to facilitate working with the 
     #ADM masking software in the brightmask module
-    mask = format_as_mask(objs)
+    mask = format_as_mask(objs,navoid=navoid)
     
     #ADM split the mask on roughly arcminute scales, which seems to greatly
     #ADM speed up the masking when there are a few objects with large radii
@@ -269,7 +269,7 @@ def generate_sky_positions(objs,navoid=1.,nskymin=None,maglim=[20,20,20]):
     wsmall = np.where(~biggerthansep)
     nbig = len(wbig[0])
     nsmall = len(wsmall[0])
-    log.info("{} out of {} big masks".format(nbig,nsmall+nbig))
+    log.info('{} out of {} masks are "big"'.format(nbig,nsmall+nbig))
     if nbig > 0:
         bigmask = mask[wbig]
         smallmask = mask[wsmall]
@@ -312,12 +312,12 @@ def generate_sky_positions(objs,navoid=1.,nskymin=None,maglim=[20,20,20]):
             if len(wbad[0]) > 0:
                 goodskies[wbad] = False
 
-        if not len(wgood[0]) > 0:
-            #ADM if everything intersected a "big" mask on the first pass
-            #ADM then we may as well return everything as a "bad" sky
-            log.warning("No possible good skies in {:.2f},{:.2f},{:.2f},{:.2f} box".format(
-                ramin,ramax,decmin,decmax))
-            return np.array([]), np.array([]), skies["RA"], skies["DEC"]
+            if not len(wgood[0]) > 0:
+                #ADM if everything intersected a "big" mask on the first pass
+                #ADM then we may as well return everything as a "bad" sky
+                log.warning("No possible good skies in {:.2f},{:.2f},{:.2f},{:.2f} box".format(
+                    ramin,ramax,decmin,decmax))
+                return np.array([]), np.array([]), skies["RA"], skies["DEC"]
 
         #ADM now for the small objects
         isin = is_in_bright_mask(skies,smallmask,inonly=True)

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -32,8 +32,8 @@ from collections import defaultdict
 #ADM this can typically be scaled using the navoid parameter
 psfsize = 2.
 
-def find_duplicates_and_indexes(targetid)
-    """For a list of integers, return the indexes of duplicates
+def find_duplicates_and_indexes(targetid):
+    """For a list of integers, return any duplicates and indexes of duplicates
 
     Parameters
     ----------

--- a/py/desitarget/skies.py
+++ b/py/desitarget/skies.py
@@ -134,9 +134,9 @@ def format_as_mask(objs,navoid=1.):
     Returns
     -------
     :class:`recarray`
-        - The bright source mask in the form `RA`,`DEC`,`TARGETID`,`IN_RADIUS`,`NEAR_RADIUS`,`E1`,`E2`,`TYPE`
+        - The bright source mask in the form `RA`,`DEC`,`TARGETID`,`IN_RADIUS`,`E1`,`E2`,`TYPE`
         - TARGETID is as calculated in :mod:`desitarget.targets.encode_targetid`
-        - The radii are in ARCSECONDS (they default to equivalents of half-light radii for ellipses)
+        - The radius is in ARCSECONDS (and defaults to the equivalent of half-light radius for ellipses)
         - `E1` and `E2` are ellipticity components, which are 0 for unresolved objects
         - `TYPE` is always `PSF` for star-like objects. This is taken from the sweeps files, see, e.g.:
           http://legacysurvey.org/dr5/files/#sweep-catalogs                                                     
@@ -144,8 +144,8 @@ def format_as_mask(objs,navoid=1.):
 
     #ADM Create an output recarray that's just RA, Dec, TARGETID and the radii
     nrows = len(objs)
-    dnames = ['RA','DEC','TARGETID','IN_RADIUS','NEAR_RADIUS','E1','E2','TYPE']
-    dtypes = ['>f8','>f8','>i8','>f4','>f4','>f4','>f4','|S4']
+    dnames = ['RA','DEC','TARGETID','IN_RADIUS','E1','E2','TYPE']
+    dtypes = ['>f8','>f8','>i8','>f4','>f4','>f4','|S4']
     dt = list(zip(dnames,dtypes))
     done = np.empty(nrows, dtype=dt)
 
@@ -178,7 +178,6 @@ def format_as_mask(objs,navoid=1.):
 
     #ADM set the remaining columns
     done['IN_RADIUS'] = in_radius
-    done['NEAR_RADIUS'] = in_radius
     done['E1'] = e1
     done['E2'] = e2
 

--- a/py/desitarget/test/test_skies.py
+++ b/py/desitarget/test/test_skies.py
@@ -19,7 +19,8 @@ class TestSKIES(unittest.TestCase):
     def setUp(self):
         #ADM at this nskymin you always seem to get at least 1 bad position
         self.nskymin = 5000000
-        self.navoid = 2.
+        #ADM choose a somewhat unusual navoid to try to break the code
+        self.navoid = 3.
         self.psfsize = psfsize
         #ADM set the magnitude limits to something extremely faint
         #ADM so that nothing is limited on magnitude

--- a/py/desitarget/test/test_skies.py
+++ b/py/desitarget/test/test_skies.py
@@ -131,6 +131,17 @@ class TestSKIES(unittest.TestCase):
                                          TEXP[...,i])
             self.assertFalse(np.any(is_in))
 
+    def test_format_as_mask(self):
+        """
+        Check that a set of input objects can be recast in the mask format
+        """
+        #ADM format the input objects as a mask
+        mask = skies.format_as_mask(self.objs)
+        
+        #ADM check the output mask has the necessary columns
+        for name in ['RA','DEC','TARGETID','IN_RADIUS','E1','E2','TYPE']:
+            self.assertTrue(name in mask.dtype.names)
+
     def test_make_sky_targets_bits(self):
         """
         Check that the output bit formatting from make_sky_targets is correct


### PR DESCRIPTION
This is still not the expected final algorithm, which will instead piggyback on:

https://github.com/desihub/desitarget/blob/master/py/desitarget/skyfibers.py

but this should be good enough to begin experimenting with assigning fibers to sky positions downstream of `desitarget`. This update includes:
   * Use the formalism of https://github.com/desihub/desitarget/blob/master/py/desitarget/brightmask.py to greatly increase the speed with which sky positions are compared to masks.
   * Pass around a magnitude limit on masks from the sweeps (to better mask only objects that are genuinely detected in the sweeps).
   * Reduce the default margin to produce ~1700 sky positions per sq. deg...the previous version generated tens-of-thousands of positions per sq. deg., which was overkill.

The default code runs in under an hour on an interactive node, e.g.:

```
salloc -N 1 -C haswell -t 00:60:00 --qos interactive -L SCRATCH,project
select_targets /global/project/projectdirs/cosmo/data/legacysurvey/dr5/sweep/ $CSCRATCH/test-skies-margin-dr5.fits --skies
```

Here's an example of the results, where blue areas are masks (typically faint-ish galaxies from the sweeps):

![skies](https://user-images.githubusercontent.com/13952581/37053008-eff173c8-2172-11e8-8ffd-701a4072cce6.png)


