### PR TITLE
Improves backwards-compatability with the ELG selection

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,13 @@ desitarget Change Log
 0.20.2 (unreleased)
 -------------------
 
+* Improve north/south split functions for LRG and QSO color cuts [`PR #302`_].
 * Minor QA and selection cuts updates [`PR #297`_]:
    * QA matrix of target densities selected in multiple classes.
    * Functions to allow different north/south selections for LRGs.
 
 .. _`PR #297`: https://github.com/desihub/desitarget/pull/297
+.. _`PR #302`: https://github.com/desihub/desitarget/pull/302
 
 0.20.1 (2018-03-29)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -85,6 +85,34 @@ def shift_photo_north(gflux=None, rflux=None, zflux=None):
     return gshift, rshift, zshift
 
 
+def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
+                 w2flux=None, ggood=None, primary=None, south=True):
+    """Convenience function for backwards-compatability prior to north/south split.
+
+    Args:
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, W1 and W2 bands (if needed).
+        ggood: array_like
+            Set to True for objects with good g-band photometry.
+        primary: array_like or None
+            If given, the BRICK_PRIMARY column of the catalogue.
+        south: boolean, defaults to True
+            Call isLRG_colors_north if south=False, otherwise call isLRG_colors_south.
+    
+    Returns:
+        mask : array_like. True if and only the object is an LRG target.
+    """
+
+    if south==False:
+        return isLRG_colors_north(gflux=gflux, rflux=rflux, zflux=zflux, 
+                                  w1flux=w1flux, w2flux=w2flux,
+                                  ggood=ggood, primary=primary)
+    else:
+        return isLRG_colors_south(gflux=gflux, rflux=rflux, zflux=zflux, 
+                                  w1flux=w1flux, w2flux=w2flux,
+                                  ggood=ggood, primary=primary)
+
+
 def isLRG_colors_north(gflux=None, rflux=None, zflux=None, w1flux=None,
                         w2flux=None, ggood=None, primary=None):
     """See :func:`~desitarget.cuts.isLRG_north` for details.

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -121,8 +121,8 @@ class TestCuts(unittest.TestCase):
         self.assertTrue(np.all(qso1==qso2))
         #ADM also check that the color selections alone work. This tripped us up once
         #ADM with the mocks part of the code calling a non-existent LRG colors function.
-        qso1 = cuts.isQSO_colors(gflux, rflux, zflux, w1flux, w2flux,optical=False)
-        qso2 = cuts.isQSO_colors(gflux, rflux, zflux, w1flux, w2flux,optical=None)
+        qso1 = cuts.isQSO_colors(gflux, rflux, zflux, w1flux, w2flux, optical=False)
+        qso2 = cuts.isQSO_colors(gflux, rflux, zflux, w1flux, w2flux, optical=None)
         self.assertTrue(np.all(qso1==qso2))
 
         fstd1 = cuts.isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -88,7 +88,7 @@ class TestCuts(unittest.TestCase):
                     gflux_ivar=gfluxivar, rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
         self.assertTrue(np.all(lrg1==lrg2))
         #ADM also check that the color selections alone work. This tripped us up once
-        #ADM with the mocks part of the code calling a non-existent is colors function.
+        #ADM with the mocks part of the code calling a non-existent LRG colors function.
         lrg1 = cuts.isLRG_colors(primary=primary, gflux=gflux, rflux=rflux, zflux=zflux, 
                                  w1flux=w1flux, w2flux=w2flux)
         lrg2 = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux, zflux=zflux, 
@@ -118,6 +118,11 @@ class TestCuts(unittest.TestCase):
         qso2 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
                           deltaChi2=deltaChi2, w1snr=w1snr, w2snr=w2snr, objtype=None, primary=None,
                           release=release)
+        self.assertTrue(np.all(qso1==qso2))
+        #ADM also check that the color selections alone work. This tripped us up once
+        #ADM with the mocks part of the code calling a non-existent LRG colors function.
+        qso1 = cuts.isQSO_colors(gflux, rflux, zflux, w1flux, w2flux,optical=False)
+        qso2 = cuts.isQSO_colors(gflux, rflux, zflux, w1flux, w2flux,optical=None)
         self.assertTrue(np.all(qso1==qso2))
 
         fstd1 = cuts.isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -87,6 +87,13 @@ class TestCuts(unittest.TestCase):
         lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
                     gflux_ivar=gfluxivar, rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
         self.assertTrue(np.all(lrg1==lrg2))
+        #ADM also check that the color selections alone work. This tripped us up once
+        #ADM with the mocks part of the code calling a non-existent is colors function.
+        lrg1 = cuts.isLRG_colors(primary=primary, gflux=gflux, rflux=rflux, zflux=zflux, 
+                                 w1flux=w1flux, w2flux=w2flux)
+        lrg2 = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux, zflux=zflux, 
+                                 w1flux=w1flux, w2flux=w2flux)
+        self.assertTrue(np.all(lrg1==lrg2))
 
         elg1 = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux, primary=primary)
         elg2 = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)
@@ -111,7 +118,6 @@ class TestCuts(unittest.TestCase):
         qso2 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
                           deltaChi2=deltaChi2, w1snr=w1snr, w2snr=w2snr, objtype=None, primary=None,
                           release=release)
-        
         self.assertTrue(np.all(qso1==qso2))
 
         fstd1 = cuts.isFSTD_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)


### PR DESCRIPTION
In response to:

https://github.com/desihub/desitarget/issues/301

this PR reinstates `isLRG_colors()` as a convenience function that calls `isLRG_colors_north()` and `isLRG_colors_south()` and includes a unit test that would have caught the absence of that function.

For consistency, I also added a similar function and unit test for the color-based quasar selection.