### PR TITLE
Reweight area estimation in QA plots to better reflect the imaging survey footprint

### DIFF
--- a/bin/make_imaging_weight_map
+++ b/bin/make_imaging_weight_map
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, division
+
+import os, sys
+import numpy as np
+
+from desitarget.imagefootprint import pixweight
+
+import warnings
+warnings.simplefilter('error')
+
+import multiprocessing
+nproc = multiprocessing.cpu_count() // 2
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser()
+ap.add_argument("src", 
+                help='Legacy Surveys Data Release root directory (e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr4/ for DR4 at NERSC)')
+ap.add_argument("dest", 
+                help='Output file name to write map of HEALPixel weights in the NESTED scheme (e.g. /project/projectdirs/desi/target/catalogs/pixweight-dr4-0.20.0.fits)')
+ap.add_argument("--nside", type=int, 
+                help='The resolution (HEALPixel nside number) at which to build the map (defaults to 256)',
+                default="256")
+ap.add_argument("--density", type=int,
+                help='Number of points per sq. deg. at which to Monte Carlo the imaging masks (defaults to 10million)',
+                default="10000000")
+ap.add_argument("--outplot",
+                help='Output file name to which to write a plot of the map',
+                default=None)
+ap.add_argument("--numproc", type=int,
+                help='number of concurrent processes to use [{}]'.format(nproc),
+                default=nproc)
+
+ns = ap.parse_args()
+
+if not os.path.exists(ns.src):
+    log.critical('Input directory does not exist: {}'.format(ns.src))
+    sys.exit(1)
+
+log.info('running on {} processors'.format(nproc))
+
+_ = pixweight(nside=ns.nside, density=ns.density, numproc=ns.numproc, outfile=ns.dest, outplot=ns.outplot, drdir=ns.src)
+
+log.info('wrote map of HEALPixel weights (in the nested scheme) to {}'.format(ns.dest))
+

--- a/bin/run_target_qa
+++ b/bin/run_target_qa
@@ -15,9 +15,10 @@ from argparse import ArgumentParser
 ap = ArgumentParser()
 ap.add_argument("src", help="Input target file (e.g. /project/projectdirs/desi/target/catalogs/targets-dr3.1-dr4.0-all-0.14.0.fits)")
 ap.add_argument("dest", help="Output directory to make QA webpage hierarchy (e.g. /project/projectdirs/desi/www/users/USERNAME/ will appear at http://portal.nersc.gov/project/desi/users/USERNAME)")
-ap.add_argument('-m', "--mocks", action='store_true',help="Input target file is a set of mock targets, so we can make extra, special QA plots")
-ap.add_argument('-n', "--noplots", action='store_true',help="Do not produce any new plots, only the body of the QA webpage")
-ap.add_argument("--nside", default=None, type=int ,help="Specify the healpixel resolution of the sky maps.")
+ap.add_argument('-m', "--mocks", action='store_true', help="Input target file is a set of mock targets, so we can make extra, special QA plots")
+ap.add_argument('-n', "--noplots", action='store_true', help="Do not produce any new plots, only the body of the QA webpage")
+ap.add_argument('--nside', default=None, type=int , help="Specify the healpixel resolution of the sky maps")
+ap.add_argument('-w','--weightmapfile', default=None, help="Location (e.g. ~/project/projectdirs/desi/target/catalogs/pixweight-dr4-0.20.0.fits) of the imaging HEALPix map file for the Data Release that corresponds to these targets (e.g. as made by desitarget.imagefootprint.pixweight()")
 
 ns = ap.parse_args()
 
@@ -29,7 +30,7 @@ if ns.nside:
 else:
     max_bin_area = 1.0
 
-make_qa_page(ns.src,qadir=ns.dest,mocks=ns.mocks,makeplots=makeplots,max_bin_area=max_bin_area)
+make_qa_page(ns.src,qadir=ns.dest,mocks=ns.mocks,makeplots=makeplots,max_bin_area=max_bin_area,imaging_map_file=ns.weightmapfile)
 log.info('Targeting QA pages and plots written to {}'.format(ns.dest))
 log.info('Mocks option was set to {}'.format(ns.mocks))
 log.info('No plots option was set to {}'.format(ns.noplots))

--- a/bin/run_target_qa
+++ b/bin/run_target_qa
@@ -13,7 +13,7 @@ log = get_logger()
 
 from argparse import ArgumentParser
 ap = ArgumentParser()
-ap.add_argument("src", help="Input target file (e.g. /project/projectdirs/desi/target/catalogs/targets-dr3.1-dr4.0-all-0.14.0.fits)")
+ap.add_argument("src", help="Input target file (e.g. /project/projectdirs/desi/target/catalogs/targets-dr4-0.20.0.fits")
 ap.add_argument("dest", help="Output directory to make QA webpage hierarchy (e.g. /project/projectdirs/desi/www/users/USERNAME/ will appear at http://portal.nersc.gov/project/desi/users/USERNAME)")
 ap.add_argument('-m', "--mocks", action='store_true', help="Input target file is a set of mock targets, so we can make extra, special QA plots")
 ap.add_argument('-n', "--noplots", action='store_true', help="Do not produce any new plots, only the body of the QA webpage")

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,11 @@ desitarget Change Log
 0.20.2 (unreleased)
 -------------------
 
+* Better handling of imaging survey areas for QA [`PR #304`_]:
+   * :mod:`desitarget.imagefootprint` to build HEALPix weight maps of imaging.
+   * Executable (bin) interface to make weight maps from the command line.
+   * :mod:`desitarget.io` loader to resample maps to any HEALPix `nside`.
+   * Update :mod:`desitarget.QA` to handle new imaging area weight maps.   
 * Improve north/south split functions for LRG and QSO color cuts [`PR #302`_].
 * Minor QA and selection cuts updates [`PR #297`_]:
    * QA matrix of target densities selected in multiple classes.
@@ -12,6 +17,7 @@ desitarget Change Log
 
 .. _`PR #297`: https://github.com/desihub/desitarget/pull/297
 .. _`PR #302`: https://github.com/desihub/desitarget/pull/302
+.. _`PR #304`: https://github.com/desihub/desitarget/pull/304
 
 0.20.1 (2018-03-29)
 -------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -2307,7 +2307,15 @@ def make_qa_plots(targs, qadir='.', targdens=None, max_bin_area=1.0, weight=True
     weights = np.ones(len(targs))
     if weight:
         #ADM retrieve the map of what HEALPixels are actually in the DESI footprint
-        pixweight = io.load_pixweight(nside)
+        wtfile = ("/global/cscratch1/sd/raichoor/desi.dr4.hp256.grzareas.fits")
+        wts = fitsio.read(wtfile)
+        pixarea = hp.nside2pixarea(256,degrees=True)
+        pixweight = np.zeros(len(wts))
+        #ADM shift Anand's scheme from ring to nested scheme
+        pixweight[hp.ring2nest(256,wts['hpind'])] = wts['hparea']
+        #ADM Create the weights as the fraction of the pixel area
+        pixweight /= pixarea
+#        pixweight = io.load_pixweight(nside)
         #ADM determine what HEALPixels each target is in, to set the weights
         fracarea = pixweight[pix]
         #ADM weight by 1/(the fraction of each pixel that is in the DESI footprint)
@@ -2316,7 +2324,6 @@ def make_qa_plots(targs, qadir='.', targdens=None, max_bin_area=1.0, weight=True
         fracarea[w] = 1 #ADM to guard against division by zero warnings
         weights = 1./fracarea
         weights[w] = 0
-
         log.info('Assigned weights to pixels based on DESI footprint...t = {:.1f}s'
                  .format(time()-start))
 

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -2371,7 +2371,7 @@ def make_qa_plots(targs, qadir='.', targdens=None, max_bin_area=1.0, weight=True
     return totarea
 
 
-def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.', clip2foot=True,
+def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.', clip2foot=False,
                  weight=True, imaging_map_file=None):
     """Create a directory containing a webpage structure in which to embed QA plots
 
@@ -2389,9 +2389,9 @@ def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.'
         possible to this value without exceeding it
     qadir : :class:`str`, optional, defaults to the current directory
         The output directory to which to write produced plots
-    clip2foot : :class:`boolean`, optional, defaults to True
+    clip2foot : :class:`boolean`, optional, defaults to False
         use :mod:`desimodel.footprint.is_point_in_desi` to restrict the passed targets to
-        only those that lie within the DESI footprint
+        only those that lie within the DESI spectroscopic footprint
     weight : :class:`boolean`, optional, defaults to True
         If this is set, weight pixels using to ameliorate under dense pixels at the footprint 
         edges. This uses the `imaging_map_file` HEALPix file for real targets and the default 

--- a/py/desitarget/imagefootprint.py
+++ b/py/desitarget/imagefootprint.py
@@ -123,7 +123,6 @@ def randoms_in_a_brick_from_name(brickname,density=10000,
     -----
         - First version copied shamelessly from Anand Raichoor
     """
-    #GENERATE RANDOMS IN THE PASSED BRICK ============================================= 
     #ADM read in the survey bricks file to determine the brick boundaries
     hdu = fits.open(drdir+'survey-bricks.fits.gz')
 
@@ -195,7 +194,7 @@ def nobs_at_positions_in_a_brick(ras,decs,brickname,
     iswcs = False
 
     #ADM loop through each of the filters and store the number of observations at the
-    #ADM RA and Dec positions of th passed points
+    #ADM RA and Dec positions of the passed points
     nobsdict = {} 
     for filt in ['g','r','z']:
         nexpfile = (drdir+'/coadd/'+brickname[:3]+'/'+brickname+'/'+
@@ -413,16 +412,22 @@ def pixweight(nside=256, density=10000, numproc=16, outfile=None, outplot=None,
         - `0 < WEIGHT < 1` for pixels that partially cover LS DR area with one or more observations.
         - The index of the array is the HEALPixel integer.
     """
-    #ADM read in the survey bricks file, which lists the bricks of interest for this DR
+    #ADM get brick names of possible interest from coadd directory structure for this DR
     from glob import glob
-    sbfile = glob(drdir+'/*bricks-dr*')[0]
-    hdu = fits.open(sbfile)
-    brickinfo = hdu[1].data
+    bricknames = [os.path.basename(file) for file in glob(drdir+'coadd/*/*')]
 
-    #ADM as a speed-up, cull any bricks with zero exposures in any bands
-    wbricks = np.where( (brickinfo['nexp_g'] > 0) & 
-                        (brickinfo['nexp_r'] > 0) & (brickinfo['nexp_z'] > 0) )
-    bricknames = brickinfo['brickname'][wbricks]
+    ###ADM this should be the most rigorous approach, but it didn't work circa DR4 due to
+    ###ADM discrepancies between the coadd directory structure and the information in the
+    ###ADM survey bricks file. I'm leaving it here in case it's useful in the future.
+    ####ADM read in the survey bricks file, which lists the bricks of interest for this DR
+    ###sbfile = glob(drdir+'/*bricks-dr*')[0]
+    ###hdu = fits.open(sbfile)
+    ###brickinfo = hdu[1].data
+    ####ADM as a speed-up, cull any bricks with zero exposures in any bands
+    ###wbricks = np.where( (brickinfo['nexp_g'] > 0) & 
+    ###                    (brickinfo['nexp_r'] > 0) & (brickinfo['nexp_z'] > 0) )
+    ###bricknames = brickinfo['brickname'][wbricks]
+
     nbricks = len(bricknames)
     log.info('Processing {} bricks that have one or more observations...t = {:.1f}s'
              .format(nbricks,time()-start))

--- a/py/desitarget/imagefootprint.py
+++ b/py/desitarget/imagefootprint.py
@@ -356,7 +356,7 @@ def hp_with_nobs_in_a_brick(ramin,ramax,decmin,decmax,brickname,density=10000,ns
     ras, decs = randoms_in_a_brick_from_edges(ramin,ramax,decmin,decmax,density=density)
 
     #ADM retrieve the number of observations for each random point
-    nobs_g, nobs_r, nobs_z = nobs_at_positions_in_brick(ras,decs,brickname,drdir=drdir)
+    nobs_g, nobs_r, nobs_z = nobs_at_positions_in_a_brick(ras,decs,brickname,drdir=drdir)
 
     #ADM only retain points with one or more observations in all bands
     w = np.where( (nobs_g > 0) & (nobs_g > 0) & (nobs_z > 0) )
@@ -417,7 +417,7 @@ def pixweight(nside=256, density=10000, numproc=16, outfile=None, outplot=None,
     #ADM as a speed-up, cull any bricks with zero exposures in any bands
     wbricks = np.where( (brickinfo['nexp_g'] > 0) & 
                         (brickinfo['nexp_r'] > 0) & (brickinfo['nexp_z'] > 0) )
-    bricknames = brickinfo['brickname'][wbricks][0:1000]
+    bricknames = brickinfo['brickname'][wbricks]
     nbricks = len(bricknames)
     log.info('Processing {} bricks that have one or more observations...t = {:.1f}s'
              .format(nbricks,time()-start))

--- a/py/desitarget/imagefootprint.py
+++ b/py/desitarget/imagefootprint.py
@@ -363,7 +363,7 @@ def hp_with_nobs_in_a_brick(ramin,ramax,decmin,decmax,brickname,density=10000,ns
     nobs_g, nobs_r, nobs_z = nobs_at_positions_in_a_brick(ras,decs,brickname,drdir=drdir)
 
     #ADM only retain points with one or more observations in all bands
-    w = np.where( (nobs_g > 0) & (nobs_g > 0) & (nobs_z > 0) )
+    w = np.where( (nobs_g > 0) & (nobs_r > 0) & (nobs_z > 0) )
 
     #ADM if there were some non-zero observations, populate the pixel numbers and counts
     if len(w[0]) > 0:
@@ -412,22 +412,20 @@ def pixweight(nside=256, density=10000, numproc=16, outfile=None, outplot=None,
         - `0 < WEIGHT < 1` for pixels that partially cover LS DR area with one or more observations.
         - The index of the array is the HEALPixel integer.
     """
-    #ADM get brick names of possible interest from coadd directory structure for this DR
-    from glob import glob
-    bricknames = [os.path.basename(file) for file in glob(drdir+'coadd/*/*')]
 
-    ###ADM this should be the most rigorous approach, but it didn't work circa DR4 due to
-    ###ADM discrepancies between the coadd directory structure and the information in the
-    ###ADM survey bricks file. I'm leaving it here in case it's useful in the future.
-    ####ADM read in the survey bricks file, which lists the bricks of interest for this DR
-    ###sbfile = glob(drdir+'/*bricks-dr*')[0]
-    ###hdu = fits.open(sbfile)
-    ###brickinfo = hdu[1].data
+    #ADM read in the survey bricks file, which lists the bricks of interest for this DR
+    from glob import glob
+    sbfile = glob(drdir+'/*bricks-dr*')[0]
+    hdu = fits.open(sbfile)
+    brickinfo = hdu[1].data
+    ###ADM this (~1.7x) speed-up doesn't seem to work because of a discrepancy between the
+    ###ADM information in the survey bricks file and in the coadd directory structure, but
+    ###ADM I'm leaving it here in case its a useful trick to use at some point in the future
     ####ADM as a speed-up, cull any bricks with zero exposures in any bands
     ###wbricks = np.where( (brickinfo['nexp_g'] > 0) & 
     ###                    (brickinfo['nexp_r'] > 0) & (brickinfo['nexp_z'] > 0) )
     ###bricknames = brickinfo['brickname'][wbricks]
-
+    bricknames = brickinfo['brickname']
     nbricks = len(bricknames)
     log.info('Processing {} bricks that have one or more observations...t = {:.1f}s'
              .format(nbricks,time()-start))

--- a/py/desitarget/imagefootprint.py
+++ b/py/desitarget/imagefootprint.py
@@ -201,7 +201,7 @@ def nobs_at_positions_in_a_brick(ras,decs,brickname,
         nexpfile = (drdir+'/coadd/'+brickname[:3]+'/'+brickname+'/'+
                         'legacysurvey-'+brickname+'-'+'nexp'+'-'+filt+'.fits.'+extn)
         #ADM only process the WCS if there is a file corresponding to this filter
-        if (os.path.exists(nexpfile)):
+        if os.path.exists(nexpfile):
             img = fits.open(nexpfile)
             if (iswcs==False):
                 w = WCS(img[extn_nb].header)

--- a/py/desitarget/imagefootprint.py
+++ b/py/desitarget/imagefootprint.py
@@ -7,6 +7,11 @@ from astropy.wcs import WCS
 from time import time
 import healpy as hp
 
+#ADM fake the matplotlib display so it doesn't die on allocated nodes
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
 #ADM the parallelization script
 from desitarget.internal import sharedmem
 
@@ -495,7 +500,6 @@ def pixweight(nside=256, density=10000, numproc=16, outfile=None, outplot=None,
     #ADM if outplot was passed, make a plot of the final mask in Mollweide projection
     if outplot is not None:
         log.info('Plotting pixel map and writing to {}'.format(outplot))
-        import matplotlib.pyplot as plt
         hp.mollview(pix_weight, nest=True)
         plt.savefig(outplot)
 

--- a/py/desitarget/imagefootprint.py
+++ b/py/desitarget/imagefootprint.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+import astropy.io.fits as fits
+from astropy.wcs import WCS
+from time import time
+
+#ADM set up the DESI default logger
+from desiutil.log import get_logger
+log = get_logger()
+
+#ADM start the clock
+start = time()
+
+
+def dr_extension(drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"):
+    """Determine the extension information for files in a legacy survey coadd directory
+    
+    Parameters
+    ----------
+    drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
+       The root directory pointing to a Data Release from the Legacy Surveys
+
+    Returns
+    -------
+    :class:`str`
+        Whether the file extension is 'gz' or 'fz'
+    :class:`int`
+        The corresponding FITS extension number that needs to be read (0 or 1)
+    """
+
+    from glob import iglob
+    
+    #ADM for speed, create a generator of all of the nexp files in the coadd directory
+    gen = iglob(drdir+"/coadd/*/*/*nexp*")
+    #ADM and pop the first one
+    anexpfile = next(gen)
+    extn = anexpfile[-2:]
+
+    if extn == 'gz':
+        return 'gz', 0
+
+    return 'fz', 1
+
+
+def randoms_in_a_brick(brickname,density=10000,
+                       drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"):
+    """For a given brick name, return random (RA/Dec) positions in the brick
+
+    Parameters
+    ----------
+    brickname : :class:`str`
+        Name of brick in which to generate random points
+    density : :class:`float`
+        The number of random points to return per sq. deg. As a typical brick is 
+        ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned
+    drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
+       The root directory pointing to a Data Release from the Legacy Surveys
+
+    Returns
+    -------
+    :class:`~numpy.array`
+        Right Ascensions of random points in brick
+    :class:`~numpy.array`
+        Declinations of random points in brick
+
+    Notes
+    -----
+        - First version copied shamelessly from Anand Raichoor
+        - This version requires a survey bricks file to generate RAs and Decs in
+          a brick (rather than, e.g., using :mod:`desiutil.brick)`
+    """
+    #GENERATE RANDOMS IN THE PASSED BRICK ============================================= 
+    #ADM read in the survey bricks file to determine the brick boundaries
+    hdu = fits.open(drdir+'survey-bricks.fits.gz')
+
+    brickinfo = hdu[1].data
+    wbrick = np.where(brickinfo['brickname']==brickname)[0]
+    if len(wbrick)==0:
+        log.error('Brick {} does not exist'.format(brickname))
+    else:
+        log.info('Working on brick {}...t = {:.1f}s'.format(brickname,time()-start))
+
+    brick = brickinfo[wbrick][0]
+    ramin, ramax, decmin, decmax = brick['ra1'], brick['ra2'], brick['dec1'], brick['dec2']
+
+    #ADM generate random points within the brick at the requested density
+    #ADM guard against potential wraparound bugs
+    if ramax - ramin > 350.:
+        ramax -= 360.
+    sindecmin, sindecmax = np.sin(np.radians(decmin)), np.sin(np.radians(decmax))
+    spharea = (ramax-ramin)*np.degrees(sindecmax-sindecmin)
+    nrand = int(spharea*density)
+    print('Full area covered by brick {} is {:.5f} sq. deg....t = {:.1f}s'
+              .format(brickname,spharea,time()-start))
+    ras = np.random.uniform(ramin,ramax,nrand)
+    decs = np.degrees(np.arcsin(1.-np.random.uniform(1-sindecmax,1-sindecmin,nrand)))
+
+    nrand= len(ras)
+
+    log.info('Generated {} randoms in brick {} with bounds [{:.3f},{:.3f},{:.3f},{:.3f}]...t = {:.1f}s'
+                 .format(nrand,brickname,ramin,ramax,decmin,decmax,time()-start))
+
+    return ras, decs
+
+
+def nobs_at_positions_in_brick(ras,decs,brickname,
+                               drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"):
+    """Return the number of observations at positions in one brick of the Legacy Surveys
+
+    Parameters
+    ----------
+    ras : :class:`~numpy.array`
+        Right Ascensions of interest (degrees)
+    decs : :class:`~numpy.array`
+        Declinations of interest (degrees)
+    brickname : :class:`str`
+        Name of brick which contains RA/Dec positions
+    drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
+       The root directory pointing to a Data Release from the Legacy Surveys
+
+    Returns
+    -------
+    :class:`~numpy.array`
+        The number of observations in the Legacy Surveys at each position in g-band
+    :class:`~numpy.array`
+        The number of observations in the Legacy Surveys at each position in r-band
+    :class:`~numpy.array`
+        The number of observations in the Legacy Surveys at each position in z-band
+
+    Notes
+    -----
+        - First version copied shamelessly from Anand Raichoor 
+    """
+    npts = len(ras)
+
+    #ADM determine whether the coadd files have extension .gz or .fz based on the DR directory
+    extn, extn_nb = dr_extension(drdir)
+
+    # as a speed up, we assume all images in different filters for the brick have the same WCS
+    # -> if we have read it once (iswcs=True), we use this info
+    iswcs = False
+
+    #ADM loop through each of the filters and store the number of observations at the
+    #ADM RA and Dec positions of th passed points
+    nobsdict = {} 
+    for filt in ['g','r','z']:
+        nexpfile = (drdir+'/coadd/'+brickname[:3]+'/'+brickname+'/'+
+                        'legacysurvey-'+brickname+'-'+'nexp'+'-'+filt+'.fits.'+extn)
+        #ADM only process the WCS if there is a file corresponding to this filter
+        if (os.path.exists(nexpfile)):
+            img = fits.open(nexpfile)
+            if (iswcs==False):
+                w = WCS(img[extn_nb].header)
+                x, y = w.all_world2pix(ras, decs, 0)
+                iswcs = True
+            #ADM determine the number of observations (NOBS) at each of the passed
+            #ADM locations and store in arrays called nobs_g, nobs_r, nobs_z etc.
+            nobsdict[filt] = img[extn_nb].data[y.astype("int"),x.astype("int")]
+            log.info('Determined NOBS using WCS for {}...t = {:.1f}s'
+                         .format(nexpfile,time()-start))
+        else:
+            log.info('no NEXP file at {}...t = {:.1f}s'.format(nexpfile,time()-start))
+            #ADM if the file doesn't exist, set NOBS = 0 for all of the passed
+            #ADM locations and store in arrays called nobs_g, nobs_r, nobs_z etc.
+            nobsdict[filt] = np.zeros(npts,dtype="uint8")
+
+    log.info('Recorded number of observations for each point in brick {}...t = {:.1f}s'
+                 .format(brickname,time()-start))
+
+    return nobsdict['g'], nobsdict['r'], nobsdict['z']
+
+
+def nobs_at_positions(rasarray,decsarray,
+                      drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"):
+    """Return the number of observations at any positions in a Data Release of the Legacy Surveys
+
+    Parameters
+    ----------
+    rasarray : :class:`~numpy.array`
+        Right Ascensions of interest (degrees)
+    decsarray : :class:`~numpy.array`
+        Declinations of interest (degrees)
+    drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
+       The root directory pointing to a Data Release of the Legacy Surveys
+
+    Returns
+    -------
+    :class:`~numpy.array`
+        The number of observations in the Legacy Surveys at each position in g-band
+    :class:`~numpy.array`
+        The number of observations in the Legacy Surveys at each position in r-band
+    :class:`~numpy.array`
+        The number of observations in the Legacy Surveys at each position in z-band
+
+    Notes
+    -----
+        - See also :func:`nobs_at_positions_in_brick`, which achieves the smae thing for
+          a single brick and presupposes that all of the RAs/Decs are in that one brick
+    """
+    #ADM determine whether the coadd files have extension .gz or .fz based on the DR directory
+    extn, extn_nb = dr_extension(drdir)
+
+    #ADM assign brick names to each of the RAs/Decs
+    from desiutil import brick
+    b = brick.Bricks(bricksize=0.25)
+    bricknames = b.brickname(rasarray,decsarray)
+    log.info('loaded brick class and assigned brick names to positions...t = {:.1f}s'
+                 .format(time()-start))
+
+    #ADM set up output arrays of the number of observations in g, r, z
+    #ADM default to -1 observations, so it's easier to test for bugs
+    nras = len(rasarray)
+    nobs_g = np.zeros(nras,dtype='int8')-1
+    nobs_r = np.zeros(nras,dtype='int8')-1
+    nobs_z = np.zeros(nras,dtype='int8')-1
+
+    #ADM loop through the bricks, based on name and assign numbers of observations
+    #ADM where we have them (otherwise, default to NOBS = 0 for a missing band)
+    for brickname in set(bricknames):
+        wbrick = np.where(bricknames == brickname)
+        ras = rasarray[wbrick]
+        decs = decsarray[wbrick]
+        npts = len(ras)
+
+        # as a speed up, we assume all images in different filters for the brick have the same WCS
+        # -> if we have read it once (iswcs=True), we use this info
+        iswcs = False
+
+        #ADM loop through each of the filters and store the number of observations at the
+        #ADM RA and Dec positions of the passed points
+        nobsdict = {} 
+        for filt in ['g','r','z']:
+            nexpfile = (drdir+'/coadd/'+brickname[:3]+'/'+brickname+'/'+
+                            'legacysurvey-'+brickname+'-'+'nexp'+'-'+filt+'.fits.'+extn)
+            #ADM only process the WCS if there is a file corresponding to this filter
+            if (os.path.exists(nexpfile)):
+                img = fits.open(nexpfile)
+                if (iswcs==False):
+                    w = WCS(img[extn_nb].header)
+                    x, y = w.all_world2pix(ras, decs, 0)
+                    iswcs = True
+                    #ADM determine the number of observations (NOBS) at each of the
+                    #ADM passed locations and store in arrays called nobs_g, nobs_r, nobs_z etc.
+                nobsdict[filt] = img[extn_nb].data[y.astype("int"),x.astype("int")]
+                log.info('Determined NOBS using WCS for {}...t = {:.1f}s'
+                         .format(nexpfile,time()-start))
+            else:
+                #ADM if the file doesn't exist, set NOBS = 0 for passed points that are in
+                #ADM this brick and filter
+                log.info('no NEXP file at {}...t = {:.1f}s'.format(nexpfile,time()-start))
+                nobsdict[filt] = np.zeros(npts,dtype="uint8")
+
+        log.info('Recorded number of observations for each point in brick {}...t = {:.1f}s'
+                 .format(brickname,time()-start))
+
+        #ADM populate the output final arrays based on which points are in this brick
+        nobs_g[wbrick] =  nobsdict['g']
+        nobs_r[wbrick] =  nobsdict['r']
+        nobs_z[wbrick] =  nobsdict['z']
+
+    return nobs_g, nobs_r, nobs_z
+

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -562,9 +562,8 @@ def load_pixweight(inmapfile, nside, pixmap=None):
         #ADM read in the pixel weights file                                                                                                  
         if not os.path.exists(inmapfile):
             log.critical('Input directory does not exist: {}'.format(inmapfile))
-        with fits.open(inmapfile) as hdulist:
-            pixmap = hdulist[0].data
-
+        pixmap = fitsio.read(inmapfile)
+            
     #ADM determine the file's nside, and flag a warning if the passed nside exceeds it                                                                
     npix = len(pixmap)
     truenside = hp.npix2nside(len(pixmap))

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -537,6 +537,43 @@ def whitespace_fits_read(filename, **kwargs):
     return data
 
 
+def load_pixweight(inmapfile, nside, pixmap=None):
+    '''Loads a pixel map from file and resamples to a different HEALPixel resolution (nside)
+
+    Parameters
+    ----------
+    inmapfile : :class:`str`
+        Name of the file containing the pixel weight map
+    nside : :class:`int`
+        After loading, the array will be resampled to this HEALPix nside
+    pixmap: `~numpy.array`, optional, defaults to None
+        Pass a pixel map instead of loading it from file
+
+    Returns
+    -------
+    :class:`~numpy.array`
+        HEALPixel weight map resampled to the requested nside
+    '''
+    import healpy as hp
+
+    if pixmap is not None:
+        log.debug('Using input pixel weight map of length {}.'.format(len(pixmap)))
+    else:
+        #ADM read in the pixel weights file                                                                                                  
+        with fits.open(inmapfile) as hdulist:
+            pixmap = hdulist[0].data
+
+    #ADM determine the file's nside, and flag a warning if the passed nside exceeds it                                                                
+    npix = len(pixmap)
+    truenside = hp.npix2nside(len(pixmap))
+    if truenside < nside:
+        log.warning("downsampling is fuzzy...Passed nside={}, but file {} is stored at nside={}"
+                  .format(nside,pixfile,truenside))
+
+    #ADM resample the map                                                                                                                             
+    return hp.pixelfunc.ud_grade(pixmap,nside,order_in='NESTED',order_out='NESTED')
+
+
 def gitversion():
     """Returns `git describe --tags --dirty --always`,
     or 'unknown' if not a git repo"""

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -560,6 +560,8 @@ def load_pixweight(inmapfile, nside, pixmap=None):
         log.debug('Using input pixel weight map of length {}.'.format(len(pixmap)))
     else:
         #ADM read in the pixel weights file                                                                                                  
+        if not os.path.exists(inmapfile):
+            log.critical('Input directory does not exist: {}'.format(inmapfile))
         with fits.open(inmapfile) as hdulist:
             pixmap = hdulist[0].data
 


### PR DESCRIPTION
This PR creates the tools to better handle imaging survey areas for QA. It includes:
   * A new module `desitarget.imagefootprint` to build HEALPix weight maps of the imaging footprint.
   * An executable (bin) interface for that module to make weight maps from the command line.
   * A loader in `desitarget.io` to resample maps to any HEALPix `nside`.
   * Updates to `desitarget.QA` to handle the new imaging area weight maps.

The code was developed from an earlier script by Anand Raichoor. The main algorithm works by Monte Carlo sampling the Legacy Surveys coadd files for a given Data Release at the pixel-level. A large density of RA/Dec points are generated in order to determine the area-weighted fraction of locations that are in pixels that have one or more observations.

Generating 10million random points per sq. deg., the weight map can be produced at a rate of about 2500 bricks per minute across 32 processors on a single node on cori.

Here is a comparison of the DR4 QA plots before

![skymap-elgold](https://user-images.githubusercontent.com/13952581/38958240-3a939c44-434c-11e8-9a59-2d6f3d2c2752.png)
![histo-elgold](https://user-images.githubusercontent.com/13952581/38958243-3c76d120-434c-11e8-832e-ad24d1f8a7dd.png)

and after

![skymap-elg](https://user-images.githubusercontent.com/13952581/38958261-423cfc74-434c-11e8-8b71-86f008622c82.png)
![histo-elg](https://user-images.githubusercontent.com/13952581/38958265-43de366a-434c-11e8-9049-e1f22ac3a976.png)

the adoption of the new imaging weights.