### PR TITLE
Install files under mock/data recursively

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup_keywords['test_suite']='{name}.test.{name}_test_suite.{name}_test_suite'.f
 #
 setup_keywords['package_data'] = {'desitarget': ['data/*',],
                                   'desitarget.test': ['t/*',],
-                                  'desitarget.mock': ['data/*',],
+                                  'desitarget.mock': [os.path.relpath(_,'py/desitarget/mock') for _ in [os.path.join(_[0],'*') for _ in os.walk('py/desitarget/mock/data')]],
                                  }
 #
 # Run setup command.


### PR DESCRIPTION
Fixes #315 (the wildcards under package_data entries don't include subdirs, so e.g. `mock/data/dr2` wasn't being copied to the installation path). Maybe someone with setup.py expertise can suggest a cleaner solution. The idea is to avoid having to list each subdir individually. 

Not sure if this also needs to be applied to the other package_data entries.