### PR TITLE
Add IVARs to GFA output

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.21.0 (unreleased)
 -------------------
 
-* Add ``RA_IVAR`` and ``DEC_IVAR`` to the GFA Data Model [`PR #328`_].
+* Add ``RA_IVAR`` and ``DEC_IVAR`` to the GFA Data Model [`PR #329`_].
 * Update the Gaia Data Model [`PR #327`_]:
    * Output columns formatted as expected downstream for GFA assignment.
    * Align Gaia Data Model in matching and I/O with the Legacy Surveys.
@@ -64,7 +64,7 @@ desitarget Change Log
 .. _`PR #324`: https://github.com/desihub/desitarget/pull/324
 .. _`PR #325`: https://github.com/desihub/desitarget/pull/325
 .. _`PR #327`: https://github.com/desihub/desitarget/pull/327
-.. _`PR #328`: https://github.com/desihub/desitarget/pull/328
+.. _`PR #328`: https://github.com/desihub/desitarget/pull/329
 
 
 0.20.1 (2018-03-29)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -64,7 +64,7 @@ desitarget Change Log
 .. _`PR #324`: https://github.com/desihub/desitarget/pull/324
 .. _`PR #325`: https://github.com/desihub/desitarget/pull/325
 .. _`PR #327`: https://github.com/desihub/desitarget/pull/327
-.. _`PR #328`: https://github.com/desihub/desitarget/pull/329
+.. _`PR #329`: https://github.com/desihub/desitarget/pull/329
 
 
 0.20.1 (2018-03-29)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.21.0 (unreleased)
 -------------------
 
+* Add ``RA_IVAR`` and ``DEC_IVAR`` to the GFA Data Model [`PR #328`_].
 * Update the Gaia Data Model [`PR #327`_]:
    * Output columns formatted as expected downstream for GFA assignment.
    * Align Gaia Data Model in matching and I/O with the Legacy Surveys.
@@ -63,6 +64,7 @@ desitarget Change Log
 .. _`PR #324`: https://github.com/desihub/desitarget/pull/324
 .. _`PR #325`: https://github.com/desihub/desitarget/pull/325
 .. _`PR #327`: https://github.com/desihub/desitarget/pull/327
+.. _`PR #328`: https://github.com/desihub/desitarget/pull/328
 
 
 0.20.1 (2018-03-29)

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -29,7 +29,8 @@ start = time()
 #ADM the current data model for columns in the GFA files
 gfadatamodel = np.array([], dtype=[
     ('TARGETID', 'i8'),  ('BRICKID', 'i4'), ('BRICK_OBJID', 'i4'),  
-    ('RA', 'f8'), ('DEC', 'f8'), ('TYPE', 'S4'),
+    ('RA', 'f8'), ('DEC', 'f8'), ('RA_IVAR', 'f8'), ('DEC_IVAR', 'f8'), 
+    ('TYPE', 'S4'),
     ('FLUX_G', 'f4'), ('FLUX_R', 'f4'), ('FLUX_Z', 'f4'),
     ('FLUX_IVAR_G', 'f4'), ('FLUX_IVAR_R', 'f4'), ('FLUX_IVAR_Z', 'f4'),    
     ('REF_ID', 'i8'), 
@@ -378,8 +379,7 @@ def select_gfas(infiles, maglim=18, numproc=4,
     -------
     :class:`numpy.ndarray`
         GFA objects from Gaia across all of the passed input files, formatted 
-        according to `desitarget.gfa.gfadatamodel` but with ``GAIA_`` removed
-        from column names.
+        according to `desitarget.gfa.gfadatamodel`.
     
     Notes
     -----

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -29,7 +29,7 @@ start = time()
 #ADM the current data model for columns in the GFA files
 gfadatamodel = np.array([], dtype=[
     ('TARGETID', 'i8'),  ('BRICKID', 'i4'), ('BRICK_OBJID', 'i4'),  
-    ('RA', 'f8'), ('DEC', 'f8'), ('RA_IVAR', 'f8'), ('DEC_IVAR', 'f8'), 
+    ('RA', 'f8'), ('DEC', 'f8'), ('RA_IVAR', 'f4'), ('DEC_IVAR', 'f4'),
     ('TYPE', 'S4'),
     ('FLUX_G', 'f4'), ('FLUX_R', 'f4'), ('FLUX_Z', 'f4'),
     ('FLUX_IVAR_G', 'f4'), ('FLUX_IVAR_R', 'f4'), ('FLUX_IVAR_Z', 'f4'),    


### PR DESCRIPTION
Adds `RA_IVAR` and `DEC_IVAR` to the GFA Data Model.

New example output file at `/global/cscratch1/sd/adamyers/gfas-dr6.fits`