### PR TITLE
fix mock target QA

### DIFF
--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -2138,7 +2138,6 @@ def _in_desi_footprint(targs):
 
     return windesi
 
-
 def make_qa_plots(targs, qadir='.', targdens=None, max_bin_area=1.0, weight=True,
                   imaging_map_file=None, truths=None):
     """Make DESI targeting QA plots given a passed set of targets


### PR DESCRIPTION
I believe that #324 caused the problems @weaverba137 is seeing in https://github.com/desihub/desitest/issues/8, which this PR addresses. 

In essence, updates to `bin/run_target_qa` for "real" targets were made which were not propagated to "mock" targets.  I've consolidated the code so that QA for both types of targets is now built the same way (using `QA.make_qa_plots`), and removed the obsolete `QA.mock_make_qa_plots` function.

I tested this on the 18.3 reference run catalogs.  Here's the output treating the catalogs as mocks:
  http://portal.nersc.gov/project/cosmo/temp/ioannis/mock-qa/
which was made with
```bash
run_target_qa '/global/projecta/projectdirs/desi/datachallenge/reference_runs/18.3/targets/targets.fits'  /project/projectdirs/cosmo/www/temp/ioannis/mock-qa --mocks
```
and here's the output treating the same catalogs as "real" catalogs:
http://portal.nersc.gov/project/cosmo/temp/ioannis/test-qa/
which was made with
```bash
run_target_qa '/global/projecta/projectdirs/desi/datachallenge/reference_runs/18.3/targets/targets.fits'  /project/projectdirs/cosmo/www/temp/ioannis/test-qa
```