### PR TITLE
Write Gaia columns into sweeps

### DIFF
--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -25,7 +25,7 @@ ap.add_argument('-g', '--gaiadir',
                 help="Base directory for chunked Gaia files (defaults to ['project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'] for NERSC)",
                 default='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom')
 ap.add_argument('-m', '--maglim', type=float, 
-                help='Magnitude limit on GFA trgets in Gaia G-band (defaults to [18])',
+                help='Magnitude limit on GFA targets in Gaia G-band (defaults to [18])',
                 default=18)
 ap.add_argument('-n', "--numproc", type=int,
                 help='number of concurrent processes to use (defaults to [{}])'.format(nproc),

--- a/bin/write_gaia_matches
+++ b/bin/write_gaia_matches
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import sys
+from desitarget import io
+from desitarget.gaiamatch import write_gaia_matches
+from time import time
+start = time()
+
+#import warnings
+#warnings.simplefilter('error')
+
+import multiprocessing
+nproc = multiprocessing.cpu_count() // 2
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Match sweeps files to Gaia and rewrite files with the Gaia columns added')
+ap.add_argument("src", 
+                help="Sweeps file or root directory with sweeps files")
+ap.add_argument("dest", 
+                help="Output directory")
+ap.add_argument("--gaiadir", 
+                help="Base directory for chunked Gaia files (defaults to ['project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'] for NERSC)",
+                default='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom')
+ap.add_argument("--numproc", type=int,
+                help='number of concurrent processes to use [{}]'.format(nproc),
+                default=nproc)
+
+ns = ap.parse_args()
+infiles = io.list_sweepfiles(ns.src)
+if len(infiles) == 0:
+    log.critical('no sweep files found')
+    sys.exit(1)
+
+log.info("running on {} processors".format(ns.numproc))
+
+write_gaia_matches(infiles, numproc=ns.numproc, outdir=ns.dest, gaiadir=ns.gaiadir)
+
+log.info('Wrote sweeps files matched to Gaia to {}...t={:.1f}s'.format(ns.dest, time()-start))
+

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.22.1 (unreleased)
 -------------------
 
-* Match sweeps to Gaia and write new sweeps with Gaia columns [`PR #340`_].
+* Match sweeps to Gaia and write new sweeps with Gaia columns [`PR #340`_]:
+   * Also add BRIGHTSTARINBLOB (if available) to target output files.
+   * And include a flag to call STD star cuts function without Gaia columns.
 
 .. _`PR #340`: https://github.com/desihub/desitarget/pull/340
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.22.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Match sweeps to Gaia and write new sweeps with Gaia columns [`PR #340`_].
+
+.. _`PR #340`: https://github.com/desihub/desitarget/pull/340
 
 0.22.0 (2018-08-03)
 -------------------
@@ -21,6 +23,9 @@ desitarget Change Log
    * Rename ``FSTD`` to be ``STD`` throughout.
    * QA fails gracefully if weight maps for  systematics aren't passed.
 
+.. _`wiki`: https://desi.lbl.gov/trac/wiki/TargetSelectionWG/TargetSelection
+.. _`PR #338`: https://github.com/desihub/desitarget/pull/338
+
 0.21.1 (2018-07-26)
 -------------------
 
@@ -32,9 +37,8 @@ desitarget Change Log
    * Make several new systematics plots.
    * Make new plots of parallax and proper motion information from Gaia.
 
-.. _`wiki`: https://desi.lbl.gov/trac/wiki/TargetSelectionWG/TargetSelection
 .. _`PR #334`: https://github.com/desihub/desitarget/pull/334
-.. _`PR #338`: https://github.com/desihub/desitarget/pull/338
+
 
 0.21.0 (2018-07-18)
 -------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -2584,8 +2584,8 @@ def make_qa_plots(targs, qadir='.', targdens=None, max_bin_area=1.0, weight=True
                   'STD': 200, 'STD_BRIGHT': 50,
                   'LRG_1PASS': 1000, 'LRG_2PASS': 500,
                   'BGS_FAINT': 2500, 'BGS_BRIGHT': 2500, 'BGS_ANY': 5000,
-                  'MWS_ANY': 2000, 'MWS_MAIN': 10000, 'MWS_WD': 20000, 'MWS_NEARBY': 50,
-                  'MWS_MAIN_RED': 10000, 'MWS_MAIN_BLUE': 10000}
+                  'MWS_ANY': 2000, 'MWS_MAIN': 10000, 'MWS_WD': 50, 'MWS_NEARBY': 50,
+                  'MWS_MAIN_RED': 4000, 'MWS_MAIN_BLUE': 4000}
 
     for objtype in targdens:
         if 'ALL' in objtype:

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -1842,15 +1842,16 @@ def qahisto(cat, objtype, qadir='.', targdens=None, upclip=None, weights=None, m
     plt.legend(loc='upper left', frameon=False)
 
     #ADM add some metric conditions which are considered a failure for this
-    #ADM target class...
-
-    #ADM determine the cumulative version of the histogram of densities
-    cum = np.cumsum(h)/np.sum(h)
-    #ADM extract which bins correspond to the "68%" of central values
-    w = np.where( (cum > 0.15865) & (cum < 0.84135) )[0]
-    minbin, maxbin = b[w][0], b[w][-1]
-    #ADM this is a good plot if the peak value is within the ~68% of central values
-    good = (targdens[objtype] > minbin) & (targdens[objtype] < maxbin)
+    #ADM target class...only for classes that have an expected target density
+    good = True
+    if targdens[objtype] > 0.:
+        #ADM determine the cumulative version of the histogram of densities
+        cum = np.cumsum(h)/np.sum(h)
+        #ADM extract which bins correspond to the "68%" of central values
+        w = np.where( (cum > 0.15865) & (cum < 0.84135) )[0]
+        minbin, maxbin = b[w][0], b[w][-1]
+        #ADM this is a good plot if the peak value is within the ~68% of central values
+        good = (targdens[objtype] > minbin) & (targdens[objtype] < maxbin)
     
     #ADM write out the plot
     pngfile = os.path.join(qadir, '{}-{}.png'.format(fileprefix,objtype))

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -697,7 +697,8 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
           gfluxivar=None, rfluxivar=None, zfluxivar=None, objtype=None,
           gaia=None, astrometricexcessnoise=None, paramssolved=None,
           pmra=None, pmdec=None, parallax=None, dupsource=None, 
-          gaiagmag=None, gaiabmag=None, gaiarmag=None, bright=False):
+          gaiagmag=None, gaiabmag=None, gaiarmag=None, bright=False,
+          usegaia=True):
     """Select STD targets using color cuts and photometric quality cuts (PSF-like
     and fracflux).  See isSTD_colors() for additional info.
 
@@ -730,10 +731,15 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
         dupsource: array_like or None
             Whether the source is a duplicate in Gaia (as in the Gaia Data model).
         gaiagmag, gaiabmag, gaiarmag: array_like or None
-            (Extinction-corrected) Gaia-based g-, b- and r-band MAGNITUDES
-            (same units as the Gaia data model).
-        bright: apply magnitude cuts for "bright" conditions; otherwise, choose
-          "normal" brightness standards. Cut is performed on `gaiagmag`.
+            Gaia-based g-, b- and r-band MAGNITUDES (same units as Gaia data model).
+        bright: boolean, defaults to ``False`` 
+           if ``True`` apply magnitude cuts for "bright" conditions; otherwise, 
+           choose "normal" brightness standards. Cut is performed on `gaiagmag`.
+        usegaia: boolean, defaults to ``True``
+           if ``True`` then  call :func:`~desitarget.cuts.isSTD_gaia` to set the 
+           logic cuts. If Gaia is not available (perhaps if you're using mocks)
+           then send ``False`` and pass `gaiagmag` as 22.5-2.5*np.log10(`robs`) 
+           where `robs` is `rflux` without a correction.for Galactic extinction.
 
     Returns:
         mask : boolean array, True if the object has colors like a STD star
@@ -752,10 +758,11 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
     std &= isSTD_colors(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux)
 
     #ADM apply the Gaia quality cuts.
-    std &= isSTD_gaia(primary=primary, gaia=gaia, astrometricexcessnoise=astrometricexcessnoise, 
-                      pmra=pmra, pmdec=pmdec, parallax=parallax,
-                      dupsource=dupsource, paramssolved=paramssolved,
-                      gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag)
+    if usegaia:
+        std &= isSTD_gaia(primary=primary, gaia=gaia, astrometricexcessnoise=astrometricexcessnoise, 
+                          pmra=pmra, pmdec=pmdec, parallax=parallax,
+                          dupsource=dupsource, paramssolved=paramssolved,
+                          gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag)
 
     #ADM apply type=PSF cut
     std &= _psflike(objtype)

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -240,6 +240,16 @@ def gaia_gfas_from_sweep(objects, maglim=18., gaiabounds=[0.,360.,-90.,90.],
     if isinstance(objects, str):
         objects = desitarget.io.read_tractor(objects)
 
+    #ADM add the Gaia coordinate columns if they don't exist
+    if not "GAIA_RA" in objects.dtype.names:
+        gc = np.array([], dtype=[('GAIA_RA', '>f8'), ('GAIA_DEC', '>f8')])
+        dt = objects.dtype.descr + gc.dtype.descr
+        nrows = len(objects)
+        objectswgc = np.zeros(nrows, dtype=dt)
+        for col in objects.dtype.names:
+            objectswgc[col] = objects[col]
+        objects = objectswgc
+
     #ADM As a mild speed up, only consider sweeps objects brighter than 3 mags
     #ADM fainter than the passed Gaia magnitude limit. Note that Gaia G-band
     #ADM approximates SDSS r-band. 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -38,6 +38,7 @@ oldtscolumns = [
     ]
 
 #ADM this is an empty array of the full TS data model columns and dtypes
+#ADM other columns can be added in read_tractor
 tsdatamodel = np.array([], dtype=[
         ('RELEASE', '>i4'), ('BRICKID', '>i4'), ('BRICKNAME', 'S8'),
         ('OBJID', '<i4'), ('TYPE', 'S4'), ('RA', '>f8'), ('RA_IVAR', '>f4'),
@@ -287,6 +288,11 @@ def read_tractor(filename, header=False, columns=None):
     if (columns is None) and \
        (('BRICK_PRIMARY' in fxcolnames) or ('brick_primary' in fxcolnames)):
         readcolumns.append('BRICK_PRIMARY')
+
+    #ADM if BRIGHTSTARINBLOB exists (it does for DR7, not for DR6) add it
+    if (columns is None) and \
+       (('BRIGHTSTARINBLOB' in fxcolnames) or ('brightstarinblob' in fxcolnames)):
+        readcolumns.append('BRIGHTSTARINBLOB')
 
     #ADM if SUBPRIORITY was passed by the MWS group, add it to the columns to read
     if (columns is None) and \


### PR DESCRIPTION
The data model for the DR6 sweeps currently doesn't include the Gaia columns necessary for target selection. This PR creates a simple function and executable that can write the sweeps with only the columns necessary for target selection (including the Gaia columns). I also addressed a few typos and minor bugs.

Example outputs are in `/global/cscratch1/sd/adamyers/gaiamatch/dr6/sweep/6.0`.