### PR TITLE
Fix stdstar bit names

### DIFF
--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -1417,7 +1417,7 @@ def _load_targdens(bitnames=None):
     targdens['LRG'] = targdict['ntarget_lrg']
     targdens['QSO'] = targdict['ntarget_qso'] + targdict['ntarget_badqso']
     targdens['BGS_ANY'] = targdict['ntarget_bgs_bright'] + targdict['ntarget_bgs_faint']
-    targdens['STD'] = 0
+    targdens['STD_FAINT'] = 0
     targdens['STD_BRIGHT'] = 0
     targdens['MWS_ANY'] = targdict['ntarget_mws']
     #ADM set "ALL" to be the sum over all the target classes
@@ -2581,7 +2581,7 @@ def make_qa_plots(targs, qadir='.', targdens=None, max_bin_area=1.0, weight=True
     #ADM clip the target densities at an upper density to improve plot edges
     #ADM by rejecting highly dense outliers
     upclipdict = {'ELG': 4000, 'LRG': 1200, 'QSO': 400, 'ALL': 8000,
-                  'STD': 200, 'STD_BRIGHT': 50,
+                  'STD_FAINT': 200, 'STD_BRIGHT': 50,
                   'LRG_1PASS': 1000, 'LRG_2PASS': 500,
                   'BGS_FAINT': 2500, 'BGS_BRIGHT': 2500, 'BGS_ANY': 5000,
                   'MWS_ANY': 2000, 'MWS_MAIN': 10000, 'MWS_WD': 50, 'MWS_NEARBY': 50,

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2153,7 +2153,7 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
     if "STD" in tcnames:
         #ADM Make sure to pass all of the needed columns! At one point we stopped
         #ADM passing objtype, which meant no standards were being returned.
-        std = isSTD(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
+        std_faint = isSTD(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
             gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
             gfracmasked=gfracmasked, rfracmasked=rfracmasked, objtype=objtype,
             zfracmasked=zfracmasked, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
@@ -2171,7 +2171,7 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
             gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag, bright=True)
     else:
         #ADM if not running the standards selection, set everything to arrays of False
-        std, std_bright = ~primary, ~primary
+        std_faint, std_bright = ~primary, ~primary
 
 
     if "BGS" in tcnames:
@@ -2241,7 +2241,7 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
     desi_target |= lrg2pass * desi_mask.LRG_2PASS
 
     # Standards; still need to set STD_WD
-    desi_target |= std * desi_mask.STD
+    desi_target |= std_faint * desi_mask.STD_FAINT
     desi_target |= std_bright * desi_mask.STD_BRIGHT
 
     # BGS bright and faint, south

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -31,12 +31,16 @@ desi_mask:
     #- Calibration targets
     - [SKY,         32, "Blank sky locations",
         {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [STD,         33, "standard stars", {obsconditions: DARK|GRAY}]
+    - [STD_FAINT,   33, "Standard stars for dark/gray conditions", {obsconditions: DARK|GRAY}]
     - [STD_WD,      34, "White Dwarf stars", {obsconditions: DARK|GRAY|BRIGHT}]
-    - [STD_BRIGHT,  35, "standard stars for BRIGHT conditions",
+    - [STD_BRIGHT,  35, "Standard stars for BRIGHT conditions",
         {obsconditions: BRIGHT}]
     - [BAD_SKY,      36, "Blank sky locations that are imperfect but still useable",
         {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+
+    #- Reserving some bits that we may not use
+    # - [STD_FAINT_BEST,   37, "High quality faint standard stars", {obsconditions: DARK|GRAY}]
+    # - [STD_BRIGHT_BEST,  38, "High quality bright standard stars", {obsconditions: BRIGHT}]
 
     #- Reserved convenience bits that can, e.g., be set downstream of desitarget
     - [NO_TARGET,   49, "No known target at this location",
@@ -171,10 +175,12 @@ priorities:
         LRG_2PASS_SOUTH: SAME_AS_LRG
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
-        STD:        -1
+        STD_FAINT:  -1
         STD_WD:     -1
         SKY:        -1
         STD_BRIGHT: -1
+        # STD_FAINT_BEST: -1
+        # STD_BRIGHT_BEST: -1
         NO_TARGET:  -1
         #- placeholders to show we haven't forgotten these bits, but the
         #- exact bits in the other sections define the priorities

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -791,7 +791,7 @@ def write_targets_truth(targets, truth, trueflux, truewave, skytargets,
 
     if nobj > 0:
     # Write out the dark- and bright-time standard stars.
-        for stdsuffix, stdbit in zip(('dark', 'bright'), ('STD', 'STD_BRIGHT')):
+        for stdsuffix, stdbit in zip(('dark', 'bright'), ('STD_FAINT', 'STD_BRIGHT')):
             stdfile = mockio.findfile('standards-{}'.format(stdsuffix), nside, healpix, basedir=output_dir)
             istd = ( (targets['DESI_TARGET'] & desi_mask.mask(stdbit)) |
                      (targets['DESI_TARGET'] & desi_mask.mask('STD_WD')) ) != 0

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -791,7 +791,7 @@ def write_targets_truth(targets, truth, trueflux, truewave, skytargets,
 
     if nobj > 0:
     # Write out the dark- and bright-time standard stars.
-        for stdsuffix, stdbit in zip(('dark', 'bright'), ('STD_FSTAR', 'STD_BRIGHT')):
+        for stdsuffix, stdbit in zip(('dark', 'bright'), ('STD', 'STD_BRIGHT')):
             stdfile = mockio.findfile('standards-{}'.format(stdsuffix), nside, healpix, basedir=output_dir)
             istd = ( (targets['DESI_TARGET'] & desi_mask.mask(stdbit)) |
                      (targets['DESI_TARGET'] & desi_mask.mask('STD_WD')) ) != 0

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -3150,7 +3150,7 @@ class STARMaker(SelectTargets):
                         gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
                         usegaia=False, bright=False, gaiagmag=22.5-2.5*np.log10(obs_rflux) )
 
-        targets['DESI_TARGET'] |= (std != 0) * self.desi_mask.STD
+        targets['DESI_TARGET'] |= (std != 0) * self.desi_mask.STD_FAINT
 
         # Select bright-time STD targets.  Temporary hack to use the BOSS
         # standard-star selection algorith.

--- a/py/desitarget/sandbox/cuts.py
+++ b/py/desitarget/sandbox/cuts.py
@@ -696,7 +696,7 @@ def apply_sandbox_cuts(objects,FoMthresh=None, MethodELG='XD'):
         desi_target |= elg * desi_mask.ELG
     #desi_target |= qso * desi_mask.QSO
 
-    #desi_target |= fstd * desi_mask.STD_FSTAR
+    #desi_target |= fstd * desi_mask.STD_FAINT
 
     bgs_target = np.zeros_like(desi_target)
     #bgs_target = bgs_bright * bgs_mask.BGS_BRIGHT


### PR DESCRIPTION
Changes in this PR:
* Rename STD -> STD_FAINT for symmetry with STD_BRIGHT.
  * Very recently this was renamed from STD_FSTAR -> STD, but now we're renaming it again.
* Fix mock targets usage of STD_FSTAR vs. STD vs. STD_FAINT and related function calls.
* Fix mock targets STD/MWS selections which now require Gaia.
* Reserve bits for STD_FAINT_BEST and STD_BRIGHT_BEST, but don't use them yet (they are still commented).

@geordie666 made the original changes which I vetted, and then I hijacked this to do the STD -> STD_FAINT renaming too, so I'll punt it back to him for final approval.

Once this is merged I'll make a new desitarget tag and I have a desisim PR ready to go which will re-fix desisim for the bit renaming.  I'm not submitting that PR yet because Travis tests will fail anyway until this PR is merged.

Due to great foresight I believe fiberassign is already ready for the new bit names, but I will also verify that after desitarget + desisim have been updated.

