### PR TITLE
Update code that produces GFA targets

### DIFF
--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -44,7 +44,8 @@ if len(infiles) == 0:
 
 log.info('running on {} processors...t={:.1f}mins'.format(ns.numproc, (time()-time0)/60.))
 
-gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, gaiadir=ns.gaiadir)
+gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, 
+                   gaiamatch=ns.gaiamatch, gaiadir=ns.gaiadir)
 
 io.write_gfas(ns.dest, gfas, indir=ns.surveydir, nside=nside)
 

--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -27,9 +27,12 @@ ap.add_argument('-g', '--gaiadir',
 ap.add_argument('-m', '--maglim', type=float, 
                 help='Magnitude limit on GFA targets in Gaia G-band (defaults to [18])',
                 default=18)
+ap.add_argument("--gaiamatch", action='store_true',
+                help="DO match to Gaia DR2 chunks files in order to populate Gaia columns for the GFA locations")
 ap.add_argument('-n', "--numproc", type=int,
                 help='number of concurrent processes to use (defaults to [{}])'.format(nproc),
                 default=nproc)
+
 ns = ap.parse_args()
 
 infiles = io.list_sweepfiles(ns.surveydir)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,14 @@ desitarget Change Log
 0.23.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Update GFA targets [`PR #342`_]:
+    * Handle reading Gaia from sweeps as well as matching. Default to *not* matching.
+    * Makes Gaia matching radius stricter to return only the best Gaia objects.
+    * Retains Gaia RA/Dec when matching, instead of RA/Dec from sweeps.
+    * Fixes a bug where Gaia objects in some HEALPixels weren't being read.
+    * Add Gaia epoch to the GFA file header (still needs passed from the sweeps).
+
+.. _`PR #342`: https://github.com/desihub/desitarget/pull/342
 
 0.23.0 (2018-08-09)
 -------------------

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -158,13 +158,13 @@ def find_gaia_files(objs, neighbors=True,
     #ADM Legacy Surveys do NOT use the NESTED scheme for storing Gaia files
     theta, phi = np.radians(90-objs["DEC"]), np.radians(objs["RA"])
 
+    #ADM retrieve the pixels in which the locations lie
+    pixnum = hp.ang2pix(nside, theta, phi)
     #ADM if neighbors was sent, then retrieve all pixels that touch each
     #ADM pixel covered by the provided locations, to prevent edge effects...
     if neighbors:
-        pixnum = np.hstack(hp.pixelfunc.get_all_neighbours(nside, theta, phi))
-    #ADM ...otherwise just retrieve the pixels in which the locations lie
-    else:
-        pixnum = hp.ang2pix(nside, theta, phi)
+        pixnum = np.hstack([pixnum, 
+            np.hstack(hp.pixelfunc.get_all_neighbours(nside, theta, phi))])
 
     #ADM retrieve only the UNIQUE pixel numbers. It's possible that only
     #ADM one pixel was produced, so guard against pixnum being non-iterable

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -272,7 +272,7 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
     if gaiamatch:
         gaiainfo = match_gaia_to_primary(objects, gaiadir=gaiadir,
                                      retaingaia=True, gaiabounds=gaiabounds)
-#        log.info('Done with Gaia match...t = {:.1f}s'.format(time()-start))
+        log.info('Done with Gaia match...t = {:.1f}s'.format(time()-start))
         #ADM add the Gaia column information to the primary array
         for col in gaiainfo.dtype.names:
             objects[col] = gaiainfo[col][:nobjs]
@@ -337,9 +337,10 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
     w = np.where(gfas['GAIA_PHOT_G_MEAN_MAG'] < maglim)[0]
     gfas = gfas[w]
     
-    #ADM a final clean-up to remove columns that are Nan
+    #ADM a final clean-up to remove columns that are Nan (from
+    #ADM Gaia-matching) or are 0 (in the sweeps)
     for col in ["PMRA","PMDEC"]:
-        w = np.where(~np.isnan(gfas[col]))[0]
+        w = np.where( ~np.isnan(gfas[col]) & (gfas[col] != 0) )[0]
         gfas = gfas[w]
 #    log.info('Removed {} Gaia objects with NaN columns...t = {:.1f}s'
 #             .format(len(objects)-len(gfas),time()-start))

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -244,6 +244,10 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
     if isinstance(objects, str):
         objects = desitarget.io.read_tractor(objects)
 
+    #ADM issue a warning if gaiamatch was not sent but there's no Gaia information
+    if np.max(objects['PARALLAX']) == 0. and ~gaiamatch:
+        log.warning("Zero objects have a parallax. Did you mean to send gaiamatch?")
+
     #ADM add the Gaia coordinate columns if they don't exist and
     #ADM if Gaia-matching was requested
     if gaiamatch and not "GAIA_RA" in objects.dtype.names:

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -270,7 +270,9 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
 #    log.info('Starting Gaia match for {} objects...t = {:.1f}s'
 #             .format(nobjs,time()-start))
     if gaiamatch:
-        gaiainfo = match_gaia_to_primary(objects, gaiadir=gaiadir,
+        #ADM match with a fairly discriminating radius (0.1 arcsec) to just
+        #ADM get the best sweeps-Gaia correspondence
+        gaiainfo = match_gaia_to_primary(objects, matchrad=0.1, gaiadir=gaiadir,
                                      retaingaia=True, gaiabounds=gaiabounds)
         log.info('Done with Gaia match...t = {:.1f}s'.format(time()-start))
         #ADM add the Gaia column information to the primary array

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -227,7 +227,7 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
         Magnitude limit for GFAs in Gaia G-band.
     gaiamatch : defaults to ``False``
         If ``True``, match to Gaia DR2 chunks files and populate
-        Gaia columns to facilitate the MWS selection
+        Gaia columns, otherwise assume those columns already exist
     gaiabounds : :class:`list`, optional, defaults to the whole sky
         The area over which to retrieve Gaia objects that don't match a sweeps object. 
         Pass a 4-entry list to form a box bounded by [RAmin, RAmax, DECmin, DECmax].
@@ -378,7 +378,7 @@ def decode_sweep_name(sweepname):
     return [ramin,ramax,decmin,decmax]
 
 
-def select_gfas(infiles, maglim=18, numproc=4,
+def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False,
             gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'):
     """Create a set of GFA locations using Gaia
 
@@ -390,6 +390,9 @@ def select_gfas(infiles, maglim=18, numproc=4,
         Magnitude limit for GFAs in Gaia G-band.
     numproc : :class:`int`, optional, defaults to 4
         The number of parallel processes to use.
+    gaiamatch : defaults to ``False``
+        If ``True``, match to Gaia DR2 chunks files and populate
+        Gaia columns, otherwise assume those columns already exist
     gaiadir : :class:`str`, optional, defaults to Gaia DR2 path at NERSC
         Root directory of a Gaia Data Release as used by the Legacy Surveys.
 
@@ -422,7 +425,7 @@ def select_gfas(infiles, maglim=18, numproc=4,
         bounds = decode_sweep_name(fn)
 
         return gaia_gfas_from_sweep(fn, maglim=maglim, 
-                                    gaiadir=gaiadir, gaiabounds=bounds)
+                    gaiamatch=gaiamatch, gaiadir=gaiadir, gaiabounds=bounds)
 
     #ADM this is just to count sweeps files in _update_status 
     nfile = np.zeros((), dtype='i8')

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -289,12 +289,14 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
         #ADM populate these additional objects
         for col in gaiainfo.dtype.names:
             supg[col] = gaiainfo[col][nobjs:]
-        #ADM store the Gaia RA/DEC as the default for objects with no sweeps match
-        for col in ["RA","DEC"]:
-            supg[col] = supg["GAIA_"+col]
 
         #ADM combine the primary and supplemental arrays
         objects = np.hstack([objects,supg])
+
+        #ADM store the Gaia RA/DEC as the default for matched objects
+        #ADM as it's really the Gaia astrometry we want
+        for col in ["RA","DEC"]:
+            objects[col] = objects["GAIA_"+col]
 
     #ADM only retain objects with Gaia matches
     #ADM it's fine to propagate an empty array if there are no matches

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -529,7 +529,7 @@ def write_skies(filename, data, indir=None, apertures_arcsec=None,
     fitsio.write(filename, data, extname='SKY_TARGETS', header=hdr, clobber=True)
 
 
-def write_gfas(filename, data, indir=None, nside=None):
+def write_gfas(filename, data, indir=None, nside=None, gaiaepoch=None):
     """Write a catalogue of Guide/Focus/Alignment targets.
 
     Parameters
@@ -541,9 +541,12 @@ def write_gfas(filename, data, indir=None, nside=None):
     indir : :class:`str`, optional, defaults to None
         Name of input Legacy Survey Data Release directory, write to header
         of output file if passed (and if not None).
-    nside: :class:`int`
+    nside: :class:`int`, defaults to None
         If passed, add a column to the GFAs array popluated with HEALPixels 
         at resolution `nside`
+    gaiaepoch: :class:`float`, defaults to None
+        Gaia proper motion reference epoch. If not None, write to header of
+        output file. If None, default to an epoch of 2015.5
     """
     #ADM set up the default logger
     from desiutil.log import get_logger
@@ -569,6 +572,12 @@ def write_gfas(filename, data, indir=None, nside=None):
         data = rfn.append_fields(data, 'HPXPIXEL', hppix, usemask=False)
         hdr['HPXNSIDE'] = nside
         hdr['HPXNEST'] = True
+
+    hdr['REFEPOCH'] =  {'name': 'REFEPOCH',
+                        'value': 2015.5,
+                        'comment': "Gaia Proper Motion Reference Epoch"}
+    if gaiaepoch is not None:
+        hdr['REFEPOCH'] = gaiaepoch
 
     fitsio.write(filename, data, extname='GFA_TARGETS', header=hdr, clobber=True)
 


### PR DESCRIPTION
Better processing of GFA targets:

- Handles reading Gaia columns directly from the sweeps in addition to matching to Gaia files. 
- Defaults to *not* matching to Gaia files.
- Makes Gaia matching radius stricter to return only the best Gaia objects.
- Retains Gaia RA/Dec when matching, instead of RA/Dec from sweeps.
- Fixes a bug where potential Gaia matches in some HEALPixels weren't being read.
- Adds a default Gaia epoch to the GFA file header (the actual epoch still needs passed through from the sweeps).

Should fix:

https://github.com/desihub/desitarget/issues/319
https://github.com/desihub/desitarget/issues/232