### PR TITLE
adapt isSTD_colors to deal with differences in north/south color-cuts

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 0.23.1 (unreleased)
 -------------------
 
+* Adapt cuts.isSTD_colors to deal with different north/south color-cuts [`PR
+  #355`_]: 
 * Refactor to allow separate commissioning and SV target selections [`PR #346`_]:
     * Added ``sv`` and ``commissioning`` directories.
     * New infrastructure to have different cuts for SV and commissioning:
@@ -27,6 +29,7 @@ desitarget Change Log
 .. _`PR #342`: https://github.com/desihub/desitarget/pull/342
 .. _`PR #345`: https://github.com/desihub/desitarget/pull/345
 .. _`PR #346`: https://github.com/desihub/desitarget/pull/346
+.. _`PR #355`: https://github.com/desihub/desitarget/pull/355
 
 0.23.0 (2018-08-09)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -806,9 +806,10 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
         std &= gaiagmag >= gbright
         std &= gaiagmag < gfaint
     else:
-        gmag = 22.5 - 2.5 * np.log10( gflux.clip(1e-16) )
-        std &= gmag >= gbright
-        std &= gmag < gfaint
+        # Use LS r-band as a Gaia G-band proxy.
+        gaiamag_proxy = 22.5 - 2.5 * np.log10( rflux.clip(1e-16) )
+        std &= gaiamag_ >= gbright
+        std &= gaiamag_ < gfaint
 
     return std
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -746,16 +746,17 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
            if ``True`` apply magnitude cuts for "bright" conditions; otherwise, 
            choose "normal" brightness standards. Cut is performed on `gaiagmag`.
         usegaia: boolean, defaults to ``True``
-           if ``True`` then  call :func:`~desitarget.cuts.isSTD_gaia` to set the 
+           if ``True`` then call :func:`~desitarget.cuts.isSTD_gaia` to set the
            logic cuts. If Gaia is not available (perhaps if you're using mocks)
-           then send ``False`` and pass `gaiagmag` as 22.5-2.5*np.log10(`robs`) 
-           where `robs` is `rflux` without a correction.for Galactic extinction.
+           then send ``False``, in which case we use the LS r-band magnitude as
+           a proxy for the Gaia G-band magnitude (ignoring---incorrectly---that
+           we have already corrected for Galactic extinction.)
         south: boolean, defaults to True
             Use color-cuts based on photometry from the "south" (DECaLS) as
             opposed to the "north" (MzLS+BASS).
 
     Returns:
-        mask : boolean array, True if the object has colors like a STD star
+        mask : boolean array, True if the object has colors like a STD star.
 
     Notes:
         - Gaia data model is at:
@@ -812,7 +813,6 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
         std &= gaiamag_ < gfaint
 
     return std
-
 
 def isMWS_main_north(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
                      objtype=None, gaia=None, primary=None,

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1117,7 +1117,7 @@ def isMWS_WD(primary=None, gaia=None, galb=None, astrometricexcessnoise=None,
     return mws
 
 
-def isMWSSTAR_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, primary=None):
+def isMWSSTAR_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, primary=None, south=True):
     """Select a reasonable range of g-r colors for MWS targets. Returns a boolean array.
 
     Args:
@@ -1125,6 +1125,9 @@ def isMWSSTAR_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=Non
             The flux in nano-maggies of g, r, z, w1, and w2 bands.
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
+        south: boolean, defaults to True
+            Use color-cuts based on photometry from the "south" (DECaLS) as
+            opposed to the "north" (MzLS+BASS).
 
     Returns:
         mask : boolean array, True if the object has colors like an old stellar population,
@@ -1145,7 +1148,11 @@ def isMWSSTAR_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=Non
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         grcolor = 2.5 * np.log10(rflux / gflux)
-        mwsstar &= (grcolor > 0.0)
+        # Assume no difference in north vs south color-cuts.
+        if south:
+            mwsstar &= (grcolor > 0.0)
+        else:
+            mwsstar &= (grcolor > 0.0)
 
     return mwsstar
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -802,8 +802,13 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
         gbright = 16.
         gfaint = 19.
 
-    std &= gaiagmag >= gbright
-    std &= gaiagmag < gfaint
+    if usegaia:
+        std &= gaiagmag >= gbright
+        std &= gaiagmag < gfaint
+    else:
+        gmag = 22.5 - 2.5 * np.log10( gflux.clip(1e-16) )
+        std &= gmag >= gbright
+        std &= gmag < gfaint
 
     return std
 


### PR DESCRIPTION
Adds a `south` argument (defaulting to `True`) to `cuts.isSTD_colors` to allow for the possibility that we apply different color-cuts to standard stars with north vs south photometry (separate from the footprint-agnostic Gaia cuts).  

Currently the *grz* color-cuts are identical, as documented [here](https://desi.lbl.gov/trac/wiki/TargetSelectionWG/TargetSelection#SpectrophotometricStandardStarsSTD).

This PR also addresses #354.