### PR TITLE
add isELG_colors, isELG_colors_north, and isELG_colors_south functions

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,8 +5,9 @@ desitarget Change Log
 0.23.1 (unreleased)
 -------------------
 
+* Add isELG_colors functions [`PR #357`_].
 * Adapt cuts.isSTD_colors to deal with different north/south color-cuts [`PR
-  #355`_]: 
+  #355`_].
 * Refactor to allow separate commissioning and SV target selections [`PR #346`_]:
     * Added ``sv`` and ``commissioning`` directories.
     * New infrastructure to have different cuts for SV and commissioning:
@@ -30,6 +31,7 @@ desitarget Change Log
 .. _`PR #345`: https://github.com/desihub/desitarget/pull/345
 .. _`PR #346`: https://github.com/desihub/desitarget/pull/346
 .. _`PR #355`: https://github.com/desihub/desitarget/pull/355
+.. _`PR #357`: https://github.com/desihub/desitarget/pull/357
 
 0.23.0 (2018-08-09)
 -------------------

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -105,6 +105,10 @@ class TestCuts(unittest.TestCase):
         elg2 = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)
         self.assertTrue(np.all(elg1==elg2))
 
+        elg1 = cuts.isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=primary)
+        elg2 = cuts.isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)
+        self.assertTrue(np.all(elg1==elg2))
+
         # @moustakas - Leaving off objtype will result in different samples!
         psftype = targets['TYPE']
         bgs1 = cuts.isBGS_bright(rflux=rflux, objtype=psftype, primary=primary)


### PR DESCRIPTION
This PR adds new `isELG_colors`, `isELG_colors_north`, and `isELG_colors_south` functions in `desitarget.cuts` in order to separately apply color-cuts for data from the south vs the north (defaulting to south, i.e., DECaLS).

The corresponding functions for LRGs, STDs, and QSOs already exist.
