### PR TITLE
grab Gaia columns in a simple wrapper

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -19,8 +19,6 @@ import sys
 import numpy as np
 from pkg_resources import resource_filename
 
-import astropy.units as u
-from astropy.coordinates import SkyCoord
 from astropy.table import Table, Row
 
 from desitarget import io
@@ -50,8 +48,13 @@ def _gal_coords(ra,dec):
     The Galactic longitude and latitude (l, b)
 
     """
+    import astropy.units as u
+    from astropy.coordinates import SkyCoord
 
-    c = SkyCoord(ra*u.deg, dec*u.deg)
+    if hasattr(ra, 'unit') and hasattr(dec, 'unit'):
+        c = SkyCoord(ra.to(u.deg), dec.to(u.deg))
+    else:
+        c = SkyCoord(ra*u.deg, dec*u.deg)
     gc = c.transform_to('galactic')
 
     return gc.l.value, gc.b.value    

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -51,7 +51,7 @@ def _gal_coords(ra,dec):
     import astropy.units as u
     from astropy.coordinates import SkyCoord
 
-    if hasattr(ra, 'unit') and hasattr(dec, 'unit'):
+    if hasattr(ra, 'unit') and hasattr(dec, 'unit') and ra.unit is not None and dec.unit is not None:
         c = SkyCoord(ra.to(u.deg), dec.to(u.deg))
     else:
         c = SkyCoord(ra*u.deg, dec*u.deg)


### PR DESCRIPTION
Adds a convenience function for pulling out the requisite Gaia columns (both existing and derived) from an input catalog before target selection cuts are applied.

Having this wrapper makes it easier for the mocks to use the same columns, including whatever future updates occur.