### PR TITLE
top-level selection of QSOs using just optical color-cuts

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2218,8 +2218,8 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
         deltaChi2[w] = -1e6
 
     #ADM issue a warning if gaiamatch was not sent but there's no Gaia information
-    if np.max(objects['PARALLAX']) == 0. and ~gaiamatch:
-        log.warning("Zero objects have a parallax. Did you mean to send gaiamatch?")
+    #if np.max(objects['PARALLAX']) == 0. and ~gaiamatch:
+    #    log.warning("Zero objects have a parallax. Did you mean to send gaiamatch?")
 
     # Process the Gaia inputs for target selection.
     gaia, pmra, pmdec, parallax, parallaxovererror, gaiagmag, gaiabmag, \

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1571,7 +1571,7 @@ def isQSO_cuts_north(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi
 
 
 def isQSO_cuts_south(gflux, rflux, zflux, w1flux, w2flux, w1snr, w2snr, deltaChi2, 
-                     release=None, objtype=None, primary=None, optical=optical):
+                     release=None, objtype=None, primary=None, optical=False):
     """Cuts based QSO target selection for the DECaLS photometric system.
 
     Args:


### PR DESCRIPTION
This small PR propagates the option of applying just optical color-cuts to the selection of QSOs to the top-level `cuts.apply_cuts` wrapper.  Optical color-cuts are all we can do when generating targets using `desisim.templates.QSO`, which do not extend red enough to allow us to synthesize WISE photometry.

Although we have `desisim.templates.SIMQSO` the Lya WG still would like to be able to generated QSO continuum spectra using the PCA-based technique implemented in `desisim.templates.QSO`.