### PR TITLE
fix a bug in how objtruth is written out to the truth.fits file

### DIFF
--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -909,7 +909,7 @@ def write_targets_truth(targets, truth, objtruth, trueflux, truewave, skytargets
             hx.append(hdu)
 
         if len(objtruth) > 0:
-            for obj in sorted(objtruth.keys()):
+            for obj in sorted(set(truth['TEMPLATETYPE'])):
                 hdu = fits.convenience.table_to_hdu(objtruth[obj])
                 hdu.header['EXTNAME'] = 'TRUTH_{}'.format(obj)
                 hx.append(hdu)


### PR DESCRIPTION
This PR---together with the companion depends on https://github.com/desihub/desisim/pull/416 PR---fixes a bug identified by @sbailey when processing mock spectra from `desitarget/bin/select_mock_targets` through `desisim/bin/newexp-mock`.

I'll post a test script shortly.

