### PR TITLE
bug fix: correctly select standards from MWS_MAIN mocks

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 0.24.0 (unreleased)
 -------------------
 
+* Fix a bug which resulted in far too few standard stars being selected in the
+  mocks [`PR #378`_].  
 * Fix a bug in how the `objtruth` tables are written out to by
   `select_mock_targets` [`PR #374`_].
 * Remove Python 2.7 from Travis, add an allowed-to-fail PEP 8 check [`PR #373`_].
@@ -69,6 +71,7 @@ desitarget Change Log
 .. _`PR #372`: https://github.com/desihub/desitarget/pull/372
 .. _`PR #373`: https://github.com/desihub/desitarget/pull/373
 .. _`PR #374`: https://github.com/desihub/desitarget/pull/374
+.. _`PR #378`: https://github.com/desihub/desitarget/pull/378
 
 0.23.0 (2018-08-09)
 -------------------

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -3724,16 +3724,13 @@ class MWS_MAINMaker(STARMaker):
         if self.calib_only:
             tcnames = 'STD'
         else:
-            tcnames = ['STD']
-            #tcnames = ['MWS', 'STD']
+            tcnames = ['MWS', 'STD']
             
         desi_target, bgs_target, mws_target = apply_cuts(targets, tcnames=tcnames)
 
         targets['DESI_TARGET'] |= targets['DESI_TARGET'] | desi_target
         targets['BGS_TARGET'] |= targets['BGS_TARGET'] | bgs_target
         targets['MWS_TARGET'] |= targets['MWS_TARGET'] | mws_target
-
-        import pdb ; pdb.set_trace()
 
         # Select bright stellar contaminants for the extragalactic targets.
         log.info('Temporarily turning off contaminants.')


### PR DESCRIPTION
This PR fixes a bug which resulted in only WDs being selected as standards by `select_mock_targets`, i.e., too few for the down-stream pipeline.

Briefly: standards are required to have `FRACMASK_[G,R,Z]>0` but in the mock target catalog `FRACMASK` had (previously) been set to zero in all bands.  (This question is being discussed on @desi-targets---follow it there if interested.)

Another bug was that only `MWS` targets were being selected from the MWS_MAIN/Galaxia mocks, instead of `MWS` *and* `STD` now.

The PR also adds some hooks to restore support for the FAINTSTAR mocks (once they have Gaia; see #352), but those are still not being used (nor do they need to be).

Testing over one healpixel yields approximately 1000 standards/deg2 (which is now overkill, but see #377).
```
select_mock_targets -c select-targets.yaml --seed 1 --nside 16 --healpixels 352 --nproc 4
```
with the following configuration file:
```
targets:
    MWS_MAIN: {
        target_type: STAR,
        mockfile: '{DESI_ROOT}/mocks/mws/galaxia/alpha/v0.0.5/healpix',
        nside_galaxia: 8,
        format: galaxia,
    }

```