### PR TITLE
fix failing tests due to #383

### DIFF
--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -535,7 +535,7 @@ def apply_cuts(objects, cmxdir=None):
         raise IOError
 
     # Process the Gaia inputs for target selection.
-    gaia, pmra, pmdec, parallax, parallaxovererror, gaiagmag, gaiabmag,   \
+    gaia, pmra, pmdec, parallax, parallaxovererror, parallaxerr, gaiagmag, gaiabmag,   \
       gaiarmag, gaiaaen, gaiadupsource, gaiaparamssolved, gaiabprpfactor, \
       gaiasigma5dmax, galb = _prepare_gaia(objects, colnames=colnames)
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2020,7 +2020,10 @@ def _prepare_gaia(objects, colnames=None):
     parallaxovererror = np.where(parallaxivar > 0., parallax*np.sqrt(parallaxivar), 0.)
 
     # We also need the parallax uncertainty, to select MWS_NEARBY targets.
-    parallaxerr = np.where(parallaxivar > 0., 1/np.sqrt(parallaxivar), -1e8) # make large and negative
+    parallaxerr = np.zeros_like(parallax) - 1e8 # make large and negative
+    notzero = parallaxivar > 0
+    if np.sum(notzero) > 0:
+        parallaxerr[notzero] = 1 / np.sqrt(parallaxivar[notzero])
     
     gaiagmag = objects['GAIA_PHOT_G_MEAN_MAG']
     gaiabmag = objects['GAIA_PHOT_BP_MEAN_MAG']

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -822,9 +822,12 @@ def isMWS_main_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=Non
 
 def isMWS_nearby(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
                  objtype=None, gaia=None, primary=None,
-                 pmra=None, pmdec=None, parallax=None, 
+                 pmra=None, pmdec=None, parallax=None, parallaxerr=None,
                  obs_rflux=None, gaiagmag=None, gaiabmag=None, gaiarmag=None):
     """Set bits for NEARBY Milky Way Survey targets.
+
+    Notes:
+    - Current version (09/20/18) is version 129 on `the wiki`_.
 
     Args:
         gflux, rflux, zflux, w1flux, w2flux: array_like or None
@@ -836,9 +839,12 @@ def isMWS_nearby(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
             Surveys and in Gaia.
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
-        pmra, pmdec, parallax: array_like or None
-            Gaia-based proper motion in RA and Dec and parallax
-            (same units as the Gaia data model, e.g.:
+        pmra, pmdec, parallax, parallaxerr: array_like or None
+            Gaia-based proper motion in RA and Dec and parallax (and
+            uncertainty) (same units as `the Gaia data model`_).
+        pmra, pmdec, parallax, parallaxerr: array_like or None
+            Gaia-based proper motion in RA and Dec and parallax (and
+            uncertainty) (same units as the Gaia data model, e.g.:
             https://gea.esac.esa.int/archive/documentation/GDR2/Gaia_archive/chap_datamodel/sec_dm_main_tables/ssec_dm_gaia_source.html).
         obs_rflux: array_like or None
             `rflux` but WITHOUT any Galactic extinction correction
@@ -849,6 +855,7 @@ def isMWS_nearby(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     Returns:
         mask : array_like. 
             True if and only if the object is a MWS-NEARBY target.
+
     """
     if primary is None:
         primary = np.ones_like(gaia, dtype='?')
@@ -872,7 +879,7 @@ def isMWS_nearby(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     #ADM Gaia G mag of less than 20
     mws &= gaiagmag < 20.
     #ADM parallax cut corresponding to 100pc
-    mws &= parallax > 10.
+    mws &= (parallax + parallaxerr) > 10. # NB: "+" is correct
     #ADM NOTE TO THE MWS GROUP: There is no bright cut on G. IS THAT THE REQUIRED BEHAVIOR?
 
     return mws


### PR DESCRIPTION
Self-explanatory PR to fix the problems introducted in #383.

I got tripped up because `sv1.sv1_cuts` has an identical copy of `cuts.isMWS_nearby` that came out of sync, even though this is not a documented target class in
https://desi.lbl.gov/trac/wiki/TargetSelectionWG/SurveyValidation

I'm worried that this is going to happen more and more...