### PR TITLE
rescale parameters when generating and querying kd-trees

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 0.24.0 (unreleased)
 -------------------
 
+* Rescale spectral parameters when generating and querying kd-trees in
+  `select_mock_targets` [`PR #386`_].
 * Bug fixes: [`PR #383`_].
     * Use `parallax_err` when selecting `MWS_NEARBY` targets.
     * In `select_mock_targets` do not use Galaxia to select WDs and 100pc
@@ -90,6 +92,7 @@ desitarget Change Log
 .. _`PR #381`: https://github.com/desihub/desitarget/pull/381
 .. _`PR #382`: https://github.com/desihub/desitarget/pull/382
 .. _`PR #383`: https://github.com/desihub/desitarget/pull/383
+.. _`PR #386`: https://github.com/desihub/desitarget/pull/386
 
 0.23.0 (2018-08-09)
 -------------------

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -3672,18 +3672,10 @@ class MWS_MAINMaker(STARMaker):
             input_meta['MAGFILTER'][:] = data['MAGFILTER'][indx]
 
             if self.mockformat == 'galaxia':
-                #input_meta['TEMPLATEID'][:] = self.KDTree_query(
-                #    np.vstack((data['TEFF'][indx], data['LOGG'][indx], data['FEH'][indx])).T
-                #    )
-
-                matrix = np.vstack((np.log10(data['TEFF'][indx]), data['LOGG'][indx], data['FEH'][indx])).T
-                norm = self.KDTree_rescale(matrix)
-                dist, rr = self.KDTree.query(norm, p=2)
-                
-                ww = np.where(np.abs(self.meta['TEFF'][rr]-data['TEFF'][indx]) > 500)[0]
-
-                #ww = np.where(np.abs(self.meta['TEFF'][input_meta['TEMPLATEID']].data-data['TEFF'][indx]) > 500)[0]
-            import pdb ; pdb.set_trace()
+                input_meta['TEMPLATEID'][:] = self.KDTree_query(
+                    np.vstack((np.log10(data['TEFF'][indx]),
+                               data['LOGG'][indx],
+                               data['FEH'][indx])).T)
 
             # Build north/south spectra separately.
             south = np.where( data['SOUTH'][indx] == True )[0]


### PR DESCRIPTION
This PR is a long-overdue and unadvertised improvement in how we use kd-tree to assign spectral templates to mock targets.  In essence, the kd-trees are constructed and queried using normalized and logarithmic (where appropriate) spectral properties rather than the properties themselves (which is how I should have written it in the first place).

The result is a much improved mapping between mock targets and their corresponding templates.

A well-hidden bug was also discovered and fixed when assigning templates to cool main-sequence stars.
