### PR TITLE
include TRUTH_ELG, TRUTH_BGS, etc HDUs

### DIFF
--- a/bin/join_mock_targets
+++ b/bin/join_mock_targets
@@ -9,7 +9,8 @@ import argparse
 parser = argparse.ArgumentParser(usage = "{prog} [options]")
 parser.add_argument("--mockdir", type=str, required=True, help="input mock directory")
 parser.add_argument("--outdir", type=str,  help="output directory [default same as mockdir]")
-parser.add_argument("--force", action="store_true", help="rerun even if output files exist")
+parser.add_argument("--force", action="store_true", help="[deprecated; see --overwrite]")
+parser.add_argument("--overwrite", action="store_true", help="overwrite pre-existing output files")
 parser.add_argument("--mpi", action="store_true", help="Use MPI parallelism")
 args = parser.parse_args()
 
@@ -22,7 +23,14 @@ else:
 
 from desitarget.mock.build import join_targets_truth
 
-join_targets_truth(args.mockdir, outdir=args.outdir, force=args.force, comm=comm)
+if args.force:
+    args.overwrite = args.force
+    if comm is None or comm.rank == 0:
+        from desiutil.log import get_logger
+        log = get_logger()
+        log.warning('--force is deprecated; please use --overwrite instead')
+
+join_targets_truth(args.mockdir, outdir=args.outdir, overwrite=args.overwrite, comm=comm)
 
 
 

--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -84,7 +84,7 @@ else:
 
 if args.join:
     from desitarget.mock.build import join_targets_truth
-    join_targets_truth(mockdir=args.output_dir, outdir=args.output_dir, force=args.overwrite)
+    join_targets_truth(mockdir=args.output_dir, outdir=args.output_dir, overwrite=args.overwrite)
     if not args.qa:
         sys.exit(1)
 

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -915,6 +915,7 @@ def _merge_file_tables(fileglob, ext, outfile=None, comm=None, addcols=None, ove
     import fitsio
     import glob
     from desiutil.log import get_logger
+    log = get_logger()
     
     if comm is not None:
         size = comm.Get_size()
@@ -958,12 +959,10 @@ def _merge_file_tables(fileglob, ext, outfile=None, comm=None, addcols=None, ove
             data = np.hstack(data)
 
     if rank == 0 and outfile is not None:
-        log = get_logger()
-
         if (data is None) or len(data) == 0:
-            message = 'EXT {} not found in any input files'.format(ext)
-            log.error(message)
-            raise IOError(message)
+            message = '{} not found in any input files; skipping'.format(ext)
+            log.warning(message)
+            return None
 
         log.info('Writing {} {}'.format(outfile, ext))
         header = fitsio.read_header(infiles[0], ext)

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -897,7 +897,7 @@ def write_targets_truth(targets, truth, objtruth, trueflux, truewave, skytargets
             hx.writeto(truthfile+'.tmp', clobber=True)
         os.rename(truthfile+'.tmp', truthfile)
 
-def _merge_file_tables(fileglob, ext, outfile=None, comm=None, addcols=None):
+def _merge_file_tables(fileglob, ext, outfile=None, comm=None, addcols=None, overwrite=False):
     '''
     parallel merge tables from individual files into an output file
 
@@ -937,18 +937,44 @@ def _merge_file_tables(fileglob, ext, outfile=None, comm=None, addcols=None):
         return
     
     #- Each rank reads and combines a different set of files
-    data = np.hstack( [fitsio.read(x, ext) for x in infiles[rank::size]] )
+    data = list()
+    for filename in infiles[rank::size]:
+        try:
+            data.append(fitsio.read(filename, ext))
+        except OSError:  #- yep, OSError not IOError
+            log.info('Extension {} not found in {}'.format(ext, filename))
+            pass
+
+    if len(data) > 0:
+        data = np.hstack(data)
+    else:
+        # some ranks may not touch files that have this ext
+        data = None
 
     if comm is not None:
         data = comm.gather(data, root=0)
         if rank == 0 and size>1:
+            data = [d for d in data if d is not None]
             data = np.hstack(data)
 
     if rank == 0 and outfile is not None:
         log = get_logger()
-        log.info('Writing {}'.format(outfile))
+
+        if (data is None) or len(data) == 0:
+            message = 'EXT {} not found in any input files'.format(ext)
+            log.error(message)
+            raise IOError(message)
+
+        log.info('Writing {} {}'.format(outfile, ext))
         header = fitsio.read_header(infiles[0], ext)
+
+        #- Use tmpout name so interupted I/O doesn't leave a corrupted file
+        #- of the correct name
         tmpout = outfile + '.tmp'
+
+        #- If appending, move file back to tmpout name
+        if (not overwrite) and os.path.exists(outfile):
+            os.rename(outfile, tmpout)
         
         # Find duplicates
         vals, idx_start, count = np.unique(data['TARGETID'], return_index=True, return_counts=True)
@@ -967,12 +993,12 @@ def _merge_file_tables(fileglob, ext, outfile=None, comm=None, addcols=None):
             data = np.lib.recfunctions.append_fields(data, colnames, coldata,
                                                      usemask=False)
 
-        fitsio.write(tmpout, data, header=header, extname=ext, clobber=True)
+        fitsio.write(tmpout, data, header=header, extname=ext, clobber=overwrite)
         os.rename(tmpout, outfile)
 
     return data
 
-def join_targets_truth(mockdir, outdir=None, force=False, comm=None):
+def join_targets_truth(mockdir, outdir=None, overwrite=False, comm=None):
     '''
     Join individual healpixel targets and truth files into combined tables
 
@@ -981,7 +1007,7 @@ def join_targets_truth(mockdir, outdir=None, force=False, comm=None):
 
     Options:
         outdir: output directory, default to mockdir
-        force: rewrite outputs even if they already exist
+        overwrite: rewrite outputs even if they already exist
         comm: MPI communicator; if not None, read data in parallel
     '''
     import fitsio
@@ -1000,12 +1026,12 @@ def join_targets_truth(mockdir, outdir=None, force=False, comm=None):
     #- Use rank 0 to check pre-existing files to avoid N>>1 ranks hitting the disk
     if rank == 0:
         todo = dict()
-        todo['sky'] = not os.path.exists(outdir+'/sky.fits') or force
-        todo['stddark'] = not os.path.exists(outdir+'/standards-dark.fits') or force
-        todo['stdbright'] = not os.path.exists(outdir+'/standards-bright.fits') or force
-        todo['targets'] = not os.path.exists(outdir+'/targets.fits') or force
-        todo['truth'] = not os.path.exists(outdir+'/truth.fits') or force
-        todo['mtl'] = not os.path.exists(outdir+'/mtl.fits') or force
+        todo['sky'] = not os.path.exists(outdir+'/sky.fits') or overwrite
+        todo['stddark'] = not os.path.exists(outdir+'/standards-dark.fits') or overwrite
+        todo['stdbright'] = not os.path.exists(outdir+'/standards-bright.fits') or overwrite
+        todo['targets'] = not os.path.exists(outdir+'/targets.fits') or overwrite
+        todo['truth'] = not os.path.exists(outdir+'/truth.fits') or overwrite
+        todo['mtl'] = not os.path.exists(outdir+'/mtl.fits') or overwrite
     else:
         todo = None
 
@@ -1015,25 +1041,36 @@ def join_targets_truth(mockdir, outdir=None, force=False, comm=None):
     if todo['sky']:
         _merge_file_tables(mockdir+'/*/*/sky-*.fits', 'SKY',
                            outfile=outdir+'/sky.fits', comm=comm,
+                           overwrite=overwrite,
                            addcols=dict(OBSCONDITIONS=obsmask.mask('DARK|GRAY|BRIGHT')))
 
     if todo['stddark']:
         _merge_file_tables(mockdir+'/*/*/standards-dark*.fits', 'STD',
                            outfile=outdir+'/standards-dark.fits', comm=comm,
+                           overwrite=overwrite,
                            addcols=dict(OBSCONDITIONS=obsmask.mask('DARK|GRAY')))
 
     if todo['stdbright']:
         _merge_file_tables(mockdir+'/*/*/standards-bright*.fits', 'STD',
                            outfile=outdir+'/standards-bright.fits', comm=comm,
+                           overwrite=overwrite,
                            addcols=dict(OBSCONDITIONS=obsmask.mask('BRIGHT')))
 
     if todo['targets']:
         _merge_file_tables(mockdir+'/*/*/targets-*.fits', 'TARGETS',
+                           overwrite=overwrite,
                            outfile=outdir+'/targets.fits', comm=comm)
 
     if todo['truth']:
         _merge_file_tables(mockdir+'/*/*/truth-*.fits', 'TRUTH',
+                           overwrite=overwrite,
                            outfile=outdir+'/truth.fits', comm=comm)
+        # append, not overwrite other per-subclass truth tables
+        for templatetype in ['BGS', 'ELG', 'LRG', 'QSO', 'STAR', 'WD']:
+            extname = 'TRUTH_' + templatetype
+            _merge_file_tables(mockdir+'/*/*/truth-*.fits', extname,
+                               overwrite=False,
+                               outfile=outdir+'/truth.fits', comm=comm)
 
     #- Make initial merged target list (MTL) using rank 0
     if rank == 0 and todo['mtl']:


### PR DESCRIPTION
PR #368 moves the per-type truth entries into separate HDUs, e.g. `TRUTH_ELG`, 'TRUTH_BGS`, `TRUTH_STAR`, etc.  This PR propagates those into the final merged truth file when using `join_targets_truth`.

I don't know if this case can happen, but this merging will support the case where some input truth files are missing a particular HDU (e.g. if some but not all inputs have TRUTH_WD).

If *all* input truth files are missing a particular flavor of truth, this is treated as a warning but not an error: you might be working with truth files for a particular class but don't care about the others.