### PR TITLE
generate mock sky position over a larger footprint

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,15 @@ desitarget Change Log
 0.24.1 (unreleased)
 -------------------
 
+* Updated mock sky catalog with positions over a larger footprint [`PR #398`_].
+* Major update to `select_mock_targets` to use the latest (v3.0) basis
+  templates [`PR #395`_].
 * Incorporate simple WISE depth model in `select_mock_targets` which depends on
   ecliptic latitude [`PR #391`_].
 
 .. _`PR #391`: https://github.com/desihub/desitarget/pull/391
+.. _`PR #395`: https://github.com/desihub/desitarget/pull/395
+.. _`PR #398`: https://github.com/desihub/desitarget/pull/398
 
 0.24.0 (2018-09-26)
 -------------------

--- a/py/desitarget/mock/sky.py
+++ b/py/desitarget/mock/sky.py
@@ -1,5 +1,3 @@
-import desimodel.io
-import desimodel.footprint
 import numpy as np
 import healpy as hp
 
@@ -10,7 +8,7 @@ def _random_theta_phi(nside, pix):
     phi += np.random.uniform(-dpix/2, dpix/2, size=len(phi)) * np.cos(np.pi/2 - theta)
     return theta % np.pi, phi % (2*np.pi)
 
-def random_sky(nside=2048, allsky=True, tiles=None, maxiter=20):
+def random_sky(nside=2048, allsky=True, tiles=None, maxiter=20, outfile=None):
     '''Returns sky locations within healpixels covering tiles
 
     Options:
@@ -31,6 +29,8 @@ def random_sky(nside=2048, allsky=True, tiles=None, maxiter=20):
     if allsky:
         pix = np.arange( hp.nside2npix(nside) )
     else:
+        import desimodel.io
+        import desimodel.footprint
         if tiles is None:
             tiles = desimodel.io.load_tiles()
         pix = desimodel.footprint.tiles2pix(nside, tiles)
@@ -52,5 +52,14 @@ def random_sky(nside=2048, allsky=True, tiles=None, maxiter=20):
 
     ra = np.degrees(phi)
     dec = 90 - np.degrees(theta)
+
+    if outfile is not None:
+        from astropy.table import Table
+        out = Table()
+        out['HPXPIXEL'] = pix
+        out['RA'] = ra.astype('f8')
+        out['DEC'] = dec.astype('f8')
+        print('Writing {}'.format(outfile))
+        out.write(outfile, overwrite=True)
 
     return ra, dec

--- a/py/desitarget/mock/sky.py
+++ b/py/desitarget/mock/sky.py
@@ -15,7 +15,7 @@ def random_sky(nside=2048, allsky=True, tiles=None, maxiter=20, outfile=None):
         nside (int): healpixel nside; coverage is uniform at this scale
         allsky (bool): generate sky positions over the full sky
         tiles: DESI tiles to cover, for desimodel.footprint.tiles2pix(); only
-          used if allsky=False.
+        used if allsky=False.
         maxiter (int): maximum number of iterations to ensure coverage
 
     Generates sky locations that are more uniform than true random,

--- a/py/desitarget/mock/sky.py
+++ b/py/desitarget/mock/sky.py
@@ -55,11 +55,12 @@ def random_sky(nside=2048, allsky=True, tiles=None, maxiter=20, outfile=None):
 
     if outfile is not None:
         from astropy.table import Table
+        keep = dec >= -30
         out = Table()
-        out['HPXPIXEL'] = pix
-        out['RA'] = ra.astype('f8')
-        out['DEC'] = dec.astype('f8')
+        out['HPXPIXEL'] = pix[keep]
+        out['RA'] = ra[keep]
+        out['DEC'] = dec[keep]
         print('Writing {}'.format(outfile))
         out.write(outfile, overwrite=True)
 
-    return ra, dec
+    return ra, dec, pix

--- a/py/desitarget/mock/sky.py
+++ b/py/desitarget/mock/sky.py
@@ -10,13 +10,14 @@ def _random_theta_phi(nside, pix):
     phi += np.random.uniform(-dpix/2, dpix/2, size=len(phi)) * np.cos(np.pi/2 - theta)
     return theta % np.pi, phi % (2*np.pi)
 
-def random_sky(nside=2048, tiles=None, maxiter=20):
-    '''
-    Returns sky locations within healpixels covering tiles
+def random_sky(nside=2048, allsky=True, tiles=None, maxiter=20):
+    '''Returns sky locations within healpixels covering tiles
 
     Options:
         nside (int): healpixel nside; coverage is uniform at this scale
-        tiles: DESI tiles to cover, for desimodel.footprint.tiles2pix()
+        allsky (bool): generate sky positions over the full sky
+        tiles: DESI tiles to cover, for desimodel.footprint.tiles2pix(); only
+          used if allsky=False.
         maxiter (int): maximum number of iterations to ensure coverage
 
     Generates sky locations that are more uniform than true random,
@@ -25,10 +26,14 @@ def random_sky(nside=2048, tiles=None, maxiter=20):
     
     nside=2048 corresponds to about half of a DESI positioner patrol area
     and results in ~18M sky locations over the full footprint.
+
     '''
-    if tiles is None:
-        tiles = desimodel.io.load_tiles()
-    pix = desimodel.footprint.tiles2pix(nside, tiles)
+    if allsky:
+        pix = np.arange( hp.nside2npix(nside) )
+    else:
+        if tiles is None:
+            tiles = desimodel.io.load_tiles()
+        pix = desimodel.footprint.tiles2pix(nside, tiles)
     theta, phi = _random_theta_phi(nside, pix)
 
     #- there is probably a more clever way to do this, but iteratively

--- a/py/desitarget/test/test_mock_build.py
+++ b/py/desitarget/test/test_mock_build.py
@@ -47,7 +47,7 @@ class TestMockBuild(unittest.TestCase):
 
     def test_sky(self):
         nside = 256
-        ra, dec = random_sky(nside)
+        ra, dec, pix = random_sky(nside, allsky=False)
         self.assertEqual(len(ra), len(dec))
         surveypix = desimodel.footprint.tiles2pix(nside)
         theta = np.radians(90 - dec)


### PR DESCRIPTION
Addresses the need in #390 to have mocks over a larger footprint.

The output file generated with the code snippet below has been copied to `/global/projecta/projectdirs/desi/mocks/uniformsky/0.2/uniformsky-2048-0.2.fits` and the README has been updated:
```
from desitarget.mock.sky import random_sky
ra, dec, pix = random_sky(allsky=True, outfile='uniformsky-2048-0.2.fits')
```
The catalog contains 37,748,739 entries (vs 18,335,706 previously) and extends over the full sky northward of -30 deg.