### PR TITLE
use color-cuts not RF to select QSOs

### DIFF
--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -2662,7 +2662,8 @@ class QSOMaker(SelectTargets):
 
         """
         if self.use_simqso:
-            desi_target, bgs_target, mws_target = cuts.apply_cuts(targets, tcnames='QSO')
+            desi_target, bgs_target, mws_target = cuts.apply_cuts(targets, tcnames='QSO',
+                                                                  qso_selection='colorcuts')
         else:
             desi_target, bgs_target, mws_target = cuts.apply_cuts(
                 targets, tcnames='QSO', qso_selection='colorcuts',
@@ -2713,7 +2714,7 @@ class LYAMaker(SelectTargets):
                 LYAMaker.template_maker = QSO(wave=self.wave)
 
         if self.GMM_nospectra is None:
-            gmmfile = resource_filename('desitarget', 'mock/data/quicksurvey_gmm_lya.fits')
+            gmmfile = resource_filename('desitarget', 'mock/data/quicksurvey_gmm_qso.fits')
             LYAMaker.GMM_nospectra = GaussianMixtureModel.load(gmmfile)
 
     def read(self, mockfile=None, mockformat='CoLoRe', healpixels=None, nside=None,
@@ -2960,7 +2961,7 @@ class LYAMaker(SelectTargets):
             else:
                 for ii in range(nobj):
                     flux[ii, :] = resample_flux(self.wave, qso_wave, _flux[ii, :], extrapolate=True)
-                                     
+
         targets, truth, objtruth = self.populate_targets_truth(
                 data, meta, objmeta, indx=indx, psf=True, seed=seed,
                 truespectype='QSO', templatetype='QSO', templatesubtype='LYA')
@@ -2978,7 +2979,8 @@ class LYAMaker(SelectTargets):
             Corresponding truth table.
 
         """
-        desi_target, bgs_target, mws_target = cuts.apply_cuts(targets, tcnames='QSO')
+        desi_target, bgs_target, mws_target = cuts.apply_cuts(targets, tcnames='QSO',
+                                                              qso_selection='colorcuts')
         
         targets['DESI_TARGET'] |= desi_target
         targets['BGS_TARGET'] |= bgs_target


### PR DESCRIPTION
@forero and I independently noticed that the latest version of `select_mock_targets` was taking much longer to run, even with the `--no-spectra` option, when simulating tracer and Lya QSOs.  It turns out that the bottleneck was using the random forest selection to select QSOs, specifically the `predict_proba` method in `cuts.isQSO_randomforest`.  

This PR changes the selection method from random forest to color-cuts, which is about a 1000 times faster.