### PR TITLE
solves crashing problem in `mtl` when called from `quicksurvey`

### DIFF
--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -47,8 +47,11 @@ def make_mtl(targets, zcat=None, trim=False):
 
     n       = len(targets)
     targets = Table(targets)
+    if 'NUMOBS' in targets.keys():
+        del targets['NUMOBS'] # the relevant information coms from zcat['NUMOBS']
+    if 'PRIORITY' in targets.keys():
+        del targets['PRIORITY'] # the relevant information coms from zcat['NUMOBS']
 
-    del targets['NUMOBS'] # the relevant information coms from zcat['NUMOBS']
 
     # Create redshift catalog
     if zcat is not None:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -48,6 +48,8 @@ def make_mtl(targets, zcat=None, trim=False):
     n       = len(targets)
     targets = Table(targets)
 
+    del targets['NUMOBS'] # the relevant information coms from zcat['NUMOBS']
+
     # Create redshift catalog
     if zcat is not None:
 


### PR DESCRIPTION
One liner that solves many problems downstream in `quicksurvey`.

The problem was that the new `target` file included a `NUMOBS` column, that column clashed with the `NUMOBS` column in `zcat`. Solution: delete the input `NUMOBS` in `target`.