### PR TITLE
Refactor BGS selection to separate masking from color cuts

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.24.1 (unreleased)
 -------------------
 
+* Refactor of BGS selections to separate masking and color cuts [`PR #407`_].
 * Updates to Bright Galaxy Survey and QSO selections [`PR #402`_]. Includes:
     * Updates to `BGS_FAINT` and `BGS_BRIGHT` target selections.
     * New `BGS_WISE` selection and implementation.
@@ -23,6 +24,7 @@ desitarget Change Log
 .. _`PR #395`: https://github.com/desihub/desitarget/pull/395
 .. _`PR #398`: https://github.com/desihub/desitarget/pull/398
 .. _`PR #402`: https://github.com/desihub/desitarget/pull/402
+.. _`PR #407`: https://github.com/desihub/desitarget/pull/407
 
 0.24.0 (2018-09-26)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1253,12 +1253,12 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         primary = np.ones_like(rflux, dtype='?')
     bgs = primary.copy()
 
-    bgs &= notin_BGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                          gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                          gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                          gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
-                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
-                          gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
+    bgs &= notinBGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                         gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+                         gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
+                         gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
+                         gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
+                         gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
 
     bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
                         south=south, targtype=targtype)
@@ -1266,12 +1266,12 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     return bgs
 
 
-def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
-                   gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                   gfracflux=None, rfracflux=None, zfracflux=None,
-                   gfracin=None, rfracin=None, zfracin=None, w1snr=None,
-                   gfluxivar=None, rfluxivar=None, zfluxivar=None, Grr=None,
-                   gaiagmag=None, brightstarinblob=None, targtype=None):
+def notinBGS_mask(gnobs=None, rnobs=None, znobs=None,
+                  gfracmasked=None, rfracmasked=None, zfracmasked=None,
+                  gfracflux=None, rfracflux=None, zfracflux=None,
+                  gfracin=None, rfracin=None, zfracin=None, w1snr=None,
+                  gfluxivar=None, rfluxivar=None, zfluxivar=None, Grr=None,
+                  gaiagmag=None, brightstarinblob=None, targtype=None):
     """Standard set of masking cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS_faint` for parameters).
     """

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1242,63 +1242,81 @@ def isBGS_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
                       gaiagmag, objtype=objtype, primary=primary)
 
 
+def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
+                   gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
+                   gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None):
+    """Standard set of masking cuts used by all BGS target selection classes
+    (see, e.g., :func:`~desitarget.cuts.isBGS_faint` for parameters).
+    """
+
+    bgs = np.ones(len(gnobs), dtype='?')
+
+    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
+    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
+    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
+    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
+    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
+
+    bgs &= ~brightstarinblob
+
+    return bgs
+
+
+def isBGS_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+                 Grr=None, gaiagmag=None, primary=None, south=True, bright=True):
+    """Standard set of masking cuts used by all BGS target selection classes
+    (see, e.g., :func:`~desitarget.cuts.isBGS_faint` for parameters).
+
+    Other Args:
+        bright: boolean, defaults to ``True``
+            Use colors appropriate to ``BGS_BRIGHT`` if ``True``. Otherwise
+            use colors appropriate to ``BGS_FAINT`` target class.
+    """
+
+    bgs = np.ones(len(gflux), dtype='?')
+
+    if bright
+        if south:
+        if north:
+    else:
+        if south:
+            bgs &= rflux > 10**((22.5-20.0)/2.5)
+            bgs &= rflux <= 10**((22.5-19.5)/2.5)
+        if north:
+            bgs &= rflux > 10**((22.5-20.0)/2.5)
+            bgs &= rflux <= 10**((22.5-19.5)/2.5)
+
+    bgs &= rflux > gflux * 10**(-1.0/2.5)
+    bgs &= rflux < gflux * 10**(4.0/2.5)
+    bgs &= zflux > rflux * 10**(-1.0/2.5)
+    bgs &= zflux < rflux * 10**(4.0/2.5)
+    bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
+
+    return bgs
+
+
 def isBGS_faint_north(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
                       gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
                       gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
                       gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
                       gaiagmag=None, objtype=None, primary=None):
     """Target Definition of BGS faint targets for the BASS/MzLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            inverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            ``True`` if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
+    (see, e.g., :func:`~desitarget.cuts.isBGS_faint`).
     """
     #------ Bright Galaxy Survey
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
     bgs = primary.copy()
-    bgs_gaia = primary.copy()
-    bgs_nogaia = primary.copy()
-    bgs &= rflux > 10**((22.5-20.0)/2.5)
-    bgs &= rflux <= 10**((22.5-19.5)/2.5)
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
-    bgs &= rflux > gflux * 10**(-1.0/2.5)
-    bgs &= rflux < gflux * 10**(4.0/2.5)
-    bgs &= zflux > rflux * 10**(-1.0/2.5)
-    bgs &= zflux < rflux * 10**(4.0/2.5)
-    bgs &= ~brightstarinblob
-    bgs_gaia = bgs & (Grr > 0.6)
-    bgs_nogaia = bgs & (gaiagmag == 0)
-    bgs = bgs_gaia | bgs_nogaia
-    #if objtype is not None:
-    #    bgs &= ~_psflike(objtype)
+
+    bgs &= notin_BGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs, 
+                          gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+                          gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, 
+                          gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
+                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, 
+                          brightstarinblob=brightstarinblob):
+
+    bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
+                        Grr=Grr, gaiagmag=gaiagmag, south=False, bright=False)
 
     return bgs
 
@@ -1309,33 +1327,8 @@ def isBGS_faint_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
                       gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
                       gaiagmag=None, objtype=None, primary=None):
     """Target Definition of BGS faint targets for the DECaLS photometric system.
+    (see, e.g., :func:`~desitarget.cuts.isBGS_faint`).
 
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            inverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            ``True`` if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
     """
     #------ Bright Galaxy Survey
     if primary is None:
@@ -1343,62 +1336,27 @@ def isBGS_faint_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
     bgs = primary.copy()
     bgs_gaia = primary.copy()
     bgs_nogaia = primary.copy()
-    bgs &= rflux > 10**((22.5-20.0)/2.5)
-    bgs &= rflux <= 10**((22.5-19.5)/2.5)
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
-    bgs &= rflux > gflux * 10**(-1.0/2.5)
-    bgs &= rflux < gflux * 10**(4.0/2.5)
-    bgs &= zflux > rflux * 10**(-1.0/2.5)
-    bgs &= zflux < rflux * 10**(4.0/2.5)
-    bgs &= ~brightstarinblob
-    bgs_gaia = bgs & (Grr > 0.6)
-    bgs_nogaia = bgs & (gaiagmag == 0)
-    bgs = bgs_gaia | bgs_nogaia
-    #if objtype is not None:
-    #    bgs &= ~_psflike(objtype)
+
+    bgs &= notin_BGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs, 
+                          gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+                          gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, 
+                          gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
+                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, 
+                          brightstarinblob=brightstarinblob):
+
+    bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
+                        Grr=Grr, gaiagmag=gaiagmag, south=True, bright=False)
 
     return bgs
 
 
 def isBGS_bright(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                      gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                      gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                      gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
-                      gaiagmag=None, objtype=None, primary=None, south=True):
+                 gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
+                 gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
+                 gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
+                 gaiagmag=None, objtype=None, primary=None, south=True):
     """Convenience function for backwards-compatability prior to north/south split.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            inverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            ``True`` if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-        south: boolean, defaults to ``True``
-            Call isBGS_bright_north if ``south=False``, otherwise call isBGS_bright_south.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
+    (see, e.g., :func:`~desitarget.cuts.isBGS_faint`).
     """
     if south == False:
         return isBGS_bright_north(gflux, rflux, zflux, w1flux, w2flux, 
@@ -1420,33 +1378,7 @@ def isBGS_bright_north(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
                       gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
                       gaiagmag=None, objtype=None, primary=None):
     """Target Definition of BGS bright targets for the BASS/MzLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            inverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            ``True`` if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
+    (see, e.g., :func:`~desitarget.cuts.isBGS_faint`).
     """
     #------ Bright Galaxy Survey
     if primary is None:
@@ -1479,33 +1411,7 @@ def isBGS_bright_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
                       gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
                       gaiagmag=None, objtype=None, primary=None):
     """Target Definition of BGS bright targets for the DECaLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            inverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            ``True`` if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
+    (see, e.g., :func:`~desitarget.cuts.isBGS_faint`).
     """
     #------ Bright Galaxy Survey
     if primary is None:

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1287,7 +1287,7 @@ def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
     bgs &= ~brightstarinblob
 
     if targtype == 'bright':
-        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )        
+        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
     elif targtype == 'faint':
         bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
     elif targtype == 'wise':

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1256,7 +1256,7 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     bgs &= notinBGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                          gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
                          gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                         gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
+                         gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr,
                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
                          gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1236,7 +1236,8 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         primary: array_like or None
             If given, the BRICK_PRIMARY column of the catalogue.
         south: boolean, defaults to ``True``
-            Call isBGS_faint_north if ``south=False``, otherwise call isBGS_faint_south.
+            Use cuts appropriate to the Northern imaging surveys (BASS/MzLS) if ``south=False``,
+            otherwise use cuts appropriate to the Southern imaging survey (DECaLS).
         targtype: str, optional, defaults to ``faint``
             Pass ``bright`` to use colors appropriate to the ``BGS_BRIGHT`` selection
             or ``faint`` to use colors appropriate to the ``BGS_BRIGHT`` selection
@@ -1277,11 +1278,11 @@ def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
     _check_BGS_targtype()
     bgs = np.ones(len(gnobs), dtype='?')
 
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
+    bgs &= (gnobs >= 1) & (rnobs >= 1) & (znobs >= 1)
+    bgs &= (gfracmasked < 0.4) & (rfracmasked < 0.4) & (zfracmasked < 0.4)
+    bgs &= (gfracflux < 5.0) & (rfracflux < 5.0) & (zfracflux < 5.0)
+    bgs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
+    bgs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
 
     bgs &= ~brightstarinblob
 
@@ -2250,38 +2251,26 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # ADM combine quasar target bits for a quasar target based on any imaging
     qso = (qso_north & photsys_north) | (qso_south & photsys_south)
 
+    # ADM set the BGS bits
+    bgs_classes = []
     if "BGS" in tcnames:
-        #ADM set the BGS bits
-        bgs_bright_north = targcuts.isBGS_bright(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, 
-                      gnobs=gnobs, rnobs=rnobs, znobs=znobs, gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                      gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                      gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr,
-                      gaiagmag=gaiagmag, objtype=objtype, primary=primary, south=False)
-        bgs_bright_south = targcuts.isBGS_bright(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, 
-                      gnobs=gnobs, rnobs=rnobs, znobs=znobs, gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                      gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                      gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr,
-                      gaiagmag=gaiagmag, objtype=objtype, primary=primary, south=True)
-        bgs_faint_north = targcuts.isBGS_faint(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, 
-                      gnobs=gnobs, rnobs=rnobs, znobs=znobs, gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                      gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                      gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr,
-                      gaiagmag=gaiagmag, objtype=objtype, primary=primary, south=False)
-        bgs_faint_south = targcuts.isBGS_faint(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, 
-                      gnobs=gnobs, rnobs=rnobs, znobs=znobs, gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                      gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                      gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr,
-                      gaiagmag=gaiagmag, objtype=objtype, primary=primary, south=True)
-        bgs_wise_north = targcuts.isBGS_wise(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, 
-                      gnobs=gnobs, rnobs=rnobs, znobs=znobs, gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                      gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                      gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr,
-                      gaiagmag=gaiagmag, objtype=objtype, primary=primary, south=False)
-        bgs_wise_south = targcuts.isBGS_wise(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux, 
-                      gnobs=gnobs, rnobs=rnobs, znobs=znobs, gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                      gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                      gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr,
-                      gaiagmag=gaiagmag, objtype=objtype, primary=primary, south=True)
+            for targtype in ["bright", "faint", "wise"]:
+                for south in [False, True]:
+                    bgsclasses.append(
+                        targcuts.isBGS(gflux=gflux, rflux=rflux, zflux=zflux, 
+                                       w1flux=w1flux, w2flux=w2flux, 
+                                       gnobs=gnobs, rnobs=rnobs, znobs=znobs, 
+                                       gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+                                       gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, 
+                                       gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
+                                       gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, 
+                                       brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag, 
+                                       objtype=objtype, primary=primary, south=south, targtype=targtype)
+
+    bgs_bright_north, bgs_bright_south,  \
+    bgs_faint_north, bgs_faint_south,    \
+    bgs_wise_north, bgs_wise_south =     \
+                        bgs_classes
         
     else:
         # ADM if not running the BGS selection, set everything to arrays of False

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1257,11 +1257,11 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
                           gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
                           gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
                           gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
-                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                          brightstarinblob=brightstarinblob, targtype=targtype)
+                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr, 
+                          gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
 
     bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
-                        Grr=Grr, gaiagmag=gaiagmag, south=south, targtype=targtype)
+                        south=south, targtype=targtype)
 
     return bgs
 
@@ -1270,8 +1270,8 @@ def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
                    gfracmasked=None, rfracmasked=None, zfracmasked=None,
                    gfracflux=None, rfracflux=None, zfracflux=None,
                    gfracin=None, rfracin=None, zfracin=None, w1snr=None,
-                   gfluxivar=None, rfluxivar=None, zfluxivar=None,
-                   brightstarinblob=None, targtype=None):
+                   gfluxivar=None, rfluxivar=None, zfluxivar=None, Grr=None,
+                   gaiagmag=None, brightstarinblob=None, targtype=None):
     """Standard set of masking cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS_faint` for parameters).
     """
@@ -1286,14 +1286,22 @@ def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
 
     bgs &= ~brightstarinblob
 
-    if targtype == 'wise':
+    if targtype == 'bright':
+        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )        
+    elif targtype == 'faint':
+        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
+    elif targtype == 'wise':
+        bgs &= Grr < 0.4
+        bgs &= Grr > -1
         bgs &= w1snr > 5
+    else:
+        _check_BGS_targtype(targtype)
 
     return bgs
 
 
 def isBGS_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-                 Grr=None, gaiagmag=None, south=True, targtype=None):
+                 south=True, targtype=None):
     """Standard set of masking cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
@@ -1301,15 +1309,11 @@ def isBGS_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)
-        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
     elif targtype == 'faint':
         bgs &= rflux > 10**((22.5-20.0)/2.5)
         bgs &= rflux <= 10**((22.5-19.5)/2.5)
-        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
     elif targtype == 'wise':
         bgs &= rflux > 10**((22.5-20.0)/2.5)
-        bgs &= Grr < 0.4
-        bgs &= Grr > -1
         bgs &= w1flux*gflux > (zflux*rflux)*10**(-0.2)
     else:
         _check_BGS_targtype(targtype)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1257,7 +1257,7 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
                           gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
                           gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
                           gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
-                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr, 
+                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
                           gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
 
     bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1475,7 +1475,7 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
                           gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
                           gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
                           gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
-                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr, 
+                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
                           gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
 
     bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1471,12 +1471,12 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         primary = np.ones_like(rflux, dtype='?')
     bgs = primary.copy()
 
-    bgs &= notin_BGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                          gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                          gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                          gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
-                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
-                          gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
+    bgs &= notinBGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                         gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+                         gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
+                         gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
+                         gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
+                         gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
 
     bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
                         south=south, targtype=targtype)
@@ -1484,12 +1484,12 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     return bgs
 
 
-def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
-                   gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                   gfracflux=None, rfracflux=None, zfracflux=None,
-                   gfracin=None, rfracin=None, zfracin=None, w1snr=None,
-                   gfluxivar=None, rfluxivar=None, zfluxivar=None, Grr=None,
-                   gaiagmag=None, brightstarinblob=None, targtype=None):
+def notinBGS_mask(gnobs=None, rnobs=None, znobs=None,
+                  gfracmasked=None, rfracmasked=None, zfracmasked=None,
+                  gfracflux=None, rfracflux=None, zfracflux=None,
+                  gfracin=None, rfracin=None, zfracin=None, w1snr=None,
+                  gfluxivar=None, rfluxivar=None, zfluxivar=None, Grr=None,
+                  gaiagmag=None, brightstarinblob=None, targtype=None):
     """Standard set of masking cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS_faint` for parameters).
     """

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1474,7 +1474,7 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     bgs &= notinBGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                          gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
                          gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                         gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
+                         gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr,
                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
                          gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1420,6 +1420,7 @@ def isQSO_randomforest_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2
     
     return qso
 
+
 def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
           gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
           gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
@@ -1474,11 +1475,11 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
                           gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
                           gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
                           gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
-                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                          brightstarinblob=brightstarinblob, targtype=targtype)
+                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr, 
+                          gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, targtype=targtype)
 
     bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
-                        Grr=Grr, gaiagmag=gaiagmag, south=south, targtype=targtype)
+                        south=south, targtype=targtype)
 
     return bgs
 
@@ -1487,8 +1488,8 @@ def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
                    gfracmasked=None, rfracmasked=None, zfracmasked=None,
                    gfracflux=None, rfracflux=None, zfracflux=None,
                    gfracin=None, rfracin=None, zfracin=None, w1snr=None,
-                   gfluxivar=None, rfluxivar=None, zfluxivar=None,
-                   brightstarinblob=None, targtype=None):
+                   gfluxivar=None, rfluxivar=None, zfluxivar=None, Grr=None,
+                   gaiagmag=None, brightstarinblob=None, targtype=None):
     """Standard set of masking cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS_faint` for parameters).
     """
@@ -1503,14 +1504,22 @@ def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
 
     bgs &= ~brightstarinblob
 
-    if targtype == 'wise':
+    if targtype == 'bright':
+        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
+    elif targtype == 'faint':
+        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
+    elif targtype == 'wise':
+        bgs &= Grr < 0.4
+        bgs &= Grr > -1
         bgs &= w1snr > 5
+    else:
+        _check_BGS_targtype(targtype)
 
     return bgs
 
 
 def isBGS_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-                 Grr=None, gaiagmag=None, south=True, targtype=None):
+                 south=True, targtype=None):
     """Standard set of masking cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
@@ -1518,15 +1527,11 @@ def isBGS_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)
-        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
     elif targtype == 'faint':
         bgs &= rflux > 10**((22.5-20.0)/2.5)
         bgs &= rflux <= 10**((22.5-19.5)/2.5)
-        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
     elif targtype == 'wise':
         bgs &= rflux > 10**((22.5-20.0)/2.5)
-        bgs &= Grr < 0.4
-        bgs &= Grr > -1
         bgs &= w1flux*gflux > (zflux*rflux)*10**(-0.2)
     else:
         _check_BGS_targtype(targtype)
@@ -1543,5 +1548,4 @@ def isBGS_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         bgs &= zflux < rflux * 10**(4.0/2.5)
 
     return bgs
-
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -18,7 +18,7 @@ import warnings
 from time import time
 from pkg_resources import resource_filename
 
-from desitarget.cuts import _getColors, _psflike
+from desitarget.cuts import _getColors, _psflike, _check_BGS_targtype
 
 # ADM set up the DESI default logger
 from desiutil.log import get_logger
@@ -946,518 +946,6 @@ def isMWSSTAR_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=Non
     return mwsstar
 
 
-def isBGS_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
-                gaiagmag=None, objtype=None, primary=None, south=True):
-    """Convenience function for backwards-compatability prior to north/south split.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-        south: boolean, defaults to ``True``
-            Call isBGS_faint_north if ``south=False``, otherwise call isBGS_faint_south.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    if south == False:
-        return isBGS_faint_north(gflux, rflux, zflux, w1flux, w2flux, 
-                      gnobs, rnobs, znobs, gfracmasked, rfracmasked, zfracmasked,
-                      gfracflux, rfracflux, zfracflux, gfracin, rfracin, zfracin,
-                      gfluxivar, rfluxivar, zfluxivar, brightstarinblob, Grr,
-                      gaiagmag, objtype=objtype, primary=primary)
-    else:
-        return isBGS_faint_south(gflux, rflux, zflux, w1flux, w2flux, 
-                      gnobs, rnobs, znobs, gfracmasked, rfracmasked, zfracmasked,
-                      gfracflux, rfracflux, zfracflux, gfracin, rfracin, zfracin,
-                      gfluxivar, rfluxivar, zfluxivar, brightstarinblob, Grr,
-                      gaiagmag, objtype=objtype, primary=primary)
-
-
-def isBGS_faint_north(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                      gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                      gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                      gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
-                      gaiagmag=None, objtype=None, primary=None):
-    """Target Definition of BGS faint targets for the BASS/MzLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    #------ Bright Galaxy Survey
-    if primary is None:
-        primary = np.ones_like(rflux, dtype='?')
-    bgs = primary.copy()
-    bgs_gaia = primary.copy()
-    bgs_nogaia = primary.copy()
-    bgs &= rflux > 10**((22.5-20.0)/2.5)
-    bgs &= rflux <= 10**((22.5-19.5)/2.5)
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
-    bgs &= rflux > gflux * 10**(-1.0/2.5)
-    bgs &= rflux < gflux * 10**(4.0/2.5)
-    bgs &= zflux > rflux * 10**(-1.0/2.5)
-    bgs &= zflux < rflux * 10**(4.0/2.5)
-    bgs &= ~brightstarinblob
-    bgs_gaia = bgs & (Grr > 0.6)
-    bgs_nogaia = bgs & (gaiagmag == 0)
-    bgs = bgs_gaia | bgs_nogaia
-    #if objtype is not None:
-    #    bgs &= ~_psflike(objtype)
-
-    return bgs
-
-
-def isBGS_faint_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                      gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                      gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                      gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
-                      gaiagmag=None, objtype=None, primary=None):
-    """Target Definition of BGS faint targets for the DECaLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    #------ Bright Galaxy Survey
-    if primary is None:
-        primary = np.ones_like(rflux, dtype='?')
-    bgs = primary.copy()
-    bgs_gaia = primary.copy()
-    bgs_nogaia = primary.copy()
-    bgs &= rflux > 10**((22.5-20.0)/2.5)
-    bgs &= rflux <= 10**((22.5-19.5)/2.5)
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
-    bgs &= rflux > gflux * 10**(-1.0/2.5)
-    bgs &= rflux < gflux * 10**(4.0/2.5)
-    bgs &= zflux > rflux * 10**(-1.0/2.5)
-    bgs &= zflux < rflux * 10**(4.0/2.5)
-    bgs &= ~brightstarinblob
-    bgs_gaia = bgs & (Grr > 0.6)
-    bgs_nogaia = bgs & (gaiagmag == 0)
-    bgs = bgs_gaia | bgs_nogaia
-    #if objtype is not None:
-    #    bgs &= ~_psflike(objtype)
-
-    return bgs
-
-
-def isBGS_bright(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                      gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                      gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                      gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
-                      gaiagmag=None, objtype=None, primary=None, south=True):
-    """Convenience function for backwards-compatability prior to north/south split.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-        south: boolean, defaults to ``True``
-            Call isBGS_bright_north if ``south=False``, otherwise call isBGS_bright_south.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    if south == False:
-        return isBGS_bright_north(gflux, rflux, zflux, w1flux, w2flux, 
-                      gnobs, rnobs, znobs, gfracmasked, rfracmasked, zfracmasked,
-                      gfracflux, rfracflux, zfracflux, gfracin, rfracin, zfracin,
-                      gfluxivar, rfluxivar, zfluxivar, brightstarinblob, Grr,
-                      gaiagmag, objtype=objtype, primary=primary)
-    else:
-        return isBGS_bright_south(gflux, rflux, zflux, w1flux, w2flux, 
-                      gnobs, rnobs, znobs, gfracmasked, rfracmasked, zfracmasked,
-                      gfracflux, rfracflux, zfracflux, gfracin, rfracin, zfracin,
-                      gfluxivar, rfluxivar, zfluxivar, brightstarinblob, Grr,
-                      gaiagmag, objtype=objtype, primary=primary)
-
-
-def isBGS_bright_north(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                      gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                      gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                      gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
-                      gaiagmag=None, objtype=None, primary=None):
-    """Target Definition of BGS bright targets for the BASS/MzLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    #------ Bright Galaxy Survey
-    if primary is None:
-        primary = np.ones_like(rflux, dtype='?')
-    bgs = primary.copy()
-    bgs_gaia = primary.copy()
-    bgs_nogaia = primary.copy()
-    bgs &= rflux > 10**((22.5-19.5)/2.5)
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
-    bgs &= rflux > gflux * 10**(-1.0/2.5)
-    bgs &= rflux < gflux * 10**(4.0/2.5)
-    bgs &= zflux > rflux * 10**(-1.0/2.5)
-    bgs &= zflux < rflux * 10**(4.0/2.5)
-    bgs &= ~brightstarinblob
-    bgs_gaia = bgs & (Grr > 0.6)
-    bgs_nogaia = bgs & (gaiagmag == 0)
-    bgs = bgs_gaia | bgs_nogaia
-    #if objtype is not None:
-    #    bgs &= ~_psflike(objtype)
-    return bgs
-
-
-def isBGS_bright_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                      gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                      gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                      gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
-                      gaiagmag=None, objtype=None, primary=None):
-    """Target Definition of BGS bright targets for the DECaLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    #------ Bright Galaxy Survey
-    if primary is None:
-        primary = np.ones_like(rflux, dtype='?')
-    bgs = primary.copy()
-    bgs_gaia = primary.copy()
-    bgs_nogaia = primary.copy()
-    bgs &= rflux > 10**((22.5-19.5)/2.5)
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
-    bgs &= rflux > gflux * 10**(-1.0/2.5)
-    bgs &= rflux < gflux * 10**(4.0/2.5)
-    bgs &= zflux > rflux * 10**(-1.0/2.5)
-    bgs &= zflux < rflux * 10**(4.0/2.5)
-    bgs &= ~brightstarinblob
-    bgs_gaia = bgs & (Grr > 0.6)
-    bgs_nogaia = bgs & (gaiagmag == 0)
-    bgs = bgs_gaia | bgs_nogaia
-    #if objtype is not None:
-    #    bgs &= ~_psflike(objtype)
-    return bgs
-
-
-def isBGS_wise(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-               gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-               gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-               gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None, w1snr=None,
-               gaiagmag=None, objtype=None, primary=None, south=True):
-    """Convenience function for backwards-compatability prior to north/south split.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        w1snr: array_like or None
-            W1 band signal to noise
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-        south: boolean, defaults to ``True``
-            Call isBGS_bright_north if south=False, otherwise call isBGS_bright_south.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    if south==False:
-        return isBGS_wise_north(gflux, rflux, zflux, w1flux, w2flux, 
-                      gnobs, rnobs, znobs, gfracmasked, rfracmasked, zfracmasked,
-                      gfracflux, rfracflux, zfracflux, gfracin, rfracin, zfracin,
-                      gfluxivar, rfluxivar, zfluxivar, brightstarinblob, Grr, w1snr,
-                      gaiagmag, objtype=objtype, primary=primary)
-    else:
-        return isBGS_wise_south(gflux, rflux, zflux, w1flux, w2flux, 
-                      gnobs, rnobs, znobs, gfracmasked, rfracmasked, zfracmasked,
-                      gfracflux, rfracflux, zfracflux, gfracin, rfracin, zfracin,
-                      gfluxivar, rfluxivar, zfluxivar, brightstarinblob, Grr, w1snr,
-                      gaiagmag, objtype=objtype, primary=primary)
-
-
-def isBGS_wise_north(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                     gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                     gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                     gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None, w1snr=None,
-                     gaiagmag=None, objtype=None, primary=None):
-    """Target Definition of BGS bright targets for the BASS/MzLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        w1snr: array_like or None
-            W1 band signal to noise
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    #------ Bright Galaxy Survey
-    if primary is None:
-        primary = np.ones_like(rflux, dtype='?')
-    bgs = primary.copy()
-    bgs &= rflux > 10**((22.5-20.0)/2.5)
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
-    bgs &= rflux > gflux * 10**(-1.0/2.5)
-    bgs &= rflux < gflux * 10**(4.0/2.5)
-    bgs &= zflux > rflux * 10**(-1.0/2.5)
-    bgs &= zflux < rflux * 10**(4.0/2.5)
-    bgs &= ~brightstarinblob
-    bgs &= Grr < 0.4
-    bgs &= Grr > -1
-    bgs &= w1flux*gflux > (zflux*rflux)*10**(-0.2)
-    bgs &= w1snr > 5
-    #if objtype is not None:
-    #    bgs &= ~_psflike(objtype)
-    return bgs
-
-
-def isBGS_wise_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
-                     gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
-                     gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-                     gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None, w1snr=None,
-                     gaiagmag=None, objtype=None, primary=None):
-    """Target Definition of BGS bright targets for the DECaLS photometric system.
-
-    Args:
-        gflux, rflux, zflux, w1flux, w2flux: array_like
-            The flux in nano-maggies of g, r, z, w1, and w2 bands.
-        gnobs, rnobs, znobs: array_like or None
-            Number of observations in g, r, z bands
-        gfracmasked, rfracmasked, zfracmasked: array_like or None
-            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z
-        fracflux, rfracflux, zfracflux: array_like or None
-            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z
-        gfracin, rfracin, zfracin: array_like or None
-            Fraction of a source's flux within the blob in g,r,z
-        gfluxivar, rfluxivar, zfluxivar: array_like or None
-            nverse variance of FLUX g,r,z
-        brightstarinblob: boolean array_like or None
-            True if the object shares a blob with a "bright" (Tycho-2) star
-        Grr: array_like or None
-            Gaia G band magnitude minus observational r magnitude
-        w1snr: array_like or None
-            W1 band signal to noise
-        gaiagmag: array_like or None
-            Gaia G band magnitude
-        objtype: array_like or None
-            If given, The TYPE column of the catalogue.
-        primary: array_like or None
-            If given, the BRICK_PRIMARY column of the catalogue.
-
-    Returns:
-        mask : array_like. True if and only if the object is a BGS target.
-    """
-    #------ Bright Galaxy Survey
-    if primary is None:
-        primary = np.ones_like(rflux, dtype='?')
-    bgs = primary.copy()
-    bgs &= rflux > 10**((22.5-20.0)/2.5)
-    bgs &= (gnobs>=1) & (rnobs>=1) & (znobs>=1)
-    bgs &= (gfracmasked<0.4) & (rfracmasked<0.4) & (zfracmasked<0.4)
-    bgs &= (gfracflux<5.0) & (rfracflux<5.0) & (zfracflux<5.0)
-    bgs &= (gfracin>0.3) & (rfracin>0.3) & (zfracin>0.3)
-    bgs &= (gfluxivar>0) & (rfluxivar>0) & (zfluxivar>0)
-    bgs &= rflux > gflux * 10**(-1.0/2.5)
-    bgs &= rflux < gflux * 10**(4.0/2.5)
-    bgs &= zflux > rflux * 10**(-1.0/2.5)
-    bgs &= zflux < rflux * 10**(4.0/2.5)
-    bgs &= ~brightstarinblob
-    bgs &= Grr < 0.4
-    bgs &= Grr > -1
-    bgs &= w1flux*gflux > (zflux*rflux)*10**(-0.2)
-    bgs &= w1snr > 5
-    #if objtype is not None:
-    #    bgs &= ~_psflike(objtype)
-    return bgs
-
-
 def isQSO_colors(gflux, rflux, zflux, w1flux, w2flux, optical=False, south=True):
     """Convenience function for backwards-compatability prior to north/south split.
 
@@ -1931,4 +1419,129 @@ def isQSO_randomforest_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2
         qso = qso[0]
     
     return qso
+
+def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, 
+          gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
+          gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
+          gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
+          w1snr=None, gaiagmag=None, objtype=None, primary=None, south=True, targtype=None):
+    """Convenience function for backwards-compatability prior to north/south split.
+
+    Args:
+        gflux, rflux, zflux, w1flux, w2flux: array_like
+            The flux in nano-maggies of g, r, z, w1, and w2 bands.
+        gnobs, rnobs, znobs: array_like or None
+            Number of observations in g, r, z bands.
+        gfracmasked, rfracmasked, zfracmasked: array_like or None
+            Profile-weighted fraction of pixels masked from all observations of this object in g,r,z.
+        fracflux, rfracflux, zfracflux: array_like or None
+            Profile-weighted fraction of the flux from other sources divided by the total flux in g,r,z.
+        gfracin, rfracin, zfracin: array_like or None
+            Fraction of a source's flux within the blob in g,r,z.
+        gfluxivar, rfluxivar, zfluxivar: array_like or None
+            inverse variance of FLUX g,r,z.
+        brightstarinblob: boolean array_like or None
+            ``True`` if the object shares a blob with a "bright" (Tycho-2) star.
+        Grr: array_like or None
+            Gaia G band magnitude minus observational r magnitude.
+        w1snr: array_like or None
+            W1 band signal to noise.
+        gaiagmag: array_like or None
+            Gaia G band magnitude.
+        objtype: array_like or None
+            If given, The TYPE column of the catalogue.
+        primary: array_like or None
+            If given, the BRICK_PRIMARY column of the catalogue.
+        south: boolean, defaults to ``True``
+            Use cuts appropriate to the Northern imaging surveys (BASS/MzLS) if ``south=False``,
+            otherwise use cuts appropriate to the Southern imaging survey (DECaLS).
+        targtype: str, optional, defaults to ``faint``
+            Pass ``bright`` to use colors appropriate to the ``BGS_BRIGHT`` selection
+            or ``faint`` to use colors appropriate to the ``BGS_BRIGHT`` selection
+            or ``wise`` to use colors appropriate to the ``BGS_BRIGHT`` selection.
+
+    Returns:
+        mask : array_like. True if and only if the object is a BGS target.
+    """
+    _check_BGS_targtype(targtype)
+
+    #------ Bright Galaxy Survey
+    if primary is None:
+        primary = np.ones_like(rflux, dtype='?')
+    bgs = primary.copy()
+
+    bgs &= notin_BGS_mask(gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                          gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+                          gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
+                          gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr, 
+                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
+                          brightstarinblob=brightstarinblob, targtype=targtype)
+
+    bgs &= isBGS_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
+                        Grr=Grr, gaiagmag=gaiagmag, south=south, targtype=targtype)
+
+    return bgs
+
+
+def notin_BGS_mask(gnobs=None, rnobs=None, znobs=None,
+                   gfracmasked=None, rfracmasked=None, zfracmasked=None,
+                   gfracflux=None, rfracflux=None, zfracflux=None,
+                   gfracin=None, rfracin=None, zfracin=None, w1snr=None,
+                   gfluxivar=None, rfluxivar=None, zfluxivar=None,
+                   brightstarinblob=None, targtype=None):
+    """Standard set of masking cuts used by all BGS target selection classes
+    (see, e.g., :func:`~desitarget.cuts.isBGS_faint` for parameters).
+    """
+    _check_BGS_targtype(targtype)
+    bgs = np.ones(len(gnobs), dtype='?')
+
+    bgs &= (gnobs >= 1) & (rnobs >= 1) & (znobs >= 1)
+    bgs &= (gfracmasked < 0.4) & (rfracmasked < 0.4) & (zfracmasked < 0.4)
+    bgs &= (gfracflux < 5.0) & (rfracflux < 5.0) & (zfracflux < 5.0)
+    bgs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
+    bgs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
+
+    bgs &= ~brightstarinblob
+
+    if targtype == 'wise':
+        bgs &= w1snr > 5
+
+    return bgs
+
+
+def isBGS_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+                 Grr=None, gaiagmag=None, south=True, targtype=None):
+    """Standard set of masking cuts used by all BGS target selection classes
+    (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
+    """
+    bgs = np.ones(len(gflux), dtype='?')
+
+    if targtype == 'bright':
+        bgs &= rflux > 10**((22.5-19.5)/2.5)
+        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
+    elif targtype == 'faint':
+        bgs &= rflux > 10**((22.5-20.0)/2.5)
+        bgs &= rflux <= 10**((22.5-19.5)/2.5)
+        bgs &= ( (Grr > 0.6) | (gaiagmag == 0) )
+    elif targtype == 'wise':
+        bgs &= rflux > 10**((22.5-20.0)/2.5)
+        bgs &= Grr < 0.4
+        bgs &= Grr > -1
+        bgs &= w1flux*gflux > (zflux*rflux)*10**(-0.2)
+    else:
+        _check_BGS_targtype(targtype)
+
+    if south:
+        bgs &= rflux > gflux * 10**(-1.0/2.5)
+        bgs &= rflux < gflux * 10**(4.0/2.5)
+        bgs &= zflux > rflux * 10**(-1.0/2.5)
+        bgs &= zflux < rflux * 10**(4.0/2.5)
+    else:
+        bgs &= rflux > gflux * 10**(-1.0/2.5)
+        bgs &= rflux < gflux * 10**(4.0/2.5)
+        bgs &= zflux > rflux * 10**(-1.0/2.5)
+        bgs &= zflux < rflux * 10**(4.0/2.5)
+
+    return bgs
+
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -133,61 +133,20 @@ class TestCuts(unittest.TestCase):
         elg2 = cuts.isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)
         self.assertTrue(np.all(elg1==elg2))
 
-        bgs1 = cuts.isBGS_bright(gflux=gflux, rflux=rflux, zflux=zflux,
-                gnobs=gnobs, rnobs=rnobs, znobs=znobs, 
-                gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, 
-                gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, 
-                brightstarinblob=brightstarinblob, Grr=Grr,
-                gaiagmag=gaiagmag, primary=primary)
-        bgs2 = cuts.isBGS_bright(gflux=gflux, rflux=rflux, zflux=zflux,
-                gnobs=gnobs, rnobs=rnobs, znobs=znobs, 
-                gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux, 
-                gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, 
-                brightstarinblob=brightstarinblob, Grr=Grr,
-                gaiagmag=gaiagmag, primary=None)
-        self.assertTrue(np.all(bgs1==bgs2))
-
-        bgs1 = cuts.isBGS_faint(gflux=gflux, rflux=rflux, zflux=zflux,
-                gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                brightstarinblob=brightstarinblob, Grr=Grr,
-                gaiagmag=gaiagmag, primary=primary)
-        bgs2 = cuts.isBGS_faint(gflux=gflux, rflux=rflux, zflux=zflux,
-                gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                brightstarinblob=brightstarinblob, Grr=Grr,
-                gaiagmag=gaiagmag, primary=None)
-        self.assertTrue(np.all(bgs1==bgs2))
-
-        bgs1 = cuts.isBGS_wise(gflux=gflux, rflux=rflux, zflux=zflux,
-                w1flux=w1flux, w2flux=w2flux,
-                gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr,
-                gaiagmag=gaiagmag, primary=primary)
-        bgs2 = cuts.isBGS_wise(gflux=gflux, rflux=rflux, zflux=zflux,
-                w1flux=w1flux, w2flux=w2flux,
-                gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr,
-                gaiagmag=gaiagmag, primary=None)
-        self.assertTrue(np.all(bgs1==bgs2))
+        for targtype in ["bright", "faint", "wise"]:
+            bgs = []
+            for primary in [primary, None]:
+                bgs.append(
+                    cuts.isBGS(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
+                        gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                        gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+                        gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
+                        gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
+                        gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
+                        brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag,
+                        primary=primary, targtype=targtype)
+                )
+            self.assertTrue(np.all(bgs[0]==bgs[1]))
 
         # ADM need to include RELEASE for quasar cuts, at least.
         release = targets['RELEASE']


### PR DESCRIPTION
This PR addresses issue https://github.com/desihub/desitarget/issues/406 by splitting the masking part of the BGS selections from the color cuts.

While I was refactoring the BGS algorithms, I worked through the BGS functions to remove any redundant code. Hopefully this will make the code easier to maintain.