### PR TITLE
fix install for cmx and sv1

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.26.0 (unreleased)
 -------------------
 
+* Fix `python setup.py install` for cmx and sv1 directories [`PR #421`_].
 * More updates to target classes, mainly for SV [`PR #418`_]. Includes:
     * First full implementations of `QSO`, `LRG`, `ELG`, and `STD` for SV.
     * Update and refactor of `MWS` and `BGS` classes for the main survey.
@@ -12,6 +13,7 @@ desitarget Change Log
     * Augment QA code to handle SV sub-classes such as `ELG_FDR_FAINT`.
 
 .. _`PR #418`: https://github.com/desihub/desitarget/pull/418
+.. _`PR #421`: https://github.com/desihub/desitarget/pull/421
 
 0.25.0 (2018-11-07)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ setup_keywords['test_suite']='{name}.test.{name}_test_suite.{name}_test_suite'.f
 # Add internal data directories
 #
 setup_keywords['package_data'] = {'desitarget': ['data/*',],
+                                  'desitarget.cmx': ['data/*',],
+                                  'desitarget.sv1': ['data/*',],
                                   'desitarget.test': ['t/*',],
                                   'desitarget.mock': [os.path.relpath(_,'py/desitarget/mock') for _ in [os.path.join(_[0],'*') for _ in os.walk('py/desitarget/mock/data')]],
                                  }


### PR DESCRIPTION
This PR fixes `python setup.py install` for desitarget cmx and sv1 directories:

* `desitarget.sv1` wasn't installed at all because it was missing an `__init__.py` file (ah, python, you used to be so simple...)
* The `data/` directories for both cmx and sv1 were not installed because they weren't included in the `setup.py` file (it auto-discovered python directories, but not data directories).

i.e. desitarget was working fine for "bare" installations of just adding directories to $PATH and $PYTHONPATH, but not for full installations.  I fixed this by hand for the 18.11 software release (desitarget/0.25.0).

Asking @weaverba137 for review about whether I implemented these fixes correctly.