### PR TITLE
Add explicit r > 17.5 limit to QSO color cuts selection.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.26.0 (unreleased)
 -------------------
 
-* Refactor QSO color cuts and add hard r > 17.5 limit [`PR #432`_].
+* Refactor QSO color cuts and add hard r > 17.5 limit [`PR #433`_].
 * Minor updates to `select_mock_targets` [`PR #425`_].  
     * Use pre-computed template photometry (requires `v3.1` basis templates). 
     * Include MW dust extinction in the spectra.
@@ -26,7 +26,7 @@ desitarget Change Log
 .. _`PR #423`: https://github.com/desihub/desitarget/pull/423
 .. _`PR #424`: https://github.com/desihub/desitarget/pull/424
 .. _`PR #425`: https://github.com/desihub/desitarget/pull/425
-.. _`PR #432`: https://github.com/desihub/desitarget/pull/432
+.. _`PR #433`: https://github.com/desihub/desitarget/pull/433
 
 0.25.0 (2018-11-07)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.26.0 (unreleased)
 -------------------
 
+* Refactor QSO color cuts and add hard r > 17.5 limit [`PR #432`_].
 * Minor updates to `select_mock_targets` [`PR #425`_].  
     * Use pre-computed template photometry (requires `v3.1` basis templates). 
     * Include MW dust extinction in the spectra.
@@ -25,6 +26,7 @@ desitarget Change Log
 .. _`PR #423`: https://github.com/desihub/desitarget/pull/423
 .. _`PR #424`: https://github.com/desihub/desitarget/pull/424
 .. _`PR #425`: https://github.com/desihub/desitarget/pull/425
+.. _`PR #432`: https://github.com/desihub/desitarget/pull/432
 
 0.25.0 (2018-11-07)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1050,7 +1050,7 @@ def isQSO_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     grzflux = (gflux + 0.8*rflux + 0.5*zflux) / 2.3
 
     qso = np.ones_like(gflux, dtype='?')
-#    qso &= rflux < 10**((22.5-17.5)/2.5)    # r>17.5
+    qso &= rflux < 10**((22.5-17.5)/2.5)    # r>17.5
     qso &= rflux > 10**((22.5-22.7)/2.5)    # r<22.7
     qso &= grzflux < 10**((22.5-17)/2.5)    # grz>17
     qso &= rflux < gflux * 10**(1.3/2.5)    # (g-r)<1.3


### PR DESCRIPTION
This PR adds an r > 17.5 "bright-end" limit to the QSO color cuts selection for the FDR (see https://github.com/desihub/desitarget/issues/428).

As long as I was adding this limit, I refactored the QSO color cuts selection slightly to make it a little easier to maintain.