### PR TITLE
Remove dependencies on the Legacy Surveys Gaia astrometry files

### DIFF
--- a/bin/make_imaging_weight_map
+++ b/bin/make_imaging_weight_map
@@ -31,8 +31,7 @@ ap.add_argument("--nside", type=int,
                 help='The resolution (HEALPixel nside number) at which to build the map (defaults to 256)',
                 default="256")
 ap.add_argument("--gaialoc",
-                help='Directory of Gaia "chunks" files (to derive stellar density). A FITS file that already contains the Gaia stellar densities at nside can be passed as a speed-up',
-                default='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom')
+                help='Directory of Gaia "chunks" files (to derive stellar density). A FITS file that already contains the Gaia stellar densities at nside can be passed as a speed-up')
 
 ns = ap.parse_args()
 

--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -21,9 +21,6 @@ ap.add_argument("surveydir",
                 help="Base directory for a Legacy Surveys Data Release (e.g. '/global/project/projectdirs/cosmo/data/legacysurvey/dr6/' at NERSC)")
 ap.add_argument("dest", 
                 help="Output GFA targets file (e.g. '/project/projectdirs/desi/target/catalogs/gfas-dr6-0.20.0.fits' at NERSC)")
-ap.add_argument('-g', '--gaiadir',
-                help="Base directory for chunked Gaia files (defaults to ['project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'] for NERSC)",
-                default='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom')
 ap.add_argument('-m', '--maglim', type=float, 
                 help='Magnitude limit on GFA targets in Gaia G-band (defaults to [18])',
                 default=18)
@@ -44,10 +41,8 @@ if len(infiles) == 0:
 
 log.info('running on {} processors...t={:.1f}mins'.format(ns.numproc, (time()-time0)/60.))
 
-gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, 
-                   gaiamatch=ns.gaiamatch, gaiadir=ns.gaiadir)
+gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, gaiamatch=ns.gaiamatch)
 
 io.write_gfas(ns.dest, gfas, indir=ns.surveydir, nside=nside)
 
 log.info('{} GFAs written to {}...t={:.1f}mins'.format(len(gfas), ns.dest, (time()-time0)/60.))
-

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -43,9 +43,6 @@ ap.add_argument('--qsoselection',choices=qso_selection_options,default='randomfo
 ap.add_argument('--Method',choices=Method_sandbox_options,default='XD',
                 help="Method used in sandbox target for ELG")
 ### ap.add_argument('-b', "--bricklist", help='filename with list of bricknames to include')
-ap.add_argument("--gaiadir", 
-                help="Base directory for chunked Gaia files (defaults to ['project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'] for NERSC)",
-                default='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom')
 ap.add_argument("--gaiamatch", action='store_true',
                 help="DO match to Gaia DR2 chunks files in order to populate Gaia columns for MWS/STD selection")
 ap.add_argument("--numproc", type=int,
@@ -75,7 +72,7 @@ else:
     targets = select_targets(infiles, numproc=ns.numproc,
                              qso_selection=ns.qsoselection, gaiamatch=ns.gaiamatch,
                              sandbox=ns.sandbox, FoMthresh=ns.FoMthresh, Method=ns.Method,
-                             gaiadir=ns.gaiadir, tcnames=tcnames, survey='main')
+                             tcnames=tcnames, survey='main')
     if ns.mask:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 

--- a/bin/write_gaia_matches
+++ b/bin/write_gaia_matches
@@ -21,9 +21,6 @@ ap.add_argument("src",
                 help="Sweeps file or root directory with sweeps files")
 ap.add_argument("dest", 
                 help="Output directory")
-ap.add_argument("--gaiadir", 
-                help="Base directory for chunked Gaia files (defaults to ['/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'] for NERSC)",
-                default='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom')
 ap.add_argument("--numproc", type=int,
                 help='number of concurrent processes to use [{}]'.format(nproc),
                 default=nproc)
@@ -36,7 +33,7 @@ if len(infiles) == 0:
 
 log.info("running on {} processors".format(ns.numproc))
 
-write_gaia_matches(infiles, numproc=ns.numproc, outdir=ns.dest, gaiadir=ns.gaiadir)
+write_gaia_matches(infiles, numproc=ns.numproc, outdir=ns.dest)
 
 log.info('Wrote sweeps files matched to Gaia to {}...t={:.1f}s'.format(ns.dest, time()-start))
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,13 @@ desitarget Change Log
 0.26.0 (unreleased)
 -------------------
 
+* Remove reliance on Legacy Surveys for Gaia data [`PR #438`_]. Includes:
+    * Use ``$GAIA_DIR`` environment variable instead of passing a directory.
+    * Functions to wget Gaia DR2 CSV files and convert them to FITS.
+    * Function to reorganize Gaia FITS files into (NESTED) HEALPixels.
+    * Use the NESTED HEALPix scheme for Gaia files throughout desitarget.
+    * Change output column ``TYPE`` to ``MORPHTYPE`` for GFAs.
+* Refactor QSO color cuts and add hard r > 17.5 limit [`PR #433`_].
 * Refactor of MTL and MTL-related enhancements [`PR #429`_]. Includes:
     * Use targets file `NUMOBS_INIT` not :func:`targets.calc_numobs`.
     * Use targets file `PRIORITY_INIT` not :func:`targets.calc_priority`.
@@ -12,7 +19,6 @@ desitarget Change Log
     * New function :func:`targets.calc_priority_no_table` to use less memory.
     * Set informational (`NORTH/SOUTH`) bits to 0 `PRIORITY` and `NUMOBS`.
     * Set priorities using `LRG_1PASS/2PASS` bits rather than on `LRG`.
-* Refactor QSO color cuts and add hard r > 17.5 limit [`PR #433`_].
 * Minor updates to `select_mock_targets` [`PR #425`_].  
     * Use pre-computed template photometry (requires `v3.1` basis templates). 
     * Include MW dust extinction in the spectra.
@@ -35,6 +41,7 @@ desitarget Change Log
 .. _`PR #425`: https://github.com/desihub/desitarget/pull/425
 .. _`PR #429`: https://github.com/desihub/desitarget/pull/429
 .. _`PR #433`: https://github.com/desihub/desitarget/pull/433
+.. _`PR #438`: https://github.com/desihub/desitarget/pull/438
 
 0.25.0 (2018-11-07)
 -------------------

--- a/etc/desitarget.module
+++ b/etc/desitarget.module
@@ -76,3 +76,4 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
+setenv GAIA_DIR /project/projectdirs/desi/target/gaia_dr2

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -25,7 +25,8 @@ from astropy.table import Table, Row
 
 from desitarget import io
 from desitarget.internal import sharedmem
-from desitarget.gaiamatch import match_gaia_to_primary, pop_gaia_coords
+from desitarget.gaiamatch import match_gaia_to_primary
+from desitarget.gaiamatch import pop_gaia_coords, pop_gaia_columns
 from desitarget.targets import finalize
 
 # ADM set up the DESI default logger
@@ -2018,6 +2019,13 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
         # ADM remove the GAIA_RA, GAIA_DEC columns as they aren't
         # ADM in the imaging surveys data model.
         gaiainfo = pop_gaia_coords(gaiainfo)
+        # ADM if we need to match to Gaia, stick to the first Gaia data model
+        # ADM that we adopted for DR7.
+        gaiainfo = pop_gaia_columns(
+            gaiainfo,
+            ['REF_CAT', 'GAIA_PHOT_BP_RP_EXCESS_FACTOR',
+            'GAIA_ASTROMETRIC_SIGMA5D_MAX', 'GAIA_ASTROMETRIC_PARAMS_SOLVED']
+        )
         # ADM add the Gaia column information to the primary array.
         for col in gaiainfo.dtype.names:
             objects[col] = gaiainfo[col]

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1963,7 +1963,6 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
 def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
                tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD"],
-               gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom',
                qso_optical_cuts=False, survey='main'):
     """Perform target selection on objects, returning target mask arrays.
 
@@ -1982,8 +1981,6 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
         A list of strings, e.g. ['QSO','LRG']. If passed, process targeting only
         for those specific target classes. A useful speed-up when testing.
         Options include ["ELG", "QSO", "LRG", "MWS", "BGS", "STD"].
-    gaiadir : :class:`str`, optional, defaults to the Gaia DR2 path at NERSC
-        Root directory of a Gaia Data Release as used by `the Legacy Surveys`_.
     qso_optical_cuts : :class:`boolean` defaults to ``False``
         Apply just optical color-cuts when selecting QSOs with
         ``qso_selection="colorcuts"``.
@@ -2015,7 +2012,7 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
     if gaiamatch and ("MWS" in tcnames or "STD" in tcnames):
         log.info('Matching Gaia to {} primary objects...t = {:.1f}s'
                  .format(len(objects), time()-start))
-        gaiainfo = match_gaia_to_primary(objects, gaiadir=gaiadir)
+        gaiainfo = match_gaia_to_primary(objects)
         log.info('Done with Gaia match for {} primary objects...t = {:.1f}s'
                  .format(len(objects), time()-start))
         # ADM remove the GAIA_RA, GAIA_DEC columns as they aren't
@@ -2205,7 +2202,6 @@ Method_sandbox_options = ['XD', 'RF_photo', 'RF_spectro']
 def select_targets(infiles, numproc=4, qso_selection='randomforest',
                    gaiamatch=False, sandbox=False, FoMthresh=None, Method=None,
                    tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD"],
-                   gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom',
                    survey='main'):
     """Process input files in parallel to select targets.
 
@@ -2233,8 +2229,6 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         A list of strings, e.g. ['QSO','LRG']. If passed, process targeting only
         for those specific target classes. A useful speed-up when testing.
         Options include ["ELG", "QSO", "LRG", "MWS", "BGS", "STD"].
-    gaiadir : :class:`str`, optional, defaults to Gaia DR2 path at NERSC
-        Root directory of a Gaia Data Release as used by `the Legacy Surveys`_.
     survey : :class:`str`, defaults to ``'main'``
         Specifies which target masks yaml file and target selection cuts
         to use. Options are ``'main'`` and ``'svX``' (where X is 1, 2, 3 etc.)
@@ -2288,7 +2282,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         objects = io.read_tractor(filename)
         desi_target, bgs_target, mws_target = apply_cuts(
             objects, qso_selection=qso_selection, gaiamatch=gaiamatch,
-            tcnames=tcnames, gaiadir=gaiadir, survey=survey
+            tcnames=tcnames, survey=survey
         )
 
         return _finalize_targets(objects, desi_target, bgs_target, mws_target)

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -221,7 +221,7 @@ def gaia_csv_to_fits(numproc=4):
         cols = np.array(fitstable.dtype.names)
         boolcols = cols[np.hstack(fitstable.dtype.descr)[1::2] == '<U5']
         for col in boolcols:
-            fitstable[col] =  fitstable[col] == 'true'
+            fitstable[col] = fitstable[col] == 'true'
 
         # ADM only write out the columns we need for targeting.
         nobjs = len(fitstable)
@@ -334,17 +334,17 @@ def gaia_fits_to_healpix(numproc=4):
     pixlist = pickle.load(infile)
     npixels = len(pixlist)
     # ADM include the pixel number explicitly in the look-up table.
-    pixlist = list(zip(np.arange(npixels),pixlist))
+    pixlist = list(zip(np.arange(npixels), pixlist))
 
     # ADM the critical function to run on every file.
     def _write_hpx_fits(pixlist):
         """from files that touch a pixel, write out objects in each pixel"""
         pixnum, files = pixlist
-        # ADM only proceed if some files touch a pixel
+        # ADM only proceed if some files touch a pixel.
         if len(files) > 0:
             # ADM track if it's our first time through the files loop.
             first = True
-            # ADM Read in files that touch a pixel.        
+            # ADM Read in files that touch a pixel.
             for file in files:
                 filename = os.path.join(fitsdir, file)
                 objs = fitsio.read(filename)
@@ -364,7 +364,7 @@ def gaia_fits_to_healpix(numproc=4):
             hdr['HPXNEST'] = True
             fitsio.write(outfile, done, extname='GAIAHPX', header=hdr)
 
-        return 
+        return
 
     # ADM this is just to count processed files in _update_status.
     npix = np.zeros((), dtype='i8')
@@ -433,7 +433,7 @@ def make_gaia_files(numproc=4, download=False):
     # ADM check that the GAIA_DIR is set.
     gaiadir = _get_gaia_dir()
 
-    # ADM a quick check that the fits and healpix directories are empty 
+    # ADM a quick check that the fits and healpix directories are empty
     # ADM before embarking on the slower parts of the code.
     fitsdir = os.path.join(gaiadir, 'fits')
     hpxdir = os.path.join(gaiadir, 'healpix')
@@ -455,6 +455,7 @@ def make_gaia_files(numproc=4, download=False):
     log.info('Rearranged FITS files by HEALPixel...t={:.1f}s'.format(time()-t0))
 
     return
+
 
 def pop_gaia_coords(inarr):
     """Convenience function to pop GAIA_RA and GAIA_DEC columns off an array

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -474,7 +474,7 @@ def pop_gaia_coords(inarr):
     names = list(inarr.dtype.names)
 
     # ADM pop off any instances of GAIA_RA, GAIA_DEC be forgiving if they
-    # ADM aren't in the array
+    # ADM aren't in the array.
     try:
         names.remove("GAIA_RA")
     except ValueError:
@@ -484,6 +484,36 @@ def pop_gaia_coords(inarr):
         names.remove("GAIA_DEC")
     except ValueError:
         pass
+
+    # ADM return the array without GAIA_RA, GAIA_DEC
+    return inarr[names]
+
+
+def pop_gaia_columns(inarr, cols):
+    """Convenience function to pop columns of an input array.
+
+    Parameters
+    ----------
+    inarr : :class:`numpy.ndarray`
+        Structured array with various column names.
+    cols : :class:`list`
+        List of columns to remove from the input array.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Input array with columns in cols removed.
+    """
+    # ADM list of the column names of the passed array
+    names = list(inarr.dtype.names)
+
+    # ADM pop off any instances of GAIA_RA, GAIA_DEC be forgiving if they
+    # ADM aren't in the array.
+    for col in cols:
+        try:
+            names.remove(col)
+        except ValueError:
+            pass
 
     # ADM return the array without GAIA_RA, GAIA_DEC
     return inarr[names]
@@ -672,7 +702,7 @@ def find_gaia_files_box(gaiabounds, neighbors=True):
     return gaiafiles
 
 
-def match_gaia_to_primary(objs, matchrad=1., retaingaia=False, 
+def match_gaia_to_primary(objs, matchrad=1., retaingaia=False,
                           gaiabounds=[0., 360., -90., 90.]):
     """Match a set of objects to Gaia healpix files and return the Gaia information.
 

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -69,7 +69,7 @@ def _get_gaia_dir():
     :class:`str`
         The directory stored in the $GAIA_DIR environment variable.
     """
-    # ADM check that the GAIA_DIR is set, or fail.
+    # ADM check that the $GAIA_DIR environment variable is set.
     gaiadir = os.environ.get('GAIA_DIR')
     if gaiadir is None:
         msg = "Set $GAIA_DIR environment variable!"
@@ -861,6 +861,7 @@ def write_gaia_matches(infiles, numproc=4, outdir=".")
     Notes
     -----
         - if numproc==1, use the serial code instead of the parallel code.
+        - The environment variable $GAIA_DIR must be set.
     """
     # ADM check that the GAIA_DIR is set and retrieve it.
     gaiadir = _get_gaia_dir()

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -164,7 +164,7 @@ def gaia_csv_to_fits(numproc=4):
     -----
         - The environment variable $GAIA_DIR must be set.
         - if numproc==1, use the serial code instead of the parallel code.
-        - Runs in 1-3 hours (depending on node) with numproc=32 for 60,000 files.
+        - Runs in 1-2 hours (depending on node) with numproc=32 for 60,000 files.
     """
     # ADM the resolution at which the Gaia HEALPix files should be stored.
     nside = 32
@@ -198,7 +198,12 @@ def gaia_csv_to_fits(numproc=4):
         outbase = os.path.basename(infile)
         outfilename = "{}.fits".format(outbase.split(".")[0])
         outfile = os.path.join(fitsdir, outfilename)
-        fitstable = ascii.read(infile)
+        fitstable = ascii.read(infile, format='csv')
+        # ADM need to convert 5-string values to boolean.
+        cols = np.array(fitstable.dtype.names)
+        boolcols = cols[np.hstack(fitstable.dtype.descr)[1::2] == '<U5']
+        for col in boolcols:
+            fitstable[col] =  fitstable[col] == 'true'
         fitstable.write(outfile)
         # ADM return the HEALPixels that this file touches.
         pix = set(radec2pix(nside, fitstable["ra"], fitstable["dec"]))

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -520,7 +520,7 @@ def pop_gaia_columns(inarr, cols):
 
 
 def read_gaia_file(filename, header=False):
-    """Read in a Gaia "chunks" file in the appropriate format for desitarget
+    """Read in a Gaia healpix file in the appropriate format for desitarget.
 
     Parameters
     ----------

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -672,9 +672,9 @@ def find_gaia_files_box(gaiabounds, neighbors=True):
     return gaiafiles
 
 
-def match_gaia_to_primary(objs, matchrad=1.,
-                          retaingaia=False, gaiabounds=[0., 360., -90., 90.])
-    """Match a set of objects to Gaia "chunks" files and return the Gaia information
+def match_gaia_to_primary(objs, matchrad=1., retaingaia=False, 
+                          gaiabounds=[0., 360., -90., 90.]):
+    """Match a set of objects to Gaia healpix files and return the Gaia information.
 
     Parameters
     ----------
@@ -777,7 +777,7 @@ def match_gaia_to_primary(objs, matchrad=1.,
     return gaiainfo
 
 
-def match_gaia_to_primary_single(objs, matchrad=1.)
+def match_gaia_to_primary_single(objs, matchrad=1.):
     """Match ONE object to Gaia "chunks" files and return the Gaia information.
 
     Parameters
@@ -836,7 +836,7 @@ def match_gaia_to_primary_single(objs, matchrad=1.)
     return gaiainfo
 
 
-def write_gaia_matches(infiles, numproc=4, outdir=".")
+def write_gaia_matches(infiles, numproc=4, outdir="."):
     """Match sweeps files to Gaia and rewrite with the Gaia columns added
 
     Parameters

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -29,12 +29,12 @@ from . import __version__ as desitarget_version
 
 import healpy as hp
 
-# ADM fake the matplotlib display so it doesn't die on allocated nodes
+# ADM fake the matplotlib display so it doesn't die on allocated nodes.
 import matplotlib
 matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-from matplotlib.patches import Circle, Ellipse, Rectangle
-from matplotlib.collections import PatchCollection
+import matplotlib.pyplot as plt   # noqa: E402
+from matplotlib.patches import Circle, Ellipse, Rectangle  # noqa: E402
+from matplotlib.collections import PatchCollection  # noqa: E402
 
 
 def ellipse_matrix(r, e1, e2):

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -242,7 +242,7 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
         objects = desitarget.io.read_tractor(objects)
 
     # ADM issue a warning if gaiamatch was not sent but there's no Gaia information
-    if np.max(objects['PARALLAX']) == 0. and ~gaiamatch:
+    if np.max(objects['PARALLAX']) == 0. and not gaiamatch:
         log.warning("Zero objects have a parallax. Did you mean to send gaiamatch?")
 
     # ADM add the Gaia coordinate columns if they don't exist and

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -214,8 +214,7 @@ def add_gfa_info_to_fa_tiles(gfa_file_path="./", fa_file_path=None, output_path=
 
 
 def gaia_gfas_from_sweep(objects, maglim=18.,
-                         gaiamatch=False, gaiabounds=[0., 360., -90., 90.],
-                         gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'):
+                         gaiamatch=False, gaiabounds=[0., 360., -90., 90.]):
     """Create a set of GFAs from Gaia-matching for one sweep file or sweep objects
 
     Parameters
@@ -231,8 +230,6 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
     gaiabounds : :class:`list`, optional, defaults to the whole sky
         The area over which to retrieve Gaia objects that don't match a sweeps object.
         Pass a 4-entry list to form a box bounded by [RAmin, RAmax, DECmin, DECmax].
-    gaiadir : :class:`str`, optional, defaults to Gaia DR2 path at NERSC
-        Root directory of a Gaia Data Release as used by the Legacy Surveys.
 
     Returns
     -------
@@ -276,7 +273,7 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
     if gaiamatch:
         # ADM match with a fairly discriminating radius (0.1 arcsec) to just
         # ADM get the best sweeps-Gaia correspondence
-        gaiainfo = match_gaia_to_primary(objects, matchrad=0.1, gaiadir=gaiadir,
+        gaiainfo = match_gaia_to_primary(objects, matchrad=0.1,
                                          retaingaia=True, gaiabounds=gaiabounds)
         log.info('Done with Gaia match...t = {:.1f}s'.format(time()-start))
         # ADM add the Gaia column information to the primary array
@@ -387,8 +384,7 @@ def decode_sweep_name(sweepname):
     return [ramin, ramax, decmin, decmax]
 
 
-def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False,
-                gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'):
+def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
     """Create a set of GFA locations using Gaia
 
     Parameters
@@ -402,8 +398,6 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False,
     gaiamatch : defaults to ``False``
         If ``True``, match to Gaia DR2 chunks files and populate
         Gaia columns, otherwise assume those columns already exist
-    gaiadir : :class:`str`, optional, defaults to Gaia DR2 path at NERSC
-        Root directory of a Gaia Data Release as used by the Legacy Surveys.
 
     Returns
     -------
@@ -434,8 +428,7 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False,
         bounds = decode_sweep_name(fn)
 
         return gaia_gfas_from_sweep(
-            fn, maglim=maglim,
-            gaiamatch=gaiamatch, gaiadir=gaiadir, gaiabounds=bounds
+            fn, maglim=maglim, gaiamatch=gaiamatch, gaiabounds=bounds
         )
 
     # ADM this is just to count sweeps files in _update_status

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -19,23 +19,23 @@ from desitarget.internal import sharedmem
 from desitarget.gaiamatch import match_gaia_to_primary
 from desitarget.targets import encode_targetid
 
-#ADM set up default DESI logger
+from time import time
+
+# ADM set up default DESI logger
 from desiutil.log import get_logger
 log = get_logger()
-
-from time import time
 start = time()
 
-#ADM the current data model for columns in the GFA files
+# ADM the current data model for columns in the GFA files
 gfadatamodel = np.array([], dtype=[
-    ('TARGETID', 'i8'),  ('BRICKID', 'i4'), ('BRICK_OBJID', 'i4'),  
+    ('TARGETID', 'i8'),  ('BRICKID', 'i4'), ('BRICK_OBJID', 'i4'),
     ('RA', 'f8'), ('DEC', 'f8'), ('RA_IVAR', 'f4'), ('DEC_IVAR', 'f4'),
     ('TYPE', 'S4'),
     ('FLUX_G', 'f4'), ('FLUX_R', 'f4'), ('FLUX_Z', 'f4'),
-    ('FLUX_IVAR_G', 'f4'), ('FLUX_IVAR_R', 'f4'), ('FLUX_IVAR_Z', 'f4'),    
-    ('REF_ID', 'i8'), 
+    ('FLUX_IVAR_G', 'f4'), ('FLUX_IVAR_R', 'f4'), ('FLUX_IVAR_Z', 'f4'),
+    ('REF_ID', 'i8'),
     ('PMRA', 'f4'), ('PMDEC', 'f4'), ('PMRA_IVAR', 'f4'), ('PMDEC_IVAR', 'f4'),
-    ('GAIA_PHOT_G_MEAN_MAG', '>f4'), ('GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR', '>f4'), 
+    ('GAIA_PHOT_G_MEAN_MAG', '>f4'), ('GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR', '>f4'),
     ('GAIA_ASTROMETRIC_EXCESS_NOISE', '>f4')
 ])
 
@@ -100,20 +100,20 @@ def write_gfa_targets(sweep_dir="./", desi_tiles=None, output_path="./", log=Non
     n_sweep = len(sweep_files)
     log.info('{} sweep files'.format(len(sweep_files)))
 
-    #load all sweep data
+    # load all sweep data
     sweep_data = []
-    #n_sweep = 10
+    # n_sweep = 10
 
     for i in range(n_sweep):
         sweep_file = sweep_files[i]
         data = fitsio.read(sweep_file, columns=['RA', 'DEC', 'FLUX_R'])
 
-        #- Keep just mag>18
+        # - Keep just mag>18
         rfluxlim = 10**(0.4*(22.5-18))
         ii = data['FLUX_R'] > rfluxlim
         data = data[ii]
 
-        #- Faster for a small number of test tiles, but slower if using all tiles
+        # - Faster for a small number of test tiles, but slower if using all tiles
         # keep = np.zeros(len(data), dtype=bool)
         # for tile in desi_tiles:
         #     keep |= near_tile(data, tile['RA'], tile['DEC'])
@@ -128,7 +128,7 @@ def write_gfa_targets(sweep_dir="./", desi_tiles=None, output_path="./", log=Non
 
     log.info('There are {:.2f}M targets in the sweeps'.format(len(all_sweep)/1E6))
 
-    #find IDs of targets on every individual tile
+    # find IDs of targets on every individual tile
     for i in range(len(desi_tiles)):
         tile_id = desi_tiles['TILEID'][i]
         log.info('computing TILEID {:05d} on RA {:6.2f} DEC {:6.2f}'.format(tile_id, desi_tiles['RA'][i], desi_tiles['DEC'][i]))
@@ -136,7 +136,7 @@ def write_gfa_targets(sweep_dir="./", desi_tiles=None, output_path="./", log=Non
         # select targets in a smaller window centered on tile
         jj = near_tile(all_sweep, desi_tiles['RA'][i], desi_tiles['DEC'][i])
 
-        #find GFA targets in the smaller input window
+        # find GFA targets in the smaller input window
         if np.count_nonzero(jj):
             mini_sweep = all_sweep[jj]
             log.info('Inside mini_sweep: {:.2f}M targets'.format(len(mini_sweep)/1E6))
@@ -177,7 +177,7 @@ def add_gfa_info_to_fa_tiles(gfa_file_path="./", fa_file_path=None, output_path=
     if not os.path.isdir(output_path):
         os.makedirs(output_path, exist_ok=True)
 
-    #rewrite a new tilefile with all the info in three HDUs
+    # rewrite a new tilefile with all the info in three HDUs
     gfa_files = glob.glob(os.path.join(gfa_file_path, "gfa_targets_*.fits"))
     gfa_tile_id = {}
     for gfa_file in gfa_files:
@@ -187,7 +187,7 @@ def add_gfa_info_to_fa_tiles(gfa_file_path="./", fa_file_path=None, output_path=
         gfa_tile_id[fileid] = gfa_file
 
     if fa_file_path:
-        fiberassign_tilefiles = glob.glob(os.path.join(fa_file_path,"tile*.fits"))
+        fiberassign_tilefiles = glob.glob(os.path.join(fa_file_path, "tile*.fits"))
         log.info('{} fiberassign tile files'.format(len(fiberassign_tilefiles)))
     else:
         fiberassign_tilefiles = []
@@ -213,15 +213,15 @@ def add_gfa_info_to_fa_tiles(gfa_file_path="./", fa_file_path=None, output_path=
             fitsio.write(tileout, gfa_data, extname='GFA')
 
 
-def gaia_gfas_from_sweep(objects, maglim=18., 
-                         gaiamatch=False, gaiabounds=[0.,360.,-90.,90.], 
-            gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'):
+def gaia_gfas_from_sweep(objects, maglim=18.,
+                         gaiamatch=False, gaiabounds=[0., 360., -90., 90.],
+                         gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'):
     """Create a set of GFAs from Gaia-matching for one sweep file or sweep objects
 
     Parameters
     ----------
     objects: :class:`numpy.ndarray` or `str`
-        Numpy structured array with UPPERCASE columns needed for target selection, OR 
+        Numpy structured array with UPPERCASE columns needed for target selection, OR
         a string corresponding to a sweep filename.
     maglim : :class:`float`, optional, defaults to 18
         Magnitude limit for GFAs in Gaia G-band.
@@ -229,7 +229,7 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
         If ``True``, match to Gaia DR2 chunks files and populate
         Gaia columns, otherwise assume those columns already exist
     gaiabounds : :class:`list`, optional, defaults to the whole sky
-        The area over which to retrieve Gaia objects that don't match a sweeps object. 
+        The area over which to retrieve Gaia objects that don't match a sweeps object.
         Pass a 4-entry list to form a box bounded by [RAmin, RAmax, DECmin, DECmax].
     gaiadir : :class:`str`, optional, defaults to Gaia DR2 path at NERSC
         Root directory of a Gaia Data Release as used by the Legacy Surveys.
@@ -237,20 +237,20 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
     Returns
     -------
     :class:`numpy.ndarray`
-        GFA objects from Gaia for the region bounded by `gaiabounds`, formatted 
+        GFA objects from Gaia for the region bounded by `gaiabounds`, formatted
         according to `desitarget.gfa.gfadatamodel`.
     """
-    #ADM read in objects if a filename was passed instead of the actual data
+    # ADM read in objects if a filename was passed instead of the actual data
     if isinstance(objects, str):
         objects = desitarget.io.read_tractor(objects)
 
-    #ADM issue a warning if gaiamatch was not sent but there's no Gaia information
+    # ADM issue a warning if gaiamatch was not sent but there's no Gaia information
     if np.max(objects['PARALLAX']) == 0. and ~gaiamatch:
         log.warning("Zero objects have a parallax. Did you mean to send gaiamatch?")
 
-    #ADM add the Gaia coordinate columns if they don't exist and
-    #ADM if Gaia-matching was requested
-    if gaiamatch and not "GAIA_RA" in objects.dtype.names:
+    # ADM add the Gaia coordinate columns if they don't exist and
+    # ADM if Gaia-matching was requested
+    if gaiamatch and "GAIA_RA" not in objects.dtype.names:
         gc = np.array([], dtype=[('GAIA_RA', '>f8'), ('GAIA_DEC', '>f8')])
         dt = objects.dtype.descr + gc.dtype.descr
         nrows = len(objects)
@@ -259,96 +259,96 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
             objectswgc[col] = objects[col]
         objects = objectswgc
 
-    #ADM As a mild speed up, only consider sweeps objects brighter than 3 mags
-    #ADM fainter than the passed Gaia magnitude limit. Note that Gaia G-band
-    #ADM approximates SDSS r-band. 
-    w = np.where( (objects["FLUX_G"] > 10**((22.5-(maglim+3))/2.5)) |
-                  (objects["FLUX_R"] > 10**((22.5-(maglim+3))/2.5)) |
-                  (objects["FLUX_Z"] > 10**((22.5-(maglim+3))/2.5)) )[0]
+    # ADM As a mild speed up, only consider sweeps objects brighter than 3 mags
+    # ADM fainter than the passed Gaia magnitude limit. Note that Gaia G-band
+    # ADM approximates SDSS r-band.
+    w = np.where((objects["FLUX_G"] > 10**((22.5-(maglim+3))/2.5)) |
+                 (objects["FLUX_R"] > 10**((22.5-(maglim+3))/2.5)) |
+                 (objects["FLUX_Z"] > 10**((22.5-(maglim+3))/2.5)))[0]
     objects = objects[w]
 
     nobjs = len(objects)
 
-    #ADM match the sweeps objects to Gaia retaining Gaia objects that do not
-    #ADM have a match in the sweeps, if Gaia matching was requested
+    # ADM match the sweeps objects to Gaia retaining Gaia objects that do not
+    # ADM have a match in the sweeps, if Gaia matching was requested
 #    log.info('Starting Gaia match for {} objects...t = {:.1f}s'
 #             .format(nobjs,time()-start))
     if gaiamatch:
-        #ADM match with a fairly discriminating radius (0.1 arcsec) to just
-        #ADM get the best sweeps-Gaia correspondence
+        # ADM match with a fairly discriminating radius (0.1 arcsec) to just
+        # ADM get the best sweeps-Gaia correspondence
         gaiainfo = match_gaia_to_primary(objects, matchrad=0.1, gaiadir=gaiadir,
-                                     retaingaia=True, gaiabounds=gaiabounds)
+                                         retaingaia=True, gaiabounds=gaiabounds)
         log.info('Done with Gaia match...t = {:.1f}s'.format(time()-start))
-        #ADM add the Gaia column information to the primary array
+        # ADM add the Gaia column information to the primary array
         for col in gaiainfo.dtype.names:
             objects[col] = gaiainfo[col][:nobjs]
-    
-        #ADM an additional array to hold the Gaia objects that have no sweeps match
+
+        # ADM an additional array to hold the Gaia objects that have no sweeps match
         supg = np.zeros(len(gaiainfo) - nobjs, dtype=objects.dtype)
-        #ADM make sure all of these additional columns have "ridiculous" numbers
+        # ADM make sure all of these additional columns have "ridiculous" numbers
         supg[...] = -1
-        #ADM but default the IVARs that would appear in the sweeps (g/r/z) to 0
+        # ADM but default the IVARs that would appear in the sweeps (g/r/z) to 0
         for col in ["FLUX_IVAR_G", "FLUX_IVAR_R", "FLUX_IVAR_Z"]:
             supg[col] = 0.
-        #ADM and then TYPE to PSF
+        # ADM and then TYPE to PSF
         supg["TYPE"] = 'PSF'
-        #ADM populate these additional objects
+        # ADM populate these additional objects
         for col in gaiainfo.dtype.names:
             supg[col] = gaiainfo[col][nobjs:]
 
-        #ADM combine the primary and supplemental arrays
-        objects = np.hstack([objects,supg])
+        # ADM combine the primary and supplemental arrays
+        objects = np.hstack([objects, supg])
 
-        #ADM store the Gaia RA/DEC as the default for matched objects
-        #ADM as it's really the Gaia astrometry we want
-        for col in ["RA","DEC"]:
+        # ADM store the Gaia RA/DEC as the default for matched objects
+        # ADM as it's really the Gaia astrometry we want
+        for col in ["RA", "DEC"]:
             objects[col] = objects["GAIA_"+col]
 
-    #ADM only retain objects with Gaia matches
-    #ADM it's fine to propagate an empty array if there are no matches
-    #ADM note that the sweeps use 0 for objects with no REF_ID
-    #ADM and desitarget.gaiamatch uses -1. So, > 0 checks both.
+    # ADM only retain objects with Gaia matches
+    # ADM it's fine to propagate an empty array if there are no matches
+    # ADM note that the sweeps use 0 for objects with no REF_ID
+    # ADM and desitarget.gaiamatch uses -1. So, > 0 checks both.
     w = np.where(objects["REF_ID"] > 0)[0]
     objects = objects[w]
 
-    #ADM it's possible that a Gaia object matches two sweeps objects, so
-    #ADM only record unique Gaia IDs
+    # ADM it's possible that a Gaia object matches two sweeps objects, so
+    # ADM only record unique Gaia IDs
     _, ind = np.unique(objects["REF_ID"], return_index=True)
 #    log.info('Removed {} duplicated Gaia objects...t = {:.1f}s'
 #             .format(len(objects)-len(ind),time()-start))
     objects = objects[ind]
-     
-    #ADM determine a TARGETID for any objects on a brick (this should
-    #ADM end up as -1 for anything that is Gaia-only (from Gaia-matching)
-    #ADM as all of objid, brickid and release should be -1
+
+    # ADM determine a TARGETID for any objects on a brick (this should
+    # ADM end up as -1 for anything that is Gaia-only (from Gaia-matching)
+    # ADM as all of objid, brickid and release should be -1
     targetid = encode_targetid(objid=objects['OBJID'],
                                brickid=objects['BRICKID'],
                                release=objects['RELEASE'])
 
-    #ADM format everything according to the data model
+    # ADM format everything according to the data model
     gfas = np.zeros(len(objects), dtype=gfadatamodel.dtype)
-    #ADM make sure all columns initially have "ridiculous" numbers                                                                                       
+    # ADM make sure all columns initially have "ridiculous" numbers
     gfas[...] = -99.
-    #ADM remove the TARGETID and BRICK_OBJID columns and populate them later
-    #ADM as they require special treatment
+    # ADM remove the TARGETID and BRICK_OBJID columns and populate them later
+    # ADM as they require special treatment
     cols = list(gfadatamodel.dtype.names)
-    for col in ["TARGETID","BRICK_OBJID"]:
+    for col in ["TARGETID", "BRICK_OBJID"]:
         cols.remove(col)
     for col in cols:
         gfas[col] = objects[col]
-    #ADM populate the TARGETID column
+    # ADM populate the TARGETID column
     gfas["TARGETID"] = targetid
-    #ADM populate the BRICK_OBJID column
+    # ADM populate the BRICK_OBJID column
     gfas["BRICK_OBJID"] = objects["OBJID"]
 
-    #ADM cut the GFAs by a hard limit on magnitude
+    # ADM cut the GFAs by a hard limit on magnitude
     w = np.where(gfas['GAIA_PHOT_G_MEAN_MAG'] < maglim)[0]
     gfas = gfas[w]
-    
-    #ADM a final clean-up to remove columns that are Nan (from
-    #ADM Gaia-matching) or are 0 (in the sweeps)
-    for col in ["PMRA","PMDEC"]:
-        w = np.where( ~np.isnan(gfas[col]) & (gfas[col] != 0) )[0]
+
+    # ADM a final clean-up to remove columns that are Nan (from
+    # ADM Gaia-matching) or are 0 (in the sweeps)
+    for col in ["PMRA", "PMDEC"]:
+        w = np.where(~np.isnan(gfas[col]) & (gfas[col] != 0))[0]
         gfas = gfas[w]
 #    log.info('Removed {} Gaia objects with NaN columns...t = {:.1f}s'
 #             .format(len(objects)-len(gfas),time()-start))
@@ -358,7 +358,7 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
 
 def decode_sweep_name(sweepname):
     """Retrieve RA/Dec edges from a full directory path to a sweep file
-    
+
     Parameters
     ----------
     sweepname : :class:`str`
@@ -371,24 +371,24 @@ def decode_sweep_name(sweepname):
         in the form [RAmin, RAmax, DECmin, DECmax]
         For the above example this would be [350., 360., -5., 5.]
     """
-    #ADM extract just the file part of the name
+    # ADM extract just the file part of the name
     sweepname = os.path.basename(sweepname)
-    
-    #ADM the RA/Dec edges
+
+    # ADM the RA/Dec edges
     ramin, ramax = float(sweepname[6:9]), float(sweepname[14:17])
     decmin, decmax = float(sweepname[10:13]), float(sweepname[18:21])
 
-    #ADM flip the signs on the DECs, if needed
+    # ADM flip the signs on the DECs, if needed
     if sweepname[9] == 'm':
         decmin *= -1
     if sweepname[17] == 'm':
         decmax *= -1
-    
-    return [ramin,ramax,decmin,decmax]
+
+    return [ramin, ramax, decmin, decmax]
 
 
 def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False,
-            gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'):
+                gaiadir='/project/projectdirs/cosmo/work/gaia/chunks-gaia-dr2-astrom'):
     """Create a set of GFA locations using Gaia
 
     Parameters
@@ -408,48 +408,51 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False,
     Returns
     -------
     :class:`numpy.ndarray`
-        GFA objects from Gaia across all of the passed input files, formatted 
+        GFA objects from Gaia across all of the passed input files, formatted
         according to `desitarget.gfa.gfadatamodel`.
-    
+
     Notes
     -----
         - if numproc==1, use the serial code instead of the parallel code.
     """
 
-    #ADM convert a single file, if passed to a list of files
-    if isinstance(infiles,str):
-        infiles = [infiles,]
+    # ADM convert a single file, if passed to a list of files
+    if isinstance(infiles, str):
+        infiles = [infiles, ]
 
-    #ADM check that files exist before proceeding
+    # ADM check that files exist before proceeding
     for filename in infiles:
         if not os.path.exists(filename):
             raise ValueError("{} doesn't exist".format(filename))
 
     nfiles = len(infiles)
 
-    #ADM the critical function to run on every file
+    # ADM the critical function to run on every file
     def _get_gfas(fn):
         '''wrapper on gaia_gfas_from_sweep() given a file name'''
-        #ADM we need to pass the boundaries of the sweeps file, too
+        # ADM we need to pass the boundaries of the sweeps file, too
         bounds = decode_sweep_name(fn)
 
-        return gaia_gfas_from_sweep(fn, maglim=maglim, 
-                    gaiamatch=gaiamatch, gaiadir=gaiadir, gaiabounds=bounds)
+        return gaia_gfas_from_sweep(
+            fn, maglim=maglim,
+            gaiamatch=gaiamatch, gaiadir=gaiadir, gaiabounds=bounds
+        )
 
-    #ADM this is just to count sweeps files in _update_status 
+    # ADM this is just to count sweeps files in _update_status
     nfile = np.zeros((), dtype='i8')
 
     t0 = time()
+
     def _update_status(result):
-        ''' wrapper function for the critical reduction operation,
-            that occurs on the main parallel process '''
-        if nfile%50 == 0 and nfile>0:
+        """wrapper function for the critical reduction operation,
+        that occurs on the main parallel process"""
+        if nfile % 50 == 0 and nfile > 0:
             rate = nfile / (time() - t0)
             log.info('{}/{} files; {:.1f} files/sec'.format(nfile, nfiles, rate))
         nfile[...] += 1    # this is an in-place modification
         return result
 
-    #- Parallel process input files
+    # - Parallel process input files
     if numproc > 1:
         pool = sharedmem.MapReduce(np=numproc)
         with pool:
@@ -462,5 +465,3 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False,
     gfas = np.concatenate(gfas)
 
     return gfas
-
-

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -578,6 +578,9 @@ def write_gfas(filename, data, indir=None, nside=None, gaiaepoch=None):
     from desiutil.log import get_logger
     log = get_logger()
 
+    # ADM rename 'TYPE' to 'MORPHTYPE'.
+    data = rfn.rename_fields(data, {'TYPE': 'MORPHTYPE'})
+
     # ADM create header to include versions, etc.
     hdr = fitsio.FITSHDR()
     depend.setdep(hdr, 'desitarget', desitarget_version)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 """
-==================
+=============
 desitarget.io
-==================
+=============
 
 This file knows how to write a TS catalogue.
 """
@@ -164,11 +164,9 @@ def add_gaia_columns(indata):
         - Gaia columns resemble the data model in :mod:`desitarget.gaiamatch` 
           but with "GAIA_RA" and "GAIA_DEC" removed.
     """
-    # ADM import the Gaia data model from gaiamatch.
-    from desitarget.gaiamatch import gaiadatamodel, pop_gaia_coords
-
     # ADM remove the Gaia coordinates from the Gaia data model as they aren't
     # ADM in the imaging surveys data model.
+    from desitarget.gaiamatch import gaiadatamodel, pop_gaia_coords
     gaiadatamodel = pop_gaia_coords(gaiadatamodel)
 
     # ADM create the combined data model.
@@ -312,9 +310,16 @@ def read_tractor(filename, header=False, columns=None):
     # ADM if Gaia information was passed, add it to the columns to read.
     if (columns is None):
         if (('REF_ID' in fxcolnames) or ('ref_id' in fxcolnames)):
-            from desitarget.gaiamatch import gaiadatamodel, pop_gaia_coords
             # ADM remove the Gaia coordinates as they aren't in the imaging data model.
+            from desitarget.gaiamatch import gaiadatamodel, pop_gaia_coords, pop_gaia_columns
             gaiadatamodel = pop_gaia_coords(gaiadatamodel)
+            # ADM the DR7 sweeps don't contain these columns, but DR8 should.
+            if 'REF_CAT' not in fxcolnames:
+                gaiadatamodel = pop_gaia_columns(
+                    gaiadatamodel, 
+                    ['REF_CAT', 'GAIA_PHOT_BP_RP_EXCESS_FACTOR', 
+                     'GAIA_ASTROMETRIC_SIGMA5D_MAX', 'GAIA_ASTROMETRIC_PARAMS_SOLVED']
+                )
             gaiacols = gaiadatamodel.dtype.names
             readcolumns += gaiacols
         
@@ -322,7 +327,7 @@ def read_tractor(filename, header=False, columns=None):
        (('RELEASE' not in fxcolnames) and ('release' not in fxcolnames)):
         # ADM Rewrite the data completely to correspond to the DR4+ data model.
         # ADM we default to writing RELEASE = 3000 ("DR3, or before, data")
-        data = convert_from_old_data_model(fx,columns=readcolumns)
+        data = convert_from_old_data_model(fx, columns=readcolumns)
     else:
         data = fx[1].read(columns=readcolumns)
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -316,8 +316,8 @@ def read_tractor(filename, header=False, columns=None):
             # ADM the DR7 sweeps don't contain these columns, but DR8 should.
             if 'REF_CAT' not in fxcolnames:
                 gaiadatamodel = pop_gaia_columns(
-                    gaiadatamodel, 
-                    ['REF_CAT', 'GAIA_PHOT_BP_RP_EXCESS_FACTOR', 
+                    gaiadatamodel,
+                    ['REF_CAT', 'GAIA_PHOT_BP_RP_EXCESS_FACTOR',
                      'GAIA_ASTROMETRIC_SIGMA5D_MAX', 'GAIA_ASTROMETRIC_PARAMS_SOLVED']
                 )
             gaiacols = gaiadatamodel.dtype.names

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -63,9 +63,16 @@ class TestIO(unittest.TestCase):
 
     def test_tractor_columns(self):
         # ADM Gaia columns that get added on input.
-        from desitarget.gaiamatch import gaiadatamodel, pop_gaia_coords
+        from desitarget.gaiamatch import gaiadatamodel
+        from desitarget.gaiamatch import pop_gaia_coords, pop_gaia_columns
         # ADM have to remove the GAIA_RA, GAIA_DEC columns used for matching.
         gaiadatamodel = pop_gaia_coords(gaiadatamodel)
+        # ADM prior to DR8, we're also missing some other Gaia columns.
+        gaiadatamodel = pop_gaia_columns(
+            gaiadatamodel,
+            ['REF_CAT', 'GAIA_PHOT_BP_RP_EXCESS_FACTOR',
+             'GAIA_ASTROMETRIC_SIGMA5D_MAX', 'GAIA_ASTROMETRIC_PARAMS_SOLVED']
+        )
         # ADM BRICK_PRIMARY, PHOTSYS get added on input.
         tscolumns = list(io.tsdatamodel.dtype.names)      \
                     + ['BRICK_PRIMARY','PHOTSYS']         \


### PR DESCRIPTION
This PR removes our reliance on Legacy Surveys chunked "astrom" files when handling Gaia data. Changes include:

- Using a `$GAIA_DIR` environment variable instead of passing a Gaia directory around.
- New functions to retrieve and organize Gaia files in the `$GAIA_DIR`. Including:
    * A function to wget Gaia DR2 CSV files from the ESA archive.
    * A function to convert the Gaia DR2 CSV files to FITS.
    * A function to reorganize the Gaia FITS files into (NESTED) HEALPixels.
- Using the NESTED HEALPix scheme for Gaia files throughout `desitarget` (the Legacy Surveys "astrom" files used the RING scheme).
- Renaming the output column ``TYPE`` to ``MORPHTYPE`` for GFA targets.
