### PR TITLE
PRIORITY,NUMOBS -> PRIORITY_INIT,NUMOBS_INIT

### DIFF
--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -1013,7 +1013,7 @@ def finish_catalog(targets, truth, objtruth, skytargets, skytruth, healpix,
                 log.warning('Mismatching TARGETIDs!')
                 raise ValueError                
                     
-        targets['PRIORITY'], targets['NUMOBS'] = initial_priority_numobs(
+        targets['PRIORITY_INIT'], targets['NUMOBS_INIT'] = initial_priority_numobs(
             targets, survey=survey)
 
         # Rename TYPE --> MORPHTYPE
@@ -1028,7 +1028,7 @@ def finish_catalog(targets, truth, objtruth, skytargets, skytruth, healpix,
         skytargets['SUBPRIORITY'][:] = subpriority[nobj:]
         skytruth['TARGETID'][:] = targetid[nobj:]
 
-        skytargets['PRIORITY'], skytargets['NUMOBS'] = initial_priority_numobs(
+        skytargets['PRIORITY_INIT'], skytargets['NUMOBS_INIT'] = initial_priority_numobs(
             skytargets, survey=survey)
 
         # Rename TYPE --> MORPHTYPE

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -150,9 +150,9 @@ def empty_targets_table(nobj=1):
     targets.add_column(Column(name='BGS_TARGET', length=nobj, dtype='i8'))
     targets.add_column(Column(name='MWS_TARGET', length=nobj, dtype='i8'))
 
-    targets.add_column(Column(name='PRIORITY', length=nobj, dtype='i8'))
+    targets.add_column(Column(name='PRIORITY_INIT', length=nobj, dtype='i8'))
     targets.add_column(Column(name='SUBPRIORITY', length=nobj, dtype='f8'))
-    targets.add_column(Column(name='NUMOBS', length=nobj, dtype='i8'))
+    targets.add_column(Column(name='NUMOBS_INIT', length=nobj, dtype='i8'))
     targets.add_column(Column(name='HPXPIXEL', length=nobj, dtype='i8'))
 
     return targets


### PR DESCRIPTION
small datamodel update to have mock targets use `PRIORITY_INIT` and `NUMOBS_INIT` like the real-data targets do (instead of `PRIORITY` and `NUMOBS`).