### PR TITLE
update travis testing versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,9 @@ env:
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.14
         # - SPECLITE_VERSION=0.7
-        - SPECLITE_VERSION=master
+        - SPECLITE_VERSION=v0.8
         - DESISPEC_VERSION=0.18.0
-        - DESISIM_VERSION=master
+        - DESISIM_VERSION=0.31.1
         - DESIMODEL_VERSION=0.9.2
         - DESIMODEL_DATA=branches/test-0.9
         # - DESIMODEL_DATA=trunk

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,26 +2,27 @@
 desitarget Change Log
 =====================
 
-0.26.1 (unreleased)
+0.27.0 (unreleased)
 -------------------
 
 * Move `select-mock-targets.yaml` configuration file to an installable location
   for use by `desitest` [`PR #436`_].
 * Significant enhancement and refactor of `select_mock_targets` to include
   stellar and extragalactic contaminants [`PR #427`_].
-
-.. _`PR #427`: https://github.com/desihub/desitarget/pull/427
-.. _`PR #436`: https://github.com/desihub/desitarget/pull/436
-
-0.26.0 (2018-12-11)
--------------------
-
 * Remove reliance on Legacy Surveys for Gaia data [`PR #438`_]. Includes:
     * Use ``$GAIA_DIR`` environment variable instead of passing a directory.
     * Functions to wget Gaia DR2 CSV files and convert them to FITS.
     * Function to reorganize Gaia FITS files into (NESTED) HEALPixels.
     * Use the NESTED HEALPix scheme for Gaia files throughout desitarget.
     * Change output column ``TYPE`` to ``MORPHTYPE`` for GFAs.
+
+.. _`PR #427`: https://github.com/desihub/desitarget/pull/427
+.. _`PR #436`: https://github.com/desihub/desitarget/pull/436
+.. _`PR #438`: https://github.com/desihub/desitarget/pull/438
+
+0.26.0 (2018-12-11)
+-------------------
+
 * Refactor QSO color cuts and add hard r > 17.5 limit [`PR #433`_].
 * Refactor of MTL and MTL-related enhancements [`PR #429`_]. Includes:
     * Use targets file `NUMOBS_INIT` not :func:`targets.calc_numobs`.
@@ -52,7 +53,6 @@ desitarget Change Log
 .. _`PR #425`: https://github.com/desihub/desitarget/pull/425
 .. _`PR #429`: https://github.com/desihub/desitarget/pull/429
 .. _`PR #433`: https://github.com/desihub/desitarget/pull/433
-.. _`PR #438`: https://github.com/desihub/desitarget/pull/438
 
 0.25.0 (2018-11-07)
 -------------------


### PR DESCRIPTION
Prior to making a new desitarget tag, this PR updates the travis tests to use tagged versions of dependencies instead of master to make sure we have our dependency chain right (a tag should not depend upon master of another package).