### PR TITLE
Update QSO selection for SV, minor improvements to random catalog generation

### DIFF
--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -47,8 +47,8 @@ ap.add_argument("--brickspersec", type=float,
                 help="estimate of bricks completed per second by the (parallelized) code. Used with `bundlebricks` to guess run times (defaults to 2.5)",
                 default=2.5)
 ap.add_argument("--dustdir",
-                help="Directory of SFD dust maps (defaults to /project/projectdirs/desi/software/edison/dust/v0_1/maps)",
-                default='/project/projectdirs/desi/software/edison/dust/v0_1/maps')
+                help="Directory of SFD dust maps (defaults to the equivalent of $DUST_DIR+'/maps')",
+                default=None)
 
 ns = ap.parse_args()
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.27.1 (unreleased)
 -------------------
 
-* Update SV QSO selection, add seed and DUST_DIR for randoms [`PR #449`_].
+* Update SV QSO selections, add seed and DUST_DIR for randoms [`PR #449`_].
 * Style changes to conform to PEP 8 [`PR #446`_], [`PR #447`_], [`PR #448`_].
 
 .. _`PR #446`: https://github.com/desihub/desitarget/pull/446

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,25 +5,27 @@ desitarget Change Log
 0.27.1 (unreleased)
 -------------------
 
+* Update SV QSO selection, add seed and DUST_DIR for randoms [`PR #449`_].
 * Style changes to conform to PEP 8 [`PR #446`_], [`PR #447`_], [`PR #448`_].
 
 .. _`PR #446`: https://github.com/desihub/desitarget/pull/446
 .. _`PR #447`: https://github.com/desihub/desitarget/pull/447
 .. _`PR #448`: https://github.com/desihub/desitarget/pull/448
+.. _`PR #449`: https://github.com/desihub/desitarget/pull/449
 
 0.27.0 (2018-12-14)
 -------------------
 
-* Move `select-mock-targets.yaml` configuration file to an installable location
-  for use by `desitest` [`PR #436`_].
-* Significant enhancement and refactor of `select_mock_targets` to include
-  stellar and extragalactic contaminants [`PR #427`_].
 * Remove reliance on Legacy Surveys for Gaia data [`PR #438`_]. Includes:
     * Use ``$GAIA_DIR`` environment variable instead of passing a directory.
     * Functions to wget Gaia DR2 CSV files and convert them to FITS.
     * Function to reorganize Gaia FITS files into (NESTED) HEALPixels.
     * Use the NESTED HEALPix scheme for Gaia files throughout desitarget.
     * Change output column ``TYPE`` to ``MORPHTYPE`` for GFAs.
+* Move `select-mock-targets.yaml` configuration file to an installable location
+  for use by `desitest` [`PR #436`_].
+* Significant enhancement and refactor of `select_mock_targets` to include
+  stellar and extragalactic contaminants [`PR #427`_].
 
 .. _`PR #427`: https://github.com/desihub/desitarget/pull/427
 .. _`PR #436`: https://github.com/desihub/desitarget/pull/436

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -96,6 +96,10 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
     :class:`~numpy.array`
         Declinations of random points in brick
     """
+    # ADM create a unique random seed on the basis of the brick.
+    uniqseed = int(4*ramin)*1000+int(4*(decmin+90))
+    np.random.seed(uniqseed)
+
     # ADM generate random points within the brick at the requested density
     # ADM guard against potential wraparound bugs (assuming bricks are typical
     # ADM sizes of 0.25 x 0.25 sq. deg., or not much larger than that
@@ -159,6 +163,9 @@ def randoms_in_a_brick_from_name(brickname, density=100000,
 
     brick = brickinfo[wbrick][0]
     ramin, ramax, decmin, decmax = brick['ra1'], brick['ra2'], brick['dec1'], brick['dec2']
+    # ADM create a unique random seed on the basis of the brick.
+    uniqseed = int(4*ramin)*1000+int(4*(decmin+90))
+    np.random.seed(uniqseed)
 
     # ADM generate random points within the brick at the requested density
     # ADM guard against potential wraparound bugs

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -97,6 +97,8 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
         Declinations of random points in brick
     """
     # ADM create a unique random seed on the basis of the brick.
+    # ADM note this is only unique for bricksize=0.25 for bricks
+    # ADM that are more than 0.25 degrees from the poles.
     uniqseed = int(4*ramin)*1000+int(4*(decmin+90))
     np.random.seed(uniqseed)
 
@@ -163,7 +165,10 @@ def randoms_in_a_brick_from_name(brickname, density=100000,
 
     brick = brickinfo[wbrick][0]
     ramin, ramax, decmin, decmax = brick['ra1'], brick['ra2'], brick['dec1'], brick['dec2']
+
     # ADM create a unique random seed on the basis of the brick.
+    # ADM note this is only unique for bricksize=0.25 for bricks
+    # ADM that are more than 0.25 degrees from the poles.
     uniqseed = int(4*ramin)*1000+int(4*(decmin+90))
     np.random.seed(uniqseed)
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -339,8 +339,7 @@ def hp_with_nobs_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=100
     return hpxinfo
 
 
-def get_dust(ras, decs, scaling=1,
-             dustdir="/project/projectdirs/desi/software/edison/dust/v0_1/maps"):
+def get_dust(ras, decs, scaling=1, dustdir=None):
     """Get SFD E(B-V) values at a set of RA/Dec locations
 
     Parameters
@@ -352,8 +351,9 @@ def get_dust(ras, decs, scaling=1,
     scaling : :class:`float`
         Pass 1 for the SFD98 dust maps. A scaling of 0.86 corresponds
         to the recalibration from Schlafly & Finkbeiner (2011).
-    dustdir : :class:`str`, optional, defaults to the NERSC dust map location
-        The root directory pointing to SFD dust maps
+    dustdir : :class:`str`, optional, defaults to $DUST_DIR+'/maps'
+        The root directory pointing to SFD dust maps. If not
+        sent the code will try to use $DUST_DIR+'/maps' before failing.
 
     Returns
     -------
@@ -366,7 +366,7 @@ def get_dust(ras, decs, scaling=1,
 
 def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=100000,
                               drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/",
-                              dustdir="/project/projectdirs/desi/software/edison/dust/v0_1/maps"):
+                              dustdir=None):
     """NOBS, DEPTHS etc. (per-band) for random points in a brick of the Legacy Surveys
 
     Parameters
@@ -387,8 +387,9 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=1
     drdir : :class:`str`, optional, defaults to the DR4 root directory at NERSC
         The root directory pointing to a Data Release of the Legacy Surveys, e.g.:
         "/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"
-    dustdir : :class:`str`, optional, defaults to the NERSC dust map location
-        The root directory pointing to SFD dust maps
+    dustdir : :class:`str`, optional, defaults to $DUST_DIR+'/maps'
+        The root directory pointing to SFD dust maps. If not
+        sent the code will try to use $DUST_DIR+'/maps' before failing.
 
     Returns
     -------
@@ -894,7 +895,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=2.5,
 def select_randoms(density=100000, numproc=32, nside=4, pixlist=None,
                    bundlebricks=None, brickspersec=2.5,
                    drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/",
-                   dustdir="/project/projectdirs/desi/software/edison/dust/v0_1/maps"):
+                   dustdir=None):
     """NOBS, GALDEPTH, PSFDEPTH (per-band) for random points in a DR of the Legacy Surveys
 
     Parameters
@@ -925,8 +926,10 @@ def select_randoms(density=100000, numproc=32, nside=4, pixlist=None,
         to estimate time to completion when parallelizing across pixels.
     drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
        The root directory pointing to a Data Release from the Legacy Surveys.
-    dustdir : :class:`str`, optional, defaults to the NERSC dust map location
-        The root directory pointing to SFD dust maps.
+    dustdir : :class:`str`, optional, defaults to $DUST_DIR+'maps'
+        The root directory pointing to SFD dust maps. If not
+        sent the code will try to use $DUST_DIR+'maps')
+        before failing.
 
     Returns
     -------

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -297,9 +297,12 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None,
 
     Notes
     -----
-    - Current version (11/05/18) is version 24 on `the SV wiki`_.
+    - Current version (11/05/18) is version 29 on `the SV wiki`_.
     - See :func:`~desitarget.sv1.sv1_cuts.set_target_bits` for other parameters.
     """
+    if not south:
+        gflux, rflux, zflux = shift_photo_north(gflux, rflux, zflux)
+
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
     qso = primary.copy()
@@ -443,11 +446,11 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
         # ADM the probabilities are different for the north and the south.
         if south:
             pcut = np.where(r_Reduced > 20.0,
-                            0.45 - (r_Reduced - 20.0) * 0.10, 0.45)
-        else:
-            pcut = np.where(r_Reduced > 20.0,
                             0.60 - (r_Reduced - 20.0) * 0.10, 0.60)
             pcut[r_Reduced > 22.0] = 0.40 - 0.25 * (r_Reduced[r_Reduced > 22.0] - 22.0)
+        else:
+            pcut = np.where(r_Reduced > 20.0,
+                            0.45 - (r_Reduced - 20.0) * 0.10, 0.45)
         pcut_HighZ = 0.40
 
         # Add rf proba test result to "qso" mask

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -19,6 +19,7 @@ from time import time
 from pkg_resources import resource_filename
 
 from desitarget.cuts import _getColors, _psflike, _check_BGS_targtype
+from desitarget.cuts import shift_photo_north
 
 # ADM set up the DESI default logger
 from desiutil.log import get_logger
@@ -448,7 +449,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
                             0.60 - (r_Reduced - 20.0) * 0.10, 0.60)
             pcut[r_Reduced > 22.0] = 0.40 - 0.25 * (r_Reduced[r_Reduced > 22.0] - 22.0)
         pcut_HighZ = 0.40
-            
+
         # Add rf proba test result to "qso" mask
         qso[colorsReducedIndex] = \
             (tmp_rf_proba >= pcut) | (tmp_rf_HighZ_proba >= pcut_HighZ)

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -297,7 +297,7 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None,
 
     Notes
     -----
-    - Current version (11/05/18) is version 29 on `the SV wiki`_.
+    - Current version (11/05/18) is version 33 on `the SV wiki`_.
     - See :func:`~desitarget.sv1.sv1_cuts.set_target_bits` for other parameters.
     """
     if not south:
@@ -384,7 +384,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
 
     Notes
     -----
-    - Current version (11/05/18) is version 29 on `the SV wiki`_.
+    - Current version (11/05/18) is version 33 on `the SV wiki`_.
     - See :func:`~desitarget.sv1.sv1_cuts.set_target_bits` for other parameters.
     """
     # BRICK_PRIMARY


### PR DESCRIPTION
This PR:

- updates the QSO random forest for SV to facilitate different selections in the north and south.
- adds seeds to the random catalog generation for better reproducibility.
- defaults to using the `DUST_DIR` environment variable when generating randoms if a map directory is not passed.