### PR TITLE
Refactor SV and main survey targeting to allow a range of spatial queries

### DIFF
--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -21,7 +21,7 @@ ap.add_argument("infiles",
                 help="SEMI-COLON separated list of input files, which may have to be enclosed by quotes (e.g. 'file1;file2;file3;file4')")
 ap.add_argument("outfile", 
                 help="Output file name")
-ap.add_argument("targtype",choices=['skies','randoms'],
+ap.add_argument("targtype",choices=['skies', 'randoms', 'targets'],
                 help="Type of target run with parallelization/multiprocessing code to gather")
 
 ns = ap.parse_args()

--- a/bin/select_cmx_targets
+++ b/bin/select_cmx_targets
@@ -3,6 +3,8 @@
 from __future__ import print_function, division
 
 import sys
+import numpy as np
+import fitsio
 
 from desitarget import io
 from desitarget.cmx.cmx_cuts import select_targets
@@ -37,6 +39,25 @@ if len(infiles) == 0:
 if len(infiles) == 0:
     log.critical('no sweep or tractor files found')
     sys.exit(1)
+
+# ADM Only coded for objects with Gaia matches
+# ADM (e.g. DR6 or above). Fail for earlier Data Releases.
+# ADM Guard against a single file being passed.
+fn = infiles
+if ~isinstance(infiles, str):
+    fn = infiles[0]
+data = fitsio.read(fn, columns=["RELEASE","PMRA"])
+if np.any(data["RELEASE"] < 6000):
+    log.critical('Commissioning cuts only coded for DR6 or above')
+    raise ValueError
+if (np.max(data['PMRA']) == 0.) & np.any(data["RELEASE"] < 7000):
+    d = "/project/projectdirs/desi/target/gaia_dr2_match_dr6"
+    log.info("Zero objects have a proper motion.")
+    log.critical(
+        "Did you mean to send the Gaia-matched sweeps in, e.g., {}?"
+        .format(d)
+    )
+    raise IOError
 
 log.info("running on {} processors".format(ns.numproc))
 

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -15,9 +15,9 @@ from desitarget.randoms import pixweight, select_randoms
 
 import multiprocessing
 nproc = multiprocessing.cpu_count() // 2
-#ADM default HEALPix Nside used throughout desitarget
-#ADM don't confuse this with the ns.nside parallelization input that is parsed below!!!
-nside = 64
+# ADM default HEALPix Nside used throughout desitarget.
+# ADM don't confuse this with the ns.nside parallelization input that is parsed below!!!
+nside = io.desitarget_nside()
 
 from desiutil.log import get_logger
 log = get_logger()
@@ -52,7 +52,7 @@ ap.add_argument("--dustdir",
 
 ns = ap.parse_args()
 
-#ADM parse the list of HEALPixels in which to run
+# ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels
 if pixlist is not None:
     pixlist = [ int(pixnum) for pixnum in pixlist.split(',') ]

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -113,7 +113,7 @@ if ns.mask:
     targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
 if ns.bundlefiles is None:
-    io.write_targets(ns.dest, targets, indir=ns.src, survey=survey, 
-                     nsidefile=ns.nside, hpxlist=pixlist, 
+    io.write_targets(ns.dest, targets, indir=ns.src, survey=survey,
+                     nsidefile=ns.nside, hpxlist=pixlist,
                      qso_selection=survey, nside=nside)
     log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -50,8 +50,13 @@ ap.add_argument("--bundlefiles", type=int,
                 default=None)
 ap.add_argument("--filespersec", type=float,
                 help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 1)",
-                default=1.)
-
+                default=1)
+ap.add_argument('--radecbox',
+                help="Only return targets in an RA/Dec box denoted by 'RAmin,RAmax,Decmin,Decmax' in degrees (e.g. '140,150,-10,-20')",
+                default=None)
+ap.add_argument('--radecrad',
+                help="Only return targets in an RA/Dec circle/cap denoted by 'centerRA,centerDec,radius' in degrees (e.g. '140,150,0.5')",
+                default=None)
 
 ns = ap.parse_args()
 infiles = io.list_sweepfiles(ns.src)
@@ -90,17 +95,25 @@ pixlist = ns.healpixels
 if pixlist is not None:
     pixlist = [ int(pixnum) for pixnum in pixlist.split(',') ]
 
+# ADM parse the list of RA/Dec regions in which to run.
+inlists = [ns.radecbox, ns.radecrad]
+for i, inlist in enumerate(inlists):
+    if inlist is not None:
+        inlists[i] = [ float(num) for num in inlist.split(',') ]
+
 # ADM if specific bit names were passed, use them, otherwise run all target classes
 tcnames = _parse_tcnames(tcstring=ns.tcnames, add_all=False)
 
 targets = select_targets(infiles, numproc=ns.numproc, 
                          nside=ns.nside, pixlist=pixlist,
                          bundlefiles=ns.bundlefiles, filespersec=ns.filespersec,
+                         radecbox=inlists[0], radecrad=inlists[1],
                          tcnames=tcnames, survey=survey)
 if ns.mask:
     targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
 if ns.bundlefiles is None:
-    io.write_targets(ns.dest, targets, indir=ns.src, survey=survey,
+    io.write_targets(ns.dest, targets, indir=ns.src, survey=survey, 
+                     nsidefile=ns.nside, hpxlist=pixlist, 
                      qso_selection=survey, nside=nside)
     log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -49,8 +49,8 @@ ap.add_argument("--bundlefiles", type=int,
                 help="(overrides all options but `src`) print slurm script to parallelize, with about this many sweeps files touching each HEALPixel (e.g. 100)",
                 default=None)
 ap.add_argument("--filespersec", type=float,
-                help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 1)",
-                default=1)
+                help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 0.08)",
+                default=0.08)
 ap.add_argument('--radecbox',
                 help="Only return targets in an RA/Dec box denoted by 'RAmin,RAmax,Decmin,Decmax' in degrees (e.g. '140,150,-10,-20')",
                 default=None)

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -39,6 +39,19 @@ ap.add_argument('-t','--tcnames', default=None,
                 help="Comma-separated names of target classes to run (e.g. QSO,LRG). Options are ELG, QSO, LRG, MWS, BGS, STD. Default is to run everything)")
 ap.add_argument('-i','--iteration', default="1", 
                 help="Iteration of SV target selection to run [defaults to 1 for 'sv1']")
+ap.add_argument('--nside', type=int,
+                help="Process targets in parallel across sweeps files that define regions that touch HEALPixels at this resolution (defaults to 2)",
+                default=2)
+ap.add_argument('--healpixels',
+                help="HEALPixels (corresponding to `nside`) to process (e.g. '6,21,57'). If not passed, run all sweeps files in the `src` directory",
+                default=None)
+ap.add_argument("--bundlefiles", type=int,
+                help="(overrides all options but `src`) print slurm script to parallelize, with about this many sweeps files touching each HEALPixel (e.g. 100)",
+                default=None)
+ap.add_argument("--filespersec", type=float,
+                help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 1)",
+                default=1.)
+
 
 ns = ap.parse_args()
 infiles = io.list_sweepfiles(ns.src)
@@ -58,7 +71,7 @@ if ~isinstance(infiles, str):
     fn = infiles[0]
 data = fitsio.read(fn, columns=["RELEASE","PMRA"])
 if np.any(data["RELEASE"] < 6000):
-    log.critical('Commissioning cuts only coded for DR6 or above')
+    log.critical('SV cuts only coded for DR6 or above')
     raise ValueError
 if (np.max(data['PMRA']) == 0.) & np.any(data["RELEASE"] < 7000):
     d = "/project/projectdirs/desi/target/gaia_dr2_match_dr6"
@@ -69,16 +82,25 @@ if (np.max(data['PMRA']) == 0.) & np.any(data["RELEASE"] < 7000):
     )
     raise IOError
 
-log.info("running on {} processors".format(ns.numproc))
+if ns.bundlefiles is None:
+    log.info("running on {} processors".format(ns.numproc))
 
-#ADM if specific bit names were passed, use them, otherwise run all target classes
+# ADM parse the list of HEALPixels in which to run.
+pixlist = ns.healpixels
+if pixlist is not None:
+    pixlist = [ int(pixnum) for pixnum in pixlist.split(',') ]
+
+# ADM if specific bit names were passed, use them, otherwise run all target classes
 tcnames = _parse_tcnames(tcstring=ns.tcnames, add_all=False)
 
-targets = select_targets(infiles, numproc=ns.numproc, tcnames=tcnames, survey=survey)
+targets = select_targets(infiles, numproc=ns.numproc, 
+                         nside=ns.nside, pixlist=pixlist,
+                         bundlefiles=ns.bundlefiles, filespersec=ns.filespersec,
+                         tcnames=tcnames, survey=survey)
 if ns.mask:
     targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
-io.write_targets(ns.dest, targets, indir=ns.src, survey=survey,
-                 qso_selection=survey, nside=nside)
-
-log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))
+if ns.bundlefiles is None:
+    io.write_targets(ns.dest, targets, indir=ns.src, survey=survey,
+                     qso_selection=survey, nside=nside)
+    log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -40,10 +40,10 @@ ap.add_argument('-t','--tcnames', default=None,
 ap.add_argument('-i','--iteration', default="1", 
                 help="Iteration of SV target selection to run [defaults to 1 for 'sv1']")
 ap.add_argument('--nside', type=int,
-                help="Process targets in parallel across sweeps files that define regions that touch HEALPixels at this resolution (defaults to 2)",
-                default=2)
+                help="Process targets in HEALPixels at this resolution (defaults to None). See also the 'healpixels' input flag",
+                default=None)
 ap.add_argument('--healpixels',
-                help="HEALPixels (corresponding to `nside`) to process (e.g. '6,21,57'). If not passed, run all sweeps files in the `src` directory",
+                help="HEALPixels corresponding to `nside` (e.g. '6,21,57'). Only process files that touch these pixels and return targets within these pixels",
                 default=None)
 ap.add_argument("--bundlefiles", type=int,
                 help="(overrides all options but `src`) print slurm script to parallelize, with about this many sweeps files touching each HEALPixel (e.g. 100)",

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -99,7 +99,8 @@ else:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
     if ns.bundlefiles is None:
-        io.write_targets(ns.dest, targets, indir=ns.src, survey="main",
+        io.write_targets(ns.dest, targets,
+                         indir=ns.src, survey="main", nsidefile=ns.nside, hpxlist=pixlist,
                          qso_selection=ns.qsoselection, sandboxcuts=ns.sandbox, nside=nside)
         log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))
 

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -52,8 +52,8 @@ ap.add_argument("--numproc", type=int,
 ap.add_argument('-t','--tcnames', default=None,
                 help="Comma-separated names of target classes to run (e.g. QSO,LRG). Options are ELG, QSO, LRG, MWS, BGS, STD. Default is to run everything)")
 ap.add_argument('--nside', type=int,
-                help="Process targets in parallel across sweeps files that define regions that touch HEALPixels at this resolution (defaults to 2)",
-                default=2)
+                help="Process targets in parallel across sweeps files that define regions that touch HEALPixels at this resolution (defaults to None)",
+                default=None)
 ap.add_argument('--healpixels',
                 help="HEALPixels (corresponding to `nside`) to process (e.g. '6,21,57'). If not passed, run all sweeps files in the `src` directory",
                 default=None)
@@ -115,4 +115,3 @@ else:
                          indir=ns.src, survey="main", nsidefile=ns.nside, hpxlist=pixlist,
                          qso_selection=ns.qsoselection, sandboxcuts=ns.sandbox, nside=nside)
         log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))
-

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -58,7 +58,7 @@ ap.add_argument('--healpixels',
                 help="HEALPixels (corresponding to `nside`) to process (e.g. '6,21,57'). If not passed, run all sweeps files in the `src` directory",
                 default=None)
 ap.add_argument("--bundlefiles", type=int,
-                help="(overrides all options but `src`) Print slurm script to parallelize, with about this many sweeps files touching each HEALPixel (e.g. 100)",
+                help="(overrides all options but `src`) print slurm script to parallelize, with about this many sweeps files touching each HEALPixel (e.g. 100)",
                 default=None)
 ap.add_argument("--filespersec", type=float,
                 help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 1)",
@@ -76,12 +76,12 @@ if len(infiles) == 0:
 if ns.bundlefiles is None:
     log.info("running on {} processors".format(ns.numproc))
 
-# ADM parse the list of HEALPixels in which to run                                                                                                                                 
+# ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels
 if pixlist is not None:
     pixlist = [ int(pixnum) for pixnum in pixlist.split(',') ]
 
-# ADM if specific bit names were passed, use them, otherwise run all target classes
+# ADM if specific bit names were passed, use them, otherwise run all target classes.
 tcnames = _parse_tcnames(tcstring=ns.tcnames, add_all=False)
 
 if ns.check:

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -19,6 +19,7 @@ start = time()
 
 import multiprocessing
 nproc = multiprocessing.cpu_count() // 2
+# ADM don't confuse this with the ns.nside parallelization input that is parsed below!!!
 nside = io.desitarget_nside()
 
 from desiutil.log import get_logger
@@ -26,21 +27,21 @@ log = get_logger()
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Generates DESI target bits from Legacy Surveys sweeps or tractor files')
-ap.add_argument("src", 
+ap.add_argument("src",
                 help="Tractor/sweeps file or root directory with tractor/sweeps files")
-ap.add_argument("dest", 
+ap.add_argument("dest",
                 help="Output target selection file")
 ap.add_argument('-c', "--check", action='store_true',
                 help="Process tractor/sweeps files to check for corruption, without running full target selection")
-ap.add_argument('-m', "--mask", 
+ap.add_argument('-m', "--mask",
                 help="If sent then mask the targets, the name of the mask file should be supplied")
 ap.add_argument("--sandbox", action='store_true',
                 help="Apply the sandbox target selection algorithms")
 ap.add_argument("--FoMthresh", type=float,
                 help='XD Figure of Merit Threshold for an ELG (sandbox)')
-ap.add_argument('--qsoselection',choices=qso_selection_options,default='randomforest',
+ap.add_argument('--qsoselection', choices=qso_selection_options, default='randomforest',
                 help="QSO target selection method")
-ap.add_argument('--Method',choices=Method_sandbox_options,default='XD',
+ap.add_argument('--Method' ,choices=Method_sandbox_options, default='XD',
                 help="Method used in sandbox target for ELG")
 ### ap.add_argument('-b', "--bricklist", help='filename with list of bricknames to include')
 ap.add_argument("--gaiamatch", action='store_true',
@@ -48,8 +49,21 @@ ap.add_argument("--gaiamatch", action='store_true',
 ap.add_argument("--numproc", type=int,
                 help='number of concurrent processes to use [{}]'.format(nproc),
                 default=nproc)
-ap.add_argument('-t','--tcnames', default=None, 
+ap.add_argument('-t','--tcnames', default=None,
                 help="Comma-separated names of target classes to run (e.g. QSO,LRG). Options are ELG, QSO, LRG, MWS, BGS, STD. Default is to run everything)")
+ap.add_argument('--nside', type=int,
+                help="Process targets in parallel across sweeps files that define regions that touch HEALPixels at this resolution (defaults to 2)",
+                default=2)
+ap.add_argument('--healpixels',
+                help="HEALPixels (corresponding to `nside`) to process (e.g. '6,21,57'). If not passed, run all sweeps files in the `src` directory",
+                default=None)
+ap.add_argument("--bundlefiles", type=int,
+                help="(overrides all options but `src`) Print slurm script to parallelize, with about this many sweeps files touching each HEALPixel (e.g. 100)",
+                default=None)
+ap.add_argument("--filespersec", type=float,
+                help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 1)",
+                default=1.)
+
 
 ns = ap.parse_args()
 infiles = io.list_sweepfiles(ns.src)
@@ -59,9 +73,15 @@ if len(infiles) == 0:
     log.critical('no sweep or tractor files found')
     sys.exit(1)
 
-log.info("running on {} processors".format(ns.numproc))
+if ns.bundlefiles is None:
+    log.info("running on {} processors".format(ns.numproc))
 
-#ADM if specific bit names were passed, use them, otherwise run all target classes
+# ADM parse the list of HEALPixels in which to run                                                                                                                                 
+pixlist = ns.healpixels
+if pixlist is not None:
+    pixlist = [ int(pixnum) for pixnum in pixlist.split(',') ]
+
+# ADM if specific bit names were passed, use them, otherwise run all target classes
 tcnames = _parse_tcnames(tcstring=ns.tcnames, add_all=False)
 
 if ns.check:
@@ -72,12 +92,14 @@ else:
     targets = select_targets(infiles, numproc=ns.numproc,
                              qso_selection=ns.qsoselection, gaiamatch=ns.gaiamatch,
                              sandbox=ns.sandbox, FoMthresh=ns.FoMthresh, Method=ns.Method,
+                             nside=ns.nside, pixlist=pixlist,
+                             bundlefiles=ns.bundlefiles, filespersec=ns.filespersec,
                              tcnames=tcnames, survey='main')
     if ns.mask:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
-    io.write_targets(ns.dest, targets, indir=ns.src, survey="main",
-                     qso_selection=ns.qsoselection, sandboxcuts=ns.sandbox, nside=nside)
-
-    log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))
+    if ns.bundlefiles is None:
+        io.write_targets(ns.dest, targets, indir=ns.src, survey="main",
+                         qso_selection=ns.qsoselection, sandboxcuts=ns.sandbox, nside=nside)
+        log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))
 

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -61,9 +61,14 @@ ap.add_argument("--bundlefiles", type=int,
                 help="(overrides all options but `src`) print slurm script to parallelize, with about this many sweeps files touching each HEALPixel (e.g. 100)",
                 default=None)
 ap.add_argument("--filespersec", type=float,
-                help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 1)",
+                help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 0.12)",
                 default=0.12)
-
+ap.add_argument('--radecbox',
+                help="Only return targets in an RA/Dec box denoted by 'RAmin,RAmax,Decmin,Decmax' in degrees (e.g. '140,150,-10,-20')",
+                default=None)
+ap.add_argument('--radecrad',
+                help="Only return targets in an RA/Dec circle/cap denoted by 'centerRA,centerDec,radius' in degrees (e.g. '140,150,0.5')",
+                default=None)
 
 ns = ap.parse_args()
 infiles = io.list_sweepfiles(ns.src)
@@ -79,7 +84,13 @@ if ns.bundlefiles is None:
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels
 if pixlist is not None:
-    pixlist = [ int(pixnum) for pixnum in pixlist.split(',') ]
+    pixlist = [ int(pix) for pix in pixlist.split(',') ]
+
+# ADM parse the list of RA/Dec regions in which to run.
+inlists = [ns.radecbox, ns.radecrad]
+for i, inlist in enumerate(inlists):
+    if inlist is not None:
+        inlists[i] = [ float(num) for num in inlist.split(',') ]
 
 # ADM if specific bit names were passed, use them, otherwise run all target classes.
 tcnames = _parse_tcnames(tcstring=ns.tcnames, add_all=False)
@@ -94,6 +105,7 @@ else:
                              sandbox=ns.sandbox, FoMthresh=ns.FoMthresh, Method=ns.Method,
                              nside=ns.nside, pixlist=pixlist,
                              bundlefiles=ns.bundlefiles, filespersec=ns.filespersec,
+                             radecbox=inlists[0], radecrad=inlists[1],
                              tcnames=tcnames, survey='main')
     if ns.mask:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -52,10 +52,10 @@ ap.add_argument("--numproc", type=int,
 ap.add_argument('-t','--tcnames', default=None,
                 help="Comma-separated names of target classes to run (e.g. QSO,LRG). Options are ELG, QSO, LRG, MWS, BGS, STD. Default is to run everything)")
 ap.add_argument('--nside', type=int,
-                help="Process targets in parallel across sweeps files that define regions that touch HEALPixels at this resolution (defaults to None)",
+                help="Process targets in HEALPixels at this resolution (defaults to None). See also the 'healpixels' input flag",
                 default=None)
 ap.add_argument('--healpixels',
-                help="HEALPixels (corresponding to `nside`) to process (e.g. '6,21,57'). If not passed, run all sweeps files in the `src` directory",
+                help="HEALPixels corresponding to `nside` (e.g. '6,21,57'). Only process files that touch these pixels and return targets within these pixels",
                 default=None)
 ap.add_argument("--bundlefiles", type=int,
                 help="(overrides all options but `src`) print slurm script to parallelize, with about this many sweeps files touching each HEALPixel (e.g. 100)",

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -62,7 +62,7 @@ ap.add_argument("--bundlefiles", type=int,
                 default=None)
 ap.add_argument("--filespersec", type=float,
                 help="estimate of sweeps files completed per second by the (parallelized) code. Used with `bundlefiles` to guess run times (defaults to 1)",
-                default=1.)
+                default=0.12)
 
 
 ns = ap.parse_args()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -32,7 +32,7 @@ desitarget Change Log
 .. _`PR #452`: https://github.com/desihub/desitarget/pull/452
 .. _`PR #456`: https://github.com/desihub/desitarget/pull/456
 .. _`PR #457`: https://github.com/desihub/desitarget/pull/457
-.. _`PR #457`: https://github.com/desihub/desitarget/pull/458
+.. _`PR #458`: https://github.com/desihub/desitarget/pull/458
 
 0.27.0 (2018-12-14)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,15 @@ desitarget Change Log
 0.27.1 (unreleased)
 -------------------
 
+* Refactor SV/main targeting for spatial queries [`PR #458`_]. Includes:
+    * Many new spatial query capabilities in :func:`desitarget.geomask`.
+    * Parallelize target selection by splitting across HEALPixels.
+    * Wrappers to read in HEALPix-split target files split by:
+        * HEALPixels, RA/Dec boxes, RA/Dec/radius caps, column names.
+    * Only process subsets of targets in regions of space, again including:
+        * HEALPixels, RA/Dec boxes, RA/Dec/radius caps.
+    * New unit tests to check these spatial queries.
+    * Updated notebook including tutorials on spatial queries.
 * Update the SV selections for BGS [`PR #457`_].
 * Update MTL to work for SV0-like cmx and SV1 tables [`PR #456`_]. Includes:
     * Make SUBPRIORITY a random number (0->1) in skies output.
@@ -23,6 +32,7 @@ desitarget Change Log
 .. _`PR #452`: https://github.com/desihub/desitarget/pull/452
 .. _`PR #456`: https://github.com/desihub/desitarget/pull/456
 .. _`PR #457`: https://github.com/desihub/desitarget/pull/457
+.. _`PR #457`: https://github.com/desihub/desitarget/pull/458
 
 0.27.0 (2018-12-14)
 -------------------

--- a/doc/nb/how-to-run-target-selection.ipynb
+++ b/doc/nb/how-to-run-target-selection.ipynb
@@ -70,10 +70,10 @@
     "mkdir $TARGDIR\n",
     "```\n",
     "\n",
-    "From this point forward, we will be running production-level code at NERSC. You may want to familiarize yourself with how to run batch jobs at NERSC. A straightforward way to run the code is to request interactive nodes. For example, to reserve one interactive node for 5 minutes:\n",
+    "From this point forward, we will be running production-level code at NERSC. You may want to familiarize yourself with how to run batch jobs at NERSC. A straightforward way to run the code is to request interactive nodes. For example, to reserve one interactive node for 2 hours and 5 minutes:\n",
     "\n",
     "```\n",
-    "salloc -N 1 -C haswell -t 00:05:00 --qos interactive -L SCRATCH,project\n",
+    "salloc -N 1 -C haswell -t 02:05:00 --qos interactive -L SCRATCH,project\n",
     "```\n",
     "\n",
     "Now, to produce the file of targets:\n",
@@ -89,7 +89,294 @@
     "\n",
     "```\n",
     "chgrp desi $TARGDIR/targets-dr$DR-$VERSION.fits ; chmod 660 $TARGDIR/targets-dr$DR-$VERSION.fits\n",
-    "```"
+    "```\n",
+    "\n",
+    "In addition to the `select_targets` command line code, there are `select_cmx_targets` and `select_sv_targets` versions that can be used for commissioning and SV."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parallelizing target files across nodes#\n",
+    "\n",
+    "```desitarget``` already parallelizes sweeps files across processors on a single node. But, it can further parallelize target selection by HEALPixel across multiple nodes. In addition, this form of parallelization can be used to produce smaller target files without having to write a single monolithic output file of *all* targets. The ```bundlefiles``` option can be used to produce a slurm script, and some general guidance, for parallelizing target selection across nodes using HEALPixels. \n",
+    "\n",
+    "First, as in the previous section, set up the needed directories and a version number. For example:\n",
+    "\n",
+    "```\n",
+    "export LSDIR='/global/project/projectdirs/cosmo/data/legacysurvey/dr7'\n",
+    "export DR='7.1'\n",
+    "\n",
+    "module swap desitarget/$VERSION\n",
+    "```\n",
+    "\n",
+    "Now, pass ```select_targets``` the ```bundlefiles``` option and an ```nside``` corresponding to the HEALPixels across which you want to parallelize the code. The ```bundlefiles``` option specifies the number of input sweeps files that will be parallelized across (i.e. for ```bundlefiles=100``` the input sweep files will be bundled across HEALPixels so that approximately 100 files touch each pixel. The optimal ```nside``` is likely to correspond to the area covered by a sweep file (i.e. ```nside=8``` for about 50 square degrees). Some trial and error as to the value of ```bundlefiles``` might be necessary given the available resources, however. But, for instance:\n",
+    "\n",
+    "```\n",
+    "select_targets $LSDIR/sweep/$DR/ $CSCRATCH/blat.fits --bundlefiles 100 --nside 2\n",
+    "```\n",
+    "\n",
+    "will produce the following output:\n",
+    "\n",
+    "```\n",
+    "INFO:cuts.py:2306:select_targets: Running on the main survey\n",
+    "#######################################################\n",
+    "Numbers of bricks or files in each set of HEALPixels:\n",
+    "\n",
+    "['17: 42', '18: 40', '21: 18', 'Total: 100', 'Estimated time to run in hours (for 32 processors per node): 0.28h']\n",
+    "['19: 38', '27: 38', '30: 24', 'Total: 100', 'Estimated time to run in hours (for 32 processors per node): 0.28h']\n",
+    "['4: 36', '8: 37', '28: 1', '35: 26', 'Total: 100', 'Estimated time to run in hours (for 32 processors per node): 0.28h']\n",
+    "['12: 25', '25: 36', '26: 36', '33: 3', 'Total: 100', 'Estimated time to run in hours (for 32 processors per node): 0.28h']\n",
+    "['0: 23', '16: 25', '22: 19', '23: 10', '31: 23', 'Total: 100', 'Estimated time to run in hours (for 32 processors per node): 0.28h']\n",
+    "['2: 13', '5: 14', '9: 15', '10: 15', '14: 2', '20: 6', '24: 16', '45: 2', '47: 17', 'Total: 100', 'Estimated time to run in hours (for 32 processors per node): 0.28h']\n",
+    "['6: 13', '13: 13', '29: 12', '34: 5', '39: 11', '43: 12', 'Total: 66', 'Estimated time to run in hours (for 32 processors per node): 0.20h']\n",
+    "\n",
+    "\n",
+    "#######################################################\n",
+    "Possible salloc command if you want to run on the interactive queue:\n",
+    "\n",
+    "salloc -N 7 -C haswell -t 01:00:00 --qos interactive -L SCRATCH,project\n",
+    "\n",
+    "#######################################################\n",
+    "Example shell script for slurm:\n",
+    "\n",
+    "#!/bin/bash -l\n",
+    "#SBATCH -q regular\n",
+    "#SBATCH -N 7\n",
+    "#SBATCH -t 01:00:00\n",
+    "#SBATCH -L SCRATCH,project\n",
+    "#SBATCH -C haswell\n",
+    "\n",
+    "srun -N 1 select_targets /global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1 $CSCRATCH/targets-dr7-hp-17,18,21.fits --numproc 32 --nside 2 --healpixels 17,18,21 &\n",
+    "srun -N 1 select_targets /global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1 $CSCRATCH/targets-dr7-hp-19,27,30.fits --numproc 32 --nside 2 --healpixels 19,27,30 &\n",
+    "srun -N 1 select_targets /global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1 $CSCRATCH/targets-dr7-hp-4,8,28,35.fits --numproc 32 --nside 2 --healpixels 4,8,28,35 &\n",
+    "srun -N 1 select_targets /global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1 $CSCRATCH/targets-dr7-hp-12,25,26,33.fits --numproc 32 --nside 2 --healpixels 12,25,26,33 &\n",
+    "srun -N 1 select_targets /global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1 $CSCRATCH/targets-dr7-hp-0,16,22,23,31.fits --numproc 32 --nside 2 --healpixels 0,16,22,23,31 &\n",
+    "srun -N 1 select_targets /global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1 $CSCRATCH/targets-dr7-hp-2,5,9,10,14,20,24,45,47.fits --numproc 32 --nside 2 --healpixels 2,5,9,10,14,20,24,45,47 &\n",
+    "srun -N 1 select_targets /global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1 $CSCRATCH/targets-dr7-hp-6,13,29,34,39,43.fits --numproc 32 --nside 2 --healpixels 6,13,29,34,39,43 &\n",
+    "wait\n",
+    "\n",
+    "#gather_targets '$CSCRATCH/targets-dr7-hp-17,18,21.fits;$CSCRATCH/targets-dr7-hp-19,27,30.fits;$CSCRATCH/targets-dr7-hp-4,8,28,35.fits;$CSCRATCH/targets-dr7-hp-12,25,26,33.fits;$CSCRATCH/targets-dr7-hp-0,16,22,23,31.fits;$CSCRATCH/targets-dr7-hp-2,5,9,10,14,20,24,45,47.fits;$CSCRATCH/targets-dr7-hp-6,13,29,34,39,43.fits' $CSCRATCH/targets-dr7.fits targets\n",
+    "```\n",
+    "\n",
+    "The top half of this output tells you the approximate time it will take to process the inputs, and an ```salloc``` command for requesting nodes. The second half of provides an example slurm script to run on the requested nodes. So, to use this information, you would place everything below ```#!/bin/bash -l``` in a file called, say, ```slurm.script```. You would then execute ```salloc -N 7 -C haswell -t 01:00:00 --qos interactive -L SCRATCH,project``` at the command line, wait to be allocated nodes, and then run ```slurm.script``` on your allocated nodes.\n",
+    "\n",
+    "A monolothic output file of all of the targets can be produced by removing the comment (`#`) before the ```gather_targets``` command in the last line of the slurm script. However, this should not prove necessary, as ```desitarget``` has tools for working with the HEALPixel-split parallelized output (see the next section ```useful commands for reading and producing subsets of targets```).\n",
+    "\n",
+    "Parallelized across nodes in this manner, it takes of order 20 minutes to run targeting (for ```nside=2```), as compared to about 1.5 hours for a basic run of `select_targets`.\n",
+    "\n",
+    "Note that the information in this section also applies to the ```select_sv_targets``` command line code that runs targets for SV."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Useful commands for reading and producing subsets of targets #\n",
+    "\n",
+    "`desitarget` has tools for producing subsets of targets limited by Right Ascension (RA) and Declination (Dec), or by HEALPixel. In addition, desitarget has wrappers to read subsets of the HEALPixel-partitioned targets produced from a parallelized run of `select_targets`, as described in the previous section.\n",
+    "\n",
+    "As a general reminder, note that `desihub` code always uses the `NESTED` HEALPixel scheme.\n",
+    "\n",
+    "### Setting up some example files ###\n",
+    "\n",
+    "To demonstrate this functionality, lets first produce a monolithic set of targets, as detailed in the `Basic production of target files at the command line` section. You can use any version of the code after `0.27.1` for this example (provided you use a consistent version throughout this section) and we'll store the outputs on scratch disk. The commands you'll need are (in brief, see the previous sections for more detail):\n",
+    "\n",
+    "```\n",
+    "export LSDIR='/global/project/projectdirs/cosmo/data/legacysurvey/dr7'\n",
+    "export DR='7.1'\n",
+    "\n",
+    "salloc -N 1 -C haswell -t 02:00:00 --qos interactive -L SCRATCH,project\n",
+    "\n",
+    "select_targets $LSDIR/sweep/$DR/ $CSCRATCH/master-targets.fits\n",
+    "```\n",
+    "\n",
+    "Let's also produce a HEALPixel-split version of the files as detailed in the `Producing target files in parallel` section. To do this, run `select_targets` with the `bundlefiles` option, for example:\n",
+    "\n",
+    "```\n",
+    "select_targets $LSDIR/sweep/$DR/ $CSCRATCH/blat.fits --bundlefiles 100 --nside 2\n",
+    "```\n",
+    "\n",
+    "and execute the produced slurm script on a set of interactive nodes. Finally, for the purposes of the rest of this tutorial, move the output files (`targets-dr7-hp-0,16,22,23,31.fits`, `targets-dr7-hp-17,18,21.fits`, etc.) to a directory called `$CSCRATCH/targsplit`.\n",
+    "\n",
+    "### Reading a subset of target files ###\n",
+    "\n",
+    "```desitarget``` has several useful wrappers to read the output of the parallelized or \"bundled\" code. Options include reading in a subset of HEALPixels, a \"box\" in RA/Dec or a cap (a \"circle\" on the sky) specified by RA/Dec/radius in degrees. Let's enter the Python prompt and try each of these options:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set-up the directory of HEALPixel-split files we created in the previous subsection.\n",
+    "import os\n",
+    "hpdirname = os.path.join(os.getenv(\"SCRATCH\"), \"targsplit\")\n",
+    "\n",
+    "# The various pieces of code for reading in targets.\n",
+    "from desitarget.io import read_targets_in_hp, read_targets_in_box, read_targets_in_cap\n",
+    "\n",
+    "# Read targets by HEALPixel.\n",
+    "nside, pixlist = 16, [2303, 2557, 3063]\n",
+    "hptargs = read_targets_in_hp(hpdirname, nside, pixlist)\n",
+    "\n",
+    "# Read targets in an RAmin, RAmax, Decmin, Decmax \"rectangle\".\n",
+    "radecbox = [120,122,32,34]\n",
+    "boxtargs = read_targets_in_box(hpdirname, radecbox)\n",
+    "\n",
+    "# Read targets in an RA, Dec, radius (degrees) \"circle\".\n",
+    "radecrad = [121,33,0.5]\n",
+    "captargs = read_targets_in_cap(hpdirname, radecrad)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The default option for extracting targets is to return all columns in a target file, but it's also possible to return just a subset of columns by passing them as a list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns = [\"DESI_TARGET\", \"TARGETID\"]\n",
+    "hptargs = read_targets_in_hp(hpdirname, nside, pixlist, columns=columns)\n",
+    "boxtargs = read_targets_in_box(hpdirname, radecbox, columns=columns)\n",
+    "captargs = read_targets_in_cap(hpdirname, radecrad, columns=columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is relatively straightforward to check that these commands worked, using the master file of targets that we created in the previous subsection. It is, of course, much quicker to read in subsets of targets rather than the entire master file!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fitsio\n",
+    "mastername = os.path.join(os.getenv(\"SCRATCH\"), \"master-targets.fits\")\n",
+    "mastertargs = fitsio.read(mastername, \"TARGETS\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Note that the geomask module has several useful functions\n",
+    "# for testing whether objects are in a cap, box, pixel etc.\n",
+    "from desitarget.geomask import is_in_cap\n",
+    "ii = is_in_cap(mastertargs, radecrad)\n",
+    "\n",
+    "# Did we return the exact same set of TARGETIDs?\n",
+    "capset = set(captargs[\"TARGETID\"])\n",
+    "masterset = set(mastertargs[ii][\"TARGETID\"])\n",
+    "# Are the sets identical?\n",
+    "capset == masterset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running a subset of target files ###\n",
+    "\n",
+    "It's certainly true that reading in a subset of targets from previosuly processed HEALPixel-split files is quicker than reading in all of the targets. But, it may also be even quicker in certain situations to *only process* that subset of targets in the first place.\n",
+    "\n",
+    "```desitarget``` can process target files only in certain regions of the sky, to completely circumvent the need to produce very large target files. As in the previous section, options include running in a subset of HEALPixels, a \"box\" in RA/Dec or a cap (a \"circle\" on the sky) specified by RA/Dec/radius in degrees. Although many of the commands described below are probably sufficiently fast to run on a login node, let's grab an interactive node for this section of the tutorial:\n",
+    "\n",
+    "```\n",
+    "salloc -N 1 -C haswell -t 00:20:00 --qos interactive -L SCRATCH,project\n",
+    "```\n",
+    "\n",
+    "As before, we'll set up some environment variables that point to the location of Legacy Surveys imaging Data Release files at NERSC:\n",
+    "\n",
+    "```\n",
+    "export LSDIR='/global/project/projectdirs/cosmo/data/legacysurvey/dr7'\n",
+    "export DR='7.1'\n",
+    "```\n",
+    "\n",
+    "First, let's try the HEALPixels option. We'll produce just the targets in HEALPixel 16 for ```nside=2```. \n",
+    "\n",
+    "```\n",
+    "select_targets $LSDIR/sweep/$DR/ $CSCRATCH/targets-hp-16.fits --nside 2 --healpixels 16\n",
+    "```\n",
+    "\n",
+    "Note that this only takes about 4 minutes to run (on the default 32 processors), as compared to an hour or more when running the full set of targets.\n",
+    "\n",
+    "There are similar options for an (RAmin, RAmax, Decmin, Decmax) \"box\":\n",
+    "\n",
+    "```\n",
+    "select_targets $LSDIR/sweep/$DR/ $CSCRATCH/targets-radecbox-120-122-32-34.fits --radecbox 120,122,32,34\n",
+    "```\n",
+    "\n",
+    "and for a cap (a \"circle\" on the sky) specified by RA/Dec/radius in degrees:\n",
+    "\n",
+    "```\n",
+    "select_targets $LSDIR/sweep/$DR/ $CSCRATCH/targets-radecrad-121-33-0.5.fits --radecrad 121,33,0.5\n",
+    "```\n",
+    "\n",
+    "These last two commands should run even faster (in 1-2 minutes) as they are querying much smaller areas than for the HEALPixel example.\n",
+    "\n",
+    "Note that all of the above options will work with the SV version of the code (`select_sv_targets`) in addition to the main survey version of the code (`select_targets`).\n",
+    "\n",
+    "We can check that these commands returned the expected outcomes using the same method as we used in the previous subsection to verify reading in subsets of targets. For example, returning to the Python prompt:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os, fitsio\n",
+    "from desitarget.geomask import is_in_box\n",
+    "\n",
+    "mastername = os.path.join(os.getenv(\"SCRATCH\"), \"master-targets.fits\")\n",
+    "mastertargs = fitsio.read(mastername, \"TARGETS\")\n",
+    "radecbox = [120, 122, 32, 34]\n",
+    "ii = is_in_box(mastertargs, radecbox)\n",
+    "masterset = set(mastertargs[ii][\"TARGETID\"])\n",
+    "\n",
+    "boxname = os.path.join(os.getenv(\"SCRATCH\"), \"targets-radecbox-120-122-32-34.fits\")\n",
+    "boxtargs = fitsio.read(boxname, \"TARGETS\")\n",
+    "boxset = set(boxtargs[\"TARGETID\"])\n",
+    "\n",
+    "# Did we return the exact same set of TARGETIDs?\n",
+    "boxset == masterset"
    ]
   },
   {
@@ -97,7 +384,6 @@
    "metadata": {},
    "source": [
     "# Production of all desitarget files at the command line #\n",
-    "\n",
     "\n",
     "In addition to the basic targets file, you may want some of the other `desitarget` products.\n",
     "\n",
@@ -158,7 +444,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Tips and tricks for working with command-line desitarget code #\n",
+    "# Other tips and tricks for working with command-line desitarget code #\n",
     "\n",
     "## General\n",
     "\n",
@@ -258,11 +544,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "```\n",
     "from desitarget.cuts import select_targets\n",
     "from desitarget import io\n",
     "\n",
@@ -277,7 +562,8 @@
     "targets = select_targets(infiles, tcnames=[\"LRG\", \"ELG\"], survey='main')\n",
     "\n",
     "# ADM write the targets to file.\n",
-    "io.write_targets(dest, targets, indir=src, survey=\"main\", nside=nside)"
+    "io.write_targets(dest, targets, indir=src, survey=\"main\", nside=nside)\n",
+    "```"
    ]
   }
  ],
@@ -297,7 +583,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2286,6 +2286,8 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
             log.critical(msg)
             raise ValueError(msg)
 
+    
+
     def _finalize_targets(objects, desi_target, bgs_target, mws_target):
         # - desi_target includes BGS_ANY and MWS_ANY, so we can filter just
         # - on desi_target != 0

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2414,6 +2414,12 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
             for x in infiles:
                 targets.append(_update_status(_select_targets_file(x)))
 
+    # ADM it's possible that somebody could pass an arangment of HEALPixels
+    # ADM that contain no targets, in which case exit (somewhat) gracefully.
+    if targets == []:
+        log.warning('ZERO targets for passed file list or region!!!')
+        return targets
+
     targets = np.concatenate(targets)
 
     # ADM restrict to only targets in a set of HEALPixels, if requested.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2265,8 +2265,8 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
     bundlefiles : :class:`int`, defaults to `None`
         If not `None`, then instead of selecting the skies, print, to screen, the slurm
         script that will approximately balance the input file distribution at `bundlefiles`
-        files per node. So, for instance, if `bundlefiles` is 100 then commands would be 
-        returned with the correct `pixlist` values set to pass to the code to pack at 
+        files per node. So, for instance, if `bundlefiles` is 100 then commands would be
+        returned with the correct `pixlist` values set to pass to the code to pack at
         about 100 files per node across all of the passed `infiles`.
     filespersec : :class:`float`, optional, defaults to 1.
         The rough number of files processed per second by the code (parallelized across
@@ -2333,7 +2333,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         nside = pixarea2nside(cap_area(np.array(radecrad[2])))
         pixlist = hp_in_cap(nside, radecrad)
 
-    # ADM if the pixlist or bundlefiles option was sent, we'll need to know          
+    # ADM if the pixlist or bundlefiles option was sent, we'll need to know
     # ADM which HEALPixels touch each file.
     if pixlist is not None or bundlefiles is not None:
         # ADM a list of HEALPixels that touch each file.
@@ -2345,7 +2345,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         pixnum = np.hstack(pixelsperfile)
         # ADM create a list of files that touch each HEALPixel.
         filesperpixel = [[] for pix in range(np.max(pixnum)+1)]
-        for ifile, pixels in enumerate(pixelsperfile):                                       
+        for ifile, pixels in enumerate(pixelsperfile):
             for pix in pixels:
                 filesperpixel[pix].append(infiles[ifile])
 
@@ -2354,8 +2354,8 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         prefix = "targets"
         if survey != "main":
             prefix = "{}_targets".format(survey)
-        bundle_bricks(pixnum, bundlefiles, nside, 
-                      brickspersec=filespersec, gather=False, 
+        bundle_bricks(pixnum, bundlefiles, nside,
+                      brickspersec=filespersec, gather=False,
                       prefix=prefix, surveydir=os.path.dirname(infiles[0]))
         return
 
@@ -2456,7 +2456,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
     if pixlist is not None:
         theta, phi = np.radians(90-targets["DEC"]), np.radians(targets["RA"])
         pixnums = hp.ang2pix(nside, theta, phi, nest=True)
-        w = np.hstack([np.where(pixnums==pix)[0] for pix in pixlist])
+        w = np.hstack([np.where(pixnums == pix)[0] for pix in pixlist])
         targets = targets[w]
 
     return targets

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2229,7 +2229,7 @@ Method_sandbox_options = ['XD', 'RF_photo', 'RF_spectro']
 
 def select_targets(infiles, numproc=4, qso_selection='randomforest',
                    gaiamatch=False, sandbox=False, FoMthresh=None, Method=None,
-                   nside=2, pixlist=None, bundlefiles=None, filespersec=1.,
+                   nside=2, pixlist=None, bundlefiles=None, filespersec=0.12,
                    radecbox=None, radecrad=None,
                    tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD"],
                    survey='main'):

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2318,7 +2318,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
 
     # ADM check that only one of pixlist, radecrad, radecbox was sent.
     inputs = [ins for ins in (pixlist, radecbox, radecrad) if ins is not None]
-    if len(ins) > 1:
+    if len(inputs) > 1:
         msg = "Only one of pixist, radecbox or radecrad can be passed"
         log.critical(msg)
         raise ValueError(msg)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2324,9 +2324,12 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
 
     # ADM if the bundlefiles option was sent, call the packing code.
     if bundlefiles is not None:
+        prefix = "targets"
+        if survey != "main":
+            prefix = "{}_targets".format(survey)
         bundle_bricks(pixnum, bundlefiles, nside, 
                       brickspersec=filespersec, gather=False, 
-                      prefix='targets', surveydir=os.path.dirname(infiles[0]))
+                      prefix=prefix, surveydir=os.path.dirname(infiles[0]))
         return
 
     # ADM restrict to only input files in a set of HEALPixels, if requested.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2326,13 +2326,17 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
 
     # ADM if radecbox was sent, determine which pixels touch the box.
     if radecbox is not None:
-        nside = pixarea2nside(box_area(radec))
+        nside = pixarea2nside(box_area(radecbox))
         pixlist = hp_in_box(nside, radecbox)
+        log.info("Run targets in box bounded by [RAmin, RAmax, Decmin, Decmax]={}"
+                 .format(radecbox))
 
     # ADM if radecrad was sent, determine which pixels touch the box.
     if radecrad is not None:
         nside = pixarea2nside(cap_area(np.array(radecrad[2])))
         pixlist = hp_in_cap(nside, radecrad)
+        log.info("Run targets in cap bounded by [centerRA, centerDec, radius]={}"
+                 .format(radecrad))
 
     # ADM if the pixlist or bundlefiles option was sent, we'll need to know
     # ADM which HEALPixels touch each file.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1811,7 +1811,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM combine quasar target bits for a quasar target based on any imaging
     qso = (qso_north & photsys_north) | (qso_south & photsys_south)
-
+    
     # ADM set the BGS bits
     if "BGS" in tcnames:
         bgs_classes = []
@@ -2268,14 +2268,14 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         files per node. So, for instance, if `bundlefiles` is 100 then commands would be
         returned with the correct `pixlist` values set to pass to the code to pack at
         about 100 files per node across all of the passed `infiles`.
-    filespersec : :class:`float`, optional, defaults to 1.
+    filespersec : :class:`float`, optional, defaults to 1
         The rough number of files processed per second by the code (parallelized across
         a chosen number of nodes). Used in conjunction with `bundlefiles` for the code
         to estimate time to completion when parallelizing across pixels.
-    radecbox :class:`list`, defaults to `None`
+    radecbox : :class:`list`, defaults to `None`
         4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the edges
         of a box in RA/Dec (degrees). Only targets in this box region will be processed.
-    radecrad :class:`list`, defaults to `None`
+    radecrad : :class:`list`, defaults to `None`
         3-entry list of coordinates [ra, dec, radius] forming a "circle" on the sky. For
         RA/Dec/radius in degrees. Only targets in this circle region will be processed.
     tcnames : :class:`list`, defaults to running all target classes

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1811,7 +1811,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM combine quasar target bits for a quasar target based on any imaging
     qso = (qso_north & photsys_north) | (qso_south & photsys_south)
-    
+
     # ADM set the BGS bits
     if "BGS" in tcnames:
         bgs_classes = []

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -30,7 +30,8 @@ from desitarget.gaiamatch import match_gaia_to_primary
 from desitarget.gaiamatch import pop_gaia_coords, pop_gaia_columns
 from desitarget.targets import finalize
 from desitarget.geomask import bundle_bricks, pixarea2nside
-from desitarget.geomask import cap_area, box_area, hp_in_box, hp_in_cap
+from desitarget.geomask import box_area, hp_in_box, is_in_box
+from desitarget.geomask import cap_area, hp_in_cap, is_in_cap
 
 # ADM set up the DESI default logger
 from desiutil.log import get_logger
@@ -2458,5 +2459,15 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         pixnums = hp.ang2pix(nside, theta, phi, nest=True)
         w = np.hstack([np.where(pixnums == pix)[0] for pix in pixlist])
         targets = targets[w]
+
+    # ADM restrict to only targets in an RA, Dec box, if requested.
+    if radecbox is not None:
+        ii = is_in_box(targets, radecbox)
+        targets = targets[ii]
+
+    # ADM restrict to only targets in an RA, Dec, radius cap, if requested.
+    if radecrad is not None:
+        ii = is_in_cap(targets, radecrad)
+        targets = targets[ii]
 
     return targets

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1233,7 +1233,7 @@ def isQSO_randomforest_north(gflux=None, rflux=None, zflux=None, w1flux=None, w2
                 (tmp_rf_proba >= pcut) | (tmp_rf_HighZ_proba >= pcut_HighZ)
 
     # In case of call for a single object passed to the function with scalar arguments
-    # Return "numpy.bool_" instead of "numpy.ndarray"
+    # Return "numpy.bool_" instead of "~numpy.ndarray"
     if nbEntries == 1:
         qso = qso[0]
 
@@ -1340,7 +1340,7 @@ def isQSO_randomforest_south(gflux=None, rflux=None, zflux=None, w1flux=None, w2
                 (tmp_rf_proba >= pcut) | (tmp_rf_HighZ_proba >= pcut_HighZ)
 
     # In case of call for a single object passed to the function with scalar arguments
-    # Return "numpy.bool_" instead of "numpy.ndarray"
+    # Return "numpy.bool_" instead of "~numpy.ndarray"
     if nbEntries == 1:
         qso = qso[0]
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2348,6 +2348,9 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         # ADM files. Each HEALPixel can appear multiple times if it's
         # ADM touched by multiple input sweep files.
         pixnum = np.hstack(pixelsperfile)
+        # ADM restrict input pixels to only those that touch an input file.
+        ii = [pix in pixnum for pix in pixlist]
+        pixlist = pixlist[ii]
         # ADM create a list of files that touch each HEALPixel.
         filesperpixel = [[] for pix in range(np.max(pixnum)+1)]
         for ifile, pixels in enumerate(pixelsperfile):

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -463,12 +463,12 @@ def pop_gaia_coords(inarr):
 
     Parameters
     ----------
-    inarr : :class:`numpy.ndarray`
+    inarr : :class:`~numpy.ndarray`
         Structured array with various column names.
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         Input array with columns called "GAIA_RA" and/or "GAIA_DEC" removed.
     """
     # ADM list of the column names of the passed array
@@ -495,14 +495,14 @@ def pop_gaia_columns(inarr, cols):
 
     Parameters
     ----------
-    inarr : :class:`numpy.ndarray`
+    inarr : :class:`~numpy.ndarray`
         Structured array with various column names.
     cols : :class:`list`
         List of columns to remove from the input array.
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         Input array with columns in cols removed.
     """
     # ADM list of the column names of the passed array
@@ -533,7 +533,7 @@ def read_gaia_file(filename, header=False):
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         Gaia data translated to targeting format (upper-case etc.) with the
         columns corresponding to `desitarget.gaiamatch.gaiadatamodel`
 
@@ -576,7 +576,7 @@ def find_gaia_files(objs, neighbors=True):
 
     Parameters
     ----------
-    objs : :class:`numpy.ndarray`
+    objs : :class:`~numpy.ndarray`
         Array of objects. Must contain at least the columns "RA" and "DEC".
     neighbors : :class:`bool`, optional, defaults to ``True``
         Return all of the pixels that touch the Gaia files of interest
@@ -697,7 +697,7 @@ def match_gaia_to_primary(objs, matchrad=1., retaingaia=False,
 
     Parameters
     ----------
-    objs : :class:`numpy.ndarray`
+    objs : :class:`~numpy.ndarray`
         Must contain at least "RA" and "DEC".
     matchrad : :class:`float`, optional, defaults to 1 arcsec
         The matching radius in arcseconds.
@@ -714,7 +714,7 @@ def match_gaia_to_primary(objs, matchrad=1., retaingaia=False,
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         The matching Gaia information for each object, where the returned format and
         columns correspond to `desitarget.secondary.gaiadatamodel`
 
@@ -801,14 +801,14 @@ def match_gaia_to_primary_single(objs, matchrad=1.):
 
     Parameters
     ----------
-    objs : :class:`numpy.ndarray`
+    objs : :class:`~numpy.ndarray`
         Must contain at least "RA" and "DEC". MUST BE A SINGLE ROW.
     matchrad : :class:`float`, optional, defaults to 1 arcsec
         The matching radius in arcseconds.
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         The matching Gaia information for the object, where the returned format and
         columns correspond to `desitarget.secondary.gaiadatamodel`
 
@@ -870,7 +870,7 @@ def write_gaia_matches(infiles, numproc=4, outdir="."):
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         The original sweeps files with the columns in `gaiadatamodel`
         added (except for the columns `GAIA_RA` and `GAIA_DEC`) are
         written to file. The filename is the same as the input

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -20,6 +20,7 @@ from os.path import basename
 from desitarget import io
 from desitarget.io import check_fitsio_version
 from desitarget.internal import sharedmem
+from desitarget.geomask import hp_in_box
 from desimodel.footprint import radec2pix
 from astropy.coordinates import SkyCoord
 from astropy import units as u
@@ -661,20 +662,8 @@ def find_gaia_files_box(gaiabounds, neighbors=True):
     gaiadir = _get_gaia_dir()
     hpxdir = os.path.join(gaiadir, 'healpix')
 
-    # ADM retrive the RA/Dec bounds from the passed list
-    ramin, ramax, decmin, decmax = gaiabounds
-
-    # ADM convert RA/Dec to co-latitude and longitude in radians
-    rapairs = np.array([ramin, ramin, ramax, ramax])
-    decpairs = np.array([decmin, decmax, decmax, decmin])
-    thetapairs, phipairs = np.radians(90.-decpairs), np.radians(rapairs)
-
-    # ADM convert the colatitudes to Cartesian vectors remembering to
-    # ADM transpose to pass the array to query_polygon in the correct order
-    vecs = hp.dir2vec(thetapairs, phipairs).T
-
     # ADM determine the pixels that touch the box.
-    pixnum = hp.query_polygon(nside, vecs, inclusive=True, fact=4, nest=True)
+    pixnum = hp_in_box(nside, gaiabounds, inclusive=True, fact=4)
 
     # ADM if neighbors was sent, then retrieve all pixels that touch each
     # ADM pixel covered by the provided locations, to prevent edge effects...

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -458,7 +458,7 @@ def box_area(radecbox):
 
     Parameters
     ----------
-    radecbox :class:`list`
+    radecbox : :class:`list`
         4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the
         edges of a box in RA/Dec (degrees).
 
@@ -765,7 +765,7 @@ def hp_in_box(nside, radecbox, inclusive=True, fact=4):
     ----------
     nside : :class:`int`
         (NESTED) HEALPixel nside.
-    radecbox :class:`list`
+    radecbox : :class:`list`
         4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the
         edges of a box in RA/Dec (degrees).
     inclusive : :class:`bool`, optional, defaults to ``True``
@@ -807,7 +807,7 @@ def is_in_box(objs, radecbox):
     ----------
     objs : :class:`~numpy.ndarray`
         An array of objects. Must include at least the columns "RA" and "DEC".
-    radecbox :class:`list`
+    radecbox : :class:`list`
         4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the
         edges of a box in RA/Dec (degrees).
 
@@ -841,7 +841,7 @@ def hp_in_cap(nside, radecrad, inclusive=True, fact=4):
     ----------
     nside : :class:`int`
         (NESTED) HEALPixel nside.
-    radecrad :class:`list`, defaults to `None`
+    radecrad : :class:`list`, defaults to `None`
         3-entry list of coordinates [ra, dec, radius] forming a cap or
         "circle" on the sky. ra, dec and radius are all in degrees.
     inclusive : :class:`bool`, optional, defaults to ``True``
@@ -881,7 +881,7 @@ def is_in_cap(objs, radecrad):
     ----------
     objs : :class:`~numpy.ndarray`
         An array of objects. Must include at least the columns "RA" and "DEC".
-    radecrad :class:`list`, defaults to `None`
+    radecrad : :class:`list`, defaults to `None`
         3-entry list of coordinates [ra, dec, radius] forming a cap or
         "circle" on the sky. ra, dec and radius are all in degrees.
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -576,7 +576,7 @@ def circle_boundaries(RAcens, DECcens, r, nloc):
     return np.hstack(ras), np.hstack(decs)
 
 
-def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', bundle=True,
+def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', gather=True,
                   surveydir="/global/project/projectdirs/cosmo/data/legacysurvey/dr6"):
     """Determine the optimal packing for bricks collected by HEALpixel integer
 
@@ -598,7 +598,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
         Should correspond to the binary executable "X" that is run as select_X for a 
         target type. Depending on the type of target file that is being packed for 
         parallelization, this could be 'randoms', 'skies', etc. 
-    bundle : :class:`bool`, optional, defaults to ``True``
+    gather : :class:`bool`, optional, defaults to ``True``
         If ``True`` then provide a final command for combining all of the HEALPix-split
         files into one large file. If ``False``, comment out that command.
     surveydir : :class:`str`, optional, defaults to the DR6 directory at NERSC
@@ -643,7 +643,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
     # ADM print to screen in the form of a slurm bash script, and
     # ADM other useful information
     print("#######################################################")
-    print("Numbers of bricks in each set of healpixels:")
+    print("Numbers of bricks or files in each set of HEALPixels:")
     print("")
     # ADM margin of 30 minutes for writing to disk
     margin = 30./60
@@ -671,7 +671,9 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
             print(outnote)
 
     print("")
-    print('Estimated additional margin for writing to disk in hours: {:.2f}h'.format(margin))
+    if gather:
+        print('Estimated additional margin for writing to disk in hours: {:.2f}h'
+              .format(margin))
 
     print("")
     print("#######################################################")
@@ -695,7 +697,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
     # ADM extract the Data Release number from the survey directory
     dr = surveydir.split('dr')[-1][0]
     comment = '#'
-    if bundle:
+    if gather:
         comment = ''
 
     outfiles = []

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -31,7 +31,7 @@ from desiutil.log import get_logger
 log = get_logger()
 
 # ADM fake the matplotlib display so it doesn't die on allocated nodes.
-import matplotlib
+import matplotlib   # noqa: E402
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt   # noqa: E402
 from matplotlib.patches import Circle, Ellipse, Rectangle  # noqa: E402
@@ -458,10 +458,10 @@ def box_area(radecbox):
 
     Parameters
     ----------
-    radecbox :class:`list`                                                                                                          
+    radecbox :class:`list`
         4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the vertices
         of a box in RA/Dec (degrees).
-    
+
     Returns
     -------
     :class:`list`
@@ -624,9 +624,9 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
         The rough number of bricks processed per second by the code (parallelized across
         a chosen number of nodes)
     prefix : :class:`str`, optional, defaults to 'targets'
-        Should correspond to the binary executable "X" that is run as select_X for a 
-        target type. Depending on the type of target file that is being packed for 
-        parallelization, this could be 'randoms', 'skies', 'targets', etc. 
+        Should correspond to the binary executable "X" that is run as select_X for a
+        target type. Depending on the type of target file that is being packed for
+        parallelization, this could be 'randoms', 'skies', 'targets', etc.
     gather : :class:`bool`, optional, defaults to ``True``
         If ``True`` then provide a final command for combining all of the HEALPix-split
         files into one large file. If ``False``, comment out that command.
@@ -744,14 +744,14 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
             goodpix.sort()
             strgoodpix = ",".join([str(pix) for pix in goodpix])
             # ADM the replace is to handle inputs that look like "sv1_targets".
-            outfile = "$CSCRATCH/{}-dr{}-hp-{}.fits".format(prefix.replace("_","-"), dr, strgoodpix)
+            outfile = "$CSCRATCH/{}-dr{}-hp-{}.fits".format(prefix.replace("_", "-"), dr, strgoodpix)
             outfiles.append(outfile)
             print("srun -N 1 select_{} {} {} --numproc 32 --nside {} --healpixels {} &"
                   .format(prefix2, surveydir, outfile, nside, strgoodpix))
     print("wait")
     print("")
     print("{}gather_targets '{}' $CSCRATCH/{}-dr{}.fits {}"
-            # ADM the prefix2 manipulation is to handle inputs that look like "sv1_targets".
+          # ADM the prefix2 manipulation is to handle inputs that look like "sv1_targets".
           .format(comment, ";".join(outfiles), prefix, dr, prefix2.split("_")[-1]))
     print("")
 
@@ -772,7 +772,7 @@ def hp_in_box(nside, radecbox, inclusive=True, fact=4):
         see documentation for `healpy.query_polygon()`.
     fact : :class:`int`, optional defaults to 4
         see documentation for `healpy.query_polygon()`.
-    
+
     Returns
     -------
     :class:`list`
@@ -783,7 +783,7 @@ def hp_in_box(nside, radecbox, inclusive=True, fact=4):
         - Just syntactic sugar around `healpy.query_polygon()`.
     """
     ramin, ramax, decmin, decmax = radecbox
-    
+
     # ADM convert RA/Dec to co-latitude and longitude in radians.
     rapairs = np.array([ramin, ramin, ramax, ramax])
     decpairs = np.array([decmin, decmax, decmax, decmin])
@@ -794,7 +794,7 @@ def hp_in_box(nside, radecbox, inclusive=True, fact=4):
     vecs = hp.dir2vec(thetapairs, phipairs).T
 
     # ADM determine the pixels that touch the box.
-    pixnum = hp.query_polygon(nside, vecs, 
+    pixnum = hp.query_polygon(nside, vecs,
                               inclusive=inclusive, fact=fact, nest=True)
 
     return pixnum
@@ -810,7 +810,7 @@ def is_in_box(objs, radecbox):
     radecbox :class:`list`
         4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the vertices
         of a box in RA/Dec (degrees).
-    
+
     Returns
     -------
     :class:`~numpy.ndarray`
@@ -828,7 +828,7 @@ def is_in_box(objs, radecbox):
         log.critical(msg)
         raise ValueError(msg)
 
-    ii = ((objs["RA"] >= ramin) & (objs["RA"] < ramax) 
+    ii = ((objs["RA"] >= ramin) & (objs["RA"] < ramax)
           & (objs["DEC"] >= decmin) & (objs["DEC"] < decmax))
 
     return ii
@@ -842,13 +842,13 @@ def hp_in_cap(nside, radecrad, inclusive=True, fact=4):
     nside : :class:`int`
         (NESTED) HEALPixel nside.
     radecrad :class:`list`, defaults to `None`
-        3-entry list of coordinates [ra, dec, radius] forming a cap or 
+        3-entry list of coordinates [ra, dec, radius] forming a cap or
         "circle" on the sky. ra, dec and radius are all in degrees.
     inclusive : :class:`bool`, optional, defaults to ``True``
         see documentation for `healpy.query_disc()`.
     fact : :class:`int`, optional defaults to 4
         see documentation for `healpy.query_disc()`.
-    
+
     Returns
     -------
     :class:`list`
@@ -859,7 +859,7 @@ def hp_in_cap(nside, radecrad, inclusive=True, fact=4):
         - Just syntactic sugar around `healpy.query_disc()`.
     """
     ra, dec, radius = radecrad
-    
+
     # ADM convert RA/Dec to co-latitude/longitude and everything to radians.
     theta, phi, rad = np.radians(90.-dec), np.radians(ra), np.radians(radius)
 
@@ -882,9 +882,9 @@ def is_in_cap(objs, radecrad):
     objs : :class:`~numpy.ndarray`
         An array of objects. Must include at least the columns "RA" and "DEC".
     radecrad :class:`list`, defaults to `None`
-        3-entry list of coordinates [ra, dec, radius] forming a cap or 
+        3-entry list of coordinates [ra, dec, radius] forming a cap or
         "circle" on the sky. ra, dec and radius are all in degrees.
-    
+
     Returns
     -------
     :class:`~numpy.ndarray`
@@ -896,10 +896,10 @@ def is_in_cap(objs, radecrad):
         - See also is_in_circle() which handles multiple caps.
     """
     ra, dec, radius = radecrad
-    
+
     cobjs = SkyCoord(objs["RA"]*u.degree, objs["DEC"]*u.degree)
     center = SkyCoord(ra*u.degree, dec*u.degree)
-   
+
     ii = center.separation(cobjs) <= radius*u.degree
 
     return ii
@@ -912,7 +912,7 @@ def pixarea2nside(area):
     ----------
     area : :class:`float`
         area in square degrees.
-    
+
     Returns
     -------
     :class:`int`

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1001,11 +1001,11 @@ def nside2nside(nside, nsidenew, pixlist):
     -------
     :class:`~numpy.ndarray`
         The altered list of HEALPixels.
-    
+
     Notes
     -----
-        - The size of the input list will be altered. For instance, 
-          nside=2, pixlist=[0,1] is covered by only pixel [0] at 
+        - The size of the input list will be altered. For instance,
+          nside=2, pixlist=[0,1] is covered by only pixel [0] at
           nside=1 but by pixels [0, 1, 2, 3, 4, 5, 6, 7] at nside=4.
         - Doesn't check that the passed pixels are valid at `nside`.
     """

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -752,7 +752,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
     print("")
     print("{}gather_targets '{}' $CSCRATCH/{}-dr{}.fits {}"
             # ADM the prefix2 manipulation is to handle inputs that look like "sv1_targets".
-          .format(comment, prefix2.split("_")[-1], ";".join(outfiles), dr, prefix))
+          .format(comment, ";".join(outfiles), prefix, dr, prefix2.split("_")[-1]))
     print("")
 
     return

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -700,6 +700,11 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
     if gather:
         comment = ''
 
+    # ADM to handle inputs that look like "sv1_targets".
+    prefix2 = prefix
+    if prefix[0:2] == "sv":
+        prefix2 = "sv_targets"
+
     outfiles = []
     for bin in bins:
         num = np.array(bin)[:, 0]
@@ -709,14 +714,16 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
             goodpix = pix[wpix]
             goodpix.sort()
             strgoodpix = ",".join([str(pix) for pix in goodpix])
-            outfile = "$CSCRATCH/{}-dr{}-hp-{}.fits".format(prefix, dr, strgoodpix)
+            # ADM the replace is to handle inputs that look like "sv1_targets".
+            outfile = "$CSCRATCH/{}-dr{}-hp-{}.fits".format(prefix.replace("_","-"), dr, strgoodpix)
             outfiles.append(outfile)
             print("srun -N 1 select_{} {} {} --numproc 32 --nside {} --healpixels {} &"
-                  .format(prefix, surveydir, outfile, nside, strgoodpix))
+                  .format(prefix2, surveydir, outfile, nside, strgoodpix))
     print("{}wait".format(comment))
     print("")
     print("{}gather_targets '{}' $CSCRATCH/{}-dr{}.fits {}"
-          .format(comment, prefix, ";".join(outfiles), dr, prefix))
+            # ADM the prefix2 manipulation is to handle inputs that look like "sv1_targets".
+          .format(comment, prefix2.split("_")[-1], ";".join(outfiles), dr, prefix))
     print("")
 
     return

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -976,6 +976,10 @@ def check_nside(nside):
     -------
     Nothing, but raises a ValueRrror for a bad `nside`.
     """
+    if nside is None:
+        msg = "need to pass the NSIDE parameter?"
+        log.critical(msg)
+        raise ValueError(msg)
     nside = np.atleast_1d(nside)
     good = hp.isnsideok(nside, nest=True)
     if not np.all(good):

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -975,7 +975,7 @@ def pixarea2nside(area):
     while (hp.nside2pixarea(nside, degrees=True) > area):
         nside *= 2
 
-    # ADM there is no nside of 0 so bail is nside is still 1.
+    # ADM there is no nside of 0 so bail if nside is still 1.
     if nside > 1:
         # ADM is the nside with the area that is smaller or larger
         # ADM than the passed area "closest" to the passed area?

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -459,8 +459,8 @@ def box_area(radecbox):
     Parameters
     ----------
     radecbox :class:`list`
-        4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the vertices
-        of a box in RA/Dec (degrees).
+        4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the
+        edges of a box in RA/Dec (degrees).
 
     Returns
     -------
@@ -766,8 +766,8 @@ def hp_in_box(nside, radecbox, inclusive=True, fact=4):
     nside : :class:`int`
         (NESTED) HEALPixel nside.
     radecbox :class:`list`
-        4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the vertices
-        of a box in RA/Dec (degrees).
+        4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the
+        edges of a box in RA/Dec (degrees).
     inclusive : :class:`bool`, optional, defaults to ``True``
         see documentation for `healpy.query_polygon()`.
     fact : :class:`int`, optional defaults to 4
@@ -808,8 +808,8 @@ def is_in_box(objs, radecbox):
     objs : :class:`~numpy.ndarray`
         An array of objects. Must include at least the columns "RA" and "DEC".
     radecbox :class:`list`
-        4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the vertices
-        of a box in RA/Dec (degrees).
+        4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the
+        edges of a box in RA/Dec (degrees).
 
     Returns
     -------
@@ -901,6 +901,32 @@ def is_in_cap(objs, radecrad):
     center = SkyCoord(ra*u.degree, dec*u.degree)
 
     ii = center.separation(cobjs) <= radius*u.degree
+
+    return ii
+
+
+def is_in_hp(objs, nside, pixlist):
+    """Determine which of an array of objects lie inside a set of HEALPixels.
+
+    Parameters
+    ----------
+    objs : :class:`~numpy.ndarray`
+        An array of objects. Must include at least the columns "RA" and "DEC".
+    nside : :class:`int`
+        The HEALPixel nside number (NESTED scheme).
+    pixlist : :class:`list` or `~numpy.ndarray`
+        The list of HEALPixels in which to find objects.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        ``True`` for objects in pixlist, ``False`` for objects outside of pixlist.
+    """
+    theta, phi = np.radians(90-objs["DEC"]), np.radians(objs["RA"])
+    pixnums = hp.ang2pix(nside, theta, phi, nest=True)
+    w = np.hstack([np.where(pixnums == pix)[0] for pix in pixlist])
+    ii = np.zeros(len(pixnums), dtype='bool')
+    ii[w] = True
 
     return ii
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -18,7 +18,6 @@ from astropy.coordinates import SkyCoord
 from astropy import units as u
 
 from desiutil import depend, brick
-from desitarget import io
 from desitarget.targetmask import desi_mask, targetid_mask
 from desitarget.targets import encode_targetid, finalize
 from desitarget.internal import sharedmem

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -5,7 +5,7 @@
 desitarget.geomask
 ==================
 
-Utility module with functions for masking circles and ellipses on the sky
+Utility functions for restricting targets to regions on the sky
 
 """
 from __future__ import (absolute_import, division)
@@ -574,3 +574,147 @@ def circle_boundaries(RAcens, DECcens, r, nloc):
 
     # ADM have to turn the generated locations into 1-D arrays before returning them
     return np.hstack(ras), np.hstack(decs)
+
+
+def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', bundle=True,
+                  surveydir="/global/project/projectdirs/cosmo/data/legacysurvey/dr6"):
+    """Determine the optimal packing for bricks collected by HEALpixel integer
+
+    Parameters
+    ----------
+    pixnum : :class:`np.array`
+        List of integers, e.g., HEALPixel numbers occupied by a set of bricks
+        (e.g. array([16, 16, 16...12 , 13, 19]) ).
+    maxpernode : :class:`int`
+        The maximum number of pixels to bundle together (e.g., if you were
+        trying to pass maxpernode bricks, delineated by the HEALPixels they
+        occupy, parallelized across a set of nodes).
+    nside : :class:`int`
+        The HEALPixel nside number that was used to generate `pixnum` (NESTED scheme).
+    brickspersec : :class:`float`, optional, defaults to 1.
+        The rough number of bricks processed per second by the code (parallelized across
+        a chosen number of nodes)
+    prefix : :class:`str`, optional, defaults to 'targets'
+        Should correspond to the binary executable "X" that is run as select_X for a 
+        target type. Depending on the type of target file that is being packed for 
+        parallelization, this could be 'randoms', 'skies', etc. 
+    bundle : :class:`bool`, optional, defaults to ``True``
+        If ``True`` then provide a final command for combining all of the HEALPix-split
+        files into one large file. If ``False``, comment out that command.
+    surveydir : :class:`str`, optional, defaults to the DR6 directory at NERSC
+        The root directory pointing to a Data Release from the Legacy Surveys,
+        (e.g. "/global/project/projectdirs/cosmo/data/legacysurvey/dr6").
+
+    Returns
+    -------
+    Nothing, but prints commands to screen that would facilitate running a
+    set of bricks by HEALPixel integer with the total number of bricks not
+    to exceed maxpernode. Also prints how many bricks would be on each node.
+
+    Notes
+    -----
+    h/t https://stackoverflow.com/questions/7392143/python-implementations-of-packing-algorithm
+    """
+    # ADM the number of pixels (numpix) in each pixel (pix)
+    pix, numpix = np.unique(pixnum, return_counts=True)
+
+    # ADM the indices needed to reverse-sort the array on number of pixels
+    reverse_order = np.flipud(np.argsort(numpix))
+    numpix = numpix[reverse_order]
+    pix = pix[reverse_order]
+
+    # ADM iteratively populate lists of the numbers of pixels
+    # ADM and the corrsponding pixel numbers
+    bins = []
+
+    for index, num in enumerate(numpix):
+        # Try to fit this sized number into a bin
+        for bin in bins:
+            if np.sum(np.array(bin)[:, 0]) + num <= maxpernode:
+                # print 'Adding', item, 'to', bin
+                bin.append([num, pix[index]])
+                break
+        else:
+            # item didn't fit into any bin, start a new bin
+            bin = []
+            bin.append([num, pix[index]])
+            bins.append(bin)
+
+    # ADM print to screen in the form of a slurm bash script, and
+    # ADM other useful information
+    print("#######################################################")
+    print("Numbers of bricks in each set of healpixels:")
+    print("")
+    # ADM margin of 30 minutes for writing to disk
+    margin = 30./60
+    maxeta = 0
+    for bin in bins:
+        num = np.array(bin)[:, 0]
+        pix = np.array(bin)[:, 1]
+        wpix = np.where(num > 0)[0]
+        if len(wpix) > 0:
+            goodpix, goodnum = pix[wpix], num[wpix]
+            sorter = goodpix.argsort()
+            goodpix, goodnum = goodpix[sorter], goodnum[sorter]
+            outnote = ['{}: {}'.format(pix, num) for pix, num in zip(goodpix, goodnum)]
+            # ADM add the total across all of the pixels
+            outnote.append('Total: {}'.format(np.sum(goodnum)))
+            # ADM a crude estimate of how long the script will take to run
+            # ADM brickspersec is bricks/sec. Extra delta is minutes to write to disk
+            delta = 3./60.
+            eta = delta + np.sum(goodnum)/brickspersec/3600
+            outnote.append('Estimated time to run in hours (for 32 processors per node): {:.2f}h'
+                           .format(eta))
+            # ADM track the maximum estimated time for shell scripts, etc.
+            if (eta+margin).astype(int) + 1 > maxeta:
+                maxeta = (eta+margin).astype(int) + 1
+            print(outnote)
+
+    print("")
+    print('Estimated additional margin for writing to disk in hours: {:.2f}h'.format(margin))
+
+    print("")
+    print("#######################################################")
+    print("Possible salloc command if you want to run on the interactive queue:")
+    print("")
+    print("salloc -N {} -C haswell -t 0{}:00:00 --qos interactive -L SCRATCH,project"
+          .format(len(bins), maxeta))
+
+    print("")
+    print("#######################################################")
+    print('Example shell script for slurm:')
+    print('')
+    print('#!/bin/bash -l')
+    print('#SBATCH -q regular')
+    print('#SBATCH -N {}'.format(len(bins)))
+    print('#SBATCH -t 0{}:00:00'.format(maxeta))
+    print('#SBATCH -L SCRATCH,project')
+    print('#SBATCH -C haswell')
+    print('')
+
+    # ADM extract the Data Release number from the survey directory
+    dr = surveydir.split('dr')[-1][0]
+    comment = '#'
+    if bundle:
+        comment = ''
+
+    outfiles = []
+    for bin in bins:
+        num = np.array(bin)[:, 0]
+        pix = np.array(bin)[:, 1]
+        wpix = np.where(num > 0)[0]
+        if len(wpix) > 0:
+            goodpix = pix[wpix]
+            goodpix.sort()
+            strgoodpix = ",".join([str(pix) for pix in goodpix])
+            outfile = "$CSCRATCH/{}-dr{}-hp-{}.fits".format(prefix, dr, strgoodpix)
+            outfiles.append(outfile)
+            print("srun -N 1 select_{} {} {} --numproc 32 --nside {} --healpixels {} &"
+                  .format(prefix, surveydir, outfile, nside, strgoodpix))
+    print("{}wait".format(comment))
+    print("")
+    print("{}gather_targets '{}' $CSCRATCH/{}-dr{}.fits {}"
+          .format(comment, prefix, ";".join(outfiles), dr, prefix))
+    print("")
+
+    return

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -353,37 +353,6 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
     return gfas
 
 
-def decode_sweep_name(sweepname):
-    """Retrieve RA/Dec edges from a full directory path to a sweep file
-
-    Parameters
-    ----------
-    sweepname : :class:`str`
-        Full path to a sweep file, e.g., /a/b/c/sweep-350m005-360p005.fits
-
-    Returns
-    -------
-    :class:`list`
-        A 4-entry list of the edges of the region covered by the sweeps file
-        in the form [RAmin, RAmax, DECmin, DECmax]
-        For the above example this would be [350., 360., -5., 5.]
-    """
-    # ADM extract just the file part of the name
-    sweepname = os.path.basename(sweepname)
-
-    # ADM the RA/Dec edges
-    ramin, ramax = float(sweepname[6:9]), float(sweepname[14:17])
-    decmin, decmax = float(sweepname[10:13]), float(sweepname[18:21])
-
-    # ADM flip the signs on the DECs, if needed
-    if sweepname[9] == 'm':
-        decmin *= -1
-    if sweepname[17] == 'm':
-        decmax *= -1
-
-    return [ramin, ramax, decmin, decmax]
-
-
 def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
     """Create a set of GFA locations using Gaia
 
@@ -425,7 +394,7 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
     def _get_gfas(fn):
         '''wrapper on gaia_gfas_from_sweep() given a file name'''
         # ADM we need to pass the boundaries of the sweeps file, too
-        bounds = decode_sweep_name(fn)
+        bounds = desitarget.io.decode_sweep_name(fn)
 
         return gaia_gfas_from_sweep(
             fn, maglim=maglim, gaiamatch=gaiamatch, gaiabounds=bounds

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -219,7 +219,7 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
 
     Parameters
     ----------
-    objects: :class:`numpy.ndarray` or `str`
+    objects: :class:`~numpy.ndarray` or `str`
         Numpy structured array with UPPERCASE columns needed for target selection, OR
         a string corresponding to a sweep filename.
     maglim : :class:`float`, optional, defaults to 18
@@ -233,7 +233,7 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         GFA objects from Gaia for the region bounded by `gaiabounds`, formatted
         according to `desitarget.gfa.gfadatamodel`.
     """
@@ -370,7 +370,7 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         GFA objects from Gaia across all of the passed input files, formatted
         according to `desitarget.gfa.gfadatamodel`.
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -5,7 +5,7 @@
 desitarget.io
 =============
 
-This file knows how to write a TS catalogue.
+Functions for reading, writing and manipulating files related to targeting.
 """
 from __future__ import (absolute_import, division)
 #
@@ -1055,3 +1055,34 @@ def read_external_file(filename, header=False, columns=["RA", "DEC"]):
         return outdata, hdr
     else:
         return outdata
+
+
+def decode_sweep_name(sweepname):
+    """Retrieve RA/Dec edges from a full directory path to a sweep file
+
+    Parameters
+    ----------
+    sweepname : :class:`str`
+        Full path to a sweep file, e.g., /a/b/c/sweep-350m005-360p005.fits
+
+    Returns
+    -------
+    :class:`list`
+        A 4-entry list of the edges of the region covered by the sweeps file
+        in the form [RAmin, RAmax, DECmin, DECmax]
+        For the above example this would be [350., 360., -5., 5.]
+    """
+    # ADM extract just the file part of the name
+    sweepname = os.path.basename(sweepname)
+
+    # ADM the RA/Dec edges
+    ramin, ramax = float(sweepname[6:9]), float(sweepname[14:17])
+    decmin, decmax = float(sweepname[10:13]), float(sweepname[18:21])
+
+    # ADM flip the signs on the DECs, if needed
+    if sweepname[9] == 'm':
+        decmin *= -1
+    if sweepname[17] == 'm':
+        decmax *= -1
+
+    return [ramin, ramax, decmin, decmax]

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1199,10 +1199,13 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None):
     """
     # ADM we'll need RA/Dec for final cuts, so ensure they're read.
     addedcols = []
+    columnscopy = None
     if columns is not None:
+        # ADM make a copy of columns, as it's a kwarg we'll modify.
+        columnscopy = columns.copy()
         for radec in ["RA", "DEC"]:
-            if radec not in columns:
-                columns.append(radec)
+            if radec not in columnscopy:
+                columnscopy.append(radec)
                 addedcols.append(radec)
 
     # ADM check, and grab information from, the target directory.
@@ -1219,7 +1222,8 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None):
     # ADM read in the files and concatenate the resulting targets.
     targets = []
     for pix in filepixlist:
-        targets.append(fitsio.read(filedict[pix], columns=columns))
+        targets.append(fitsio.read(filedict[pix], 
+                                   columns=columnscopy))
     targets = np.concatenate(targets)
 
     # ADM restrict the targets to the actual requested HEALPixels...
@@ -1251,10 +1255,13 @@ def read_targets_in_box(hpdirname, radecbox, columns=None):
     """
     # ADM we'll need RA/Dec for final cuts, so ensure they're read.
     addedcols = []
+    columnscopy = None
     if columns is not None:
+        # ADM make a copy of columns, as it's a kwarg we'll modify.
+        columnscopy = columns.copy()
         for radec in ["RA", "DEC"]:
-            if radec not in columns:
-                columns.append(radec)
+            if radec not in columnscopy:
+                columnscopy.append(radec)
                 addedcols.append(radec)
 
     # ADM approximate nside for area of passed box.
@@ -1264,7 +1271,8 @@ def read_targets_in_box(hpdirname, radecbox, columns=None):
     pixlist = hp_in_box(nside, radecbox)
 
     # ADM read in targets in these HEALPixels.
-    targets = read_targets_in_hp(hpdirname, nside, pixlist, columns=columns)
+    targets = read_targets_in_hp(hpdirname, nside, pixlist, 
+                                 columns=columnscopy)
 
     # ADM restrict only to targets in the requested RA/Dec box...
     ii = is_in_box(targets, radecbox)
@@ -1295,10 +1303,13 @@ def read_targets_in_cap(hpdirname, radecrad, columns=None):
     """
     # ADM we'll need RA/Dec for final cuts, so ensure they're read.
     addedcols = []
+    columnscopy = None
     if columns is not None:
+        # ADM make a copy of columns, as it's a kwarg we'll modify.
+        columnscopy = columns.copy()
         for radec in ["RA", "DEC"]:
-            if radec not in columns:
-                columns.append(radec)
+            if radec not in columnscopy:
+                columnscopy.append(radec)
                 addedcols.append(radec)
 
     # ADM approximate nside for area of passed cap.
@@ -1309,7 +1320,8 @@ def read_targets_in_cap(hpdirname, radecrad, columns=None):
 
     # FIXME: factor of 2 speed-up if we don't read the file twice.
     # ADM read in targets in these HEALPixels.
-    targets = read_targets_in_hp(hpdirname, nside, pixlist, columns=columns)
+    targets = read_targets_in_hp(hpdirname, nside, pixlist, 
+                                 columns=columnscopy)
 
     # ADM restrict only to targets in the requested cap...
     ii = is_in_cap(targets, radecrad)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1222,7 +1222,7 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None):
     # ADM read in the files and concatenate the resulting targets.
     targets = []
     for pix in filepixlist:
-        targets.append(fitsio.read(filedict[pix], 
+        targets.append(fitsio.read(filedict[pix],
                                    columns=columnscopy))
     targets = np.concatenate(targets)
 
@@ -1242,7 +1242,7 @@ def read_targets_in_box(hpdirname, radecbox, columns=None):
     hpdirname : :class:`str`
         Full path to a directory containing targets THAT HAVE
         BEEN PARTITIONED BY HEALPIXEL.
-    radecbox :class:`list`
+    radecbox : :class:`list`
         4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the edges
         of a box in RA/Dec (degrees).
     columns : :class:`list`, optional
@@ -1271,7 +1271,7 @@ def read_targets_in_box(hpdirname, radecbox, columns=None):
     pixlist = hp_in_box(nside, radecbox)
 
     # ADM read in targets in these HEALPixels.
-    targets = read_targets_in_hp(hpdirname, nside, pixlist, 
+    targets = read_targets_in_hp(hpdirname, nside, pixlist,
                                  columns=columnscopy)
 
     # ADM restrict only to targets in the requested RA/Dec box...
@@ -1290,7 +1290,7 @@ def read_targets_in_cap(hpdirname, radecrad, columns=None):
     hpdirname : :class:`str`
         Full path to a directory containing targets THAT HAVE
         BEEN PARTITIONED BY HEALPIXEL.
-    radecrad :class:`list`
+    radecrad : :class:`list`
         3-entry list of coordinates [ra, dec, radius] forming a cap or
         "circle" on the sky. ra, dec and radius are all in degrees.
     columns : :class:`list`, optional
@@ -1320,7 +1320,7 @@ def read_targets_in_cap(hpdirname, radecrad, columns=None):
 
     # FIXME: factor of 2 speed-up if we don't read the file twice.
     # ADM read in targets in these HEALPixels.
-    targets = read_targets_in_hp(hpdirname, nside, pixlist, 
+    targets = read_targets_in_hp(hpdirname, nside, pixlist,
                                  columns=columnscopy)
 
     # ADM restrict only to targets in the requested cap...

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -16,9 +16,14 @@ import re
 from . import __version__ as desitarget_version
 import numpy.lib.recfunctions as rfn
 import healpy as hp
+from glob import glob
 
 from desiutil import depend
 from desitarget.geomask import hp_in_box
+
+# ADM set up the DESI default logger
+from desiutil.log import get_logger
+log = get_logger()
 
 # ADM this is a lookup dictionary to map RELEASE to a simpler "North" or "South".
 # ADM photometric system. This will expand with the definition of RELEASE in the
@@ -92,7 +97,7 @@ def convert_from_old_data_model(fx, columns=None):
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         Array with the tractor schema, uppercase field names.
 
     Notes
@@ -154,12 +159,12 @@ def add_gaia_columns(indata):
 
     Parameters
     ----------
-    indata : :class:`numpy.ndarray`
+    indata : :class:`~numpy.ndarray`
         Numpy structured array to which to add Gaia-relevant columns.
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         Input array with the Gaia columns added.
 
     Notes
@@ -194,12 +199,12 @@ def add_dr7_columns(indata):
 
     Parameters
     ----------
-    indata : :class:`numpy.ndarray`
+    indata : :class:`~numpy.ndarray`
         Numpy structured array to which to add DR7 columns.
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         Input array with DR7 columns added.
 
     Notes
@@ -226,12 +231,12 @@ def add_photsys(indata):
 
     Parameters
     ----------
-    indata : :class:`numpy.ndarray`
+    indata : :class:`~numpy.ndarray`
         Numpy structured array to which to add PHOTSYS column.
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         Input array with PHOTSYS added (and set using RELEASE).
 
     Notes
@@ -277,13 +282,9 @@ def read_tractor(filename, header=False, columns=None):
 
     Returns
     -------
-    :class:`numpy.ndarray`
+    :class:`~numpy.ndarray`
         Array with the tractor schema, uppercase field names.
     """
-    # ADM set up the default DESI logger.
-    from desiutil.log import get_logger
-    log = get_logger()
-
     check_fitsio_version()
 
     fx = fitsio.FITS(filename, upper=True)
@@ -460,10 +461,6 @@ def write_targets(filename, data, indir=None, qso_selection=None,
     """
     # FIXME: assert data and tsbits schema
 
-    # ADM set up the default logger.
-    from desiutil.log import get_logger
-    log = get_logger()
-
     # ADM use RELEASE to determine the release string for the input targets.
     ntargs = len(data)
     if ntargs == 0:
@@ -543,10 +540,6 @@ def write_skies(filename, data, indir=None, apertures_arcsec=None,
         If passed, add a column to the skies array popluated with HEALPixels
         at resolution `nside`.
     """
-    # ADM set up the default logger.
-    from desiutil.log import get_logger
-    log = get_logger()
-
     nskies = len(data)
 
     # ADM force OBSCONDITIONS to be 65535
@@ -613,10 +606,6 @@ def write_gfas(filename, data, indir=None, nside=None, gaiaepoch=None):
         Gaia proper motion reference epoch. If not None, write to header of
         output file. If None, default to an epoch of 2015.5.
     """
-    # ADM set up the default logger.
-    from desiutil.log import get_logger
-    log = get_logger()
-
     # ADM rename 'TYPE' to 'MORPHTYPE'.
     data = rfn.rename_fields(data, {'TYPE': 'MORPHTYPE'})
 
@@ -669,10 +658,6 @@ def write_randoms(filename, data, indir=None, nside=None, density=None):
         Number of points per sq. deg. at which the catalog was generated,
         write to header of the output file if not None.
     """
-    # ADM set up the default logger.
-    from desiutil.log import get_logger
-    log = get_logger()
-
     # ADM create header to include versions, etc.
     hdr = fitsio.FITSHDR()
     depend.setdep(hdr, 'desitarget', desitarget_version)
@@ -736,9 +721,6 @@ def iter_files(root, prefix, ext='fits'):
 def list_sweepfiles(root):
     """Return a list of sweep files found under `root` directory.
     """
-    from desiutil.log import get_logger
-    log = get_logger(timestamp=True)
-
     # ADM check for duplicate files in case the listing was run
     # ADM at too low a level in the directory structure.
     check = [os.path.basename(x) for x in iter_sweepfiles(root)]
@@ -757,9 +739,6 @@ def iter_sweepfiles(root):
 def list_tractorfiles(root):
     """Return a list of tractor files found under `root` directory.
     """
-    from desiutil.log import get_logger
-    log = get_logger(timestamp=True)
-
     # ADM check for duplicate files in case the listing was run
     # ADM at too low a level in the directory structure.
     check = [os.path.basename(x) for x in iter_tractorfiles(root)]
@@ -933,10 +912,6 @@ def load_pixweight(inmapfile, nside, pixmap=None):
     :class:`~numpy.array`
         HEALPixel weight map resampled to the requested nside.
     """
-    import healpy as hp
-    from desiutil.log import get_logger
-    log = get_logger()
-
     if pixmap is not None:
         log.debug('Using input pixel weight map of length {}.'.format(len(pixmap)))
     else:
@@ -982,10 +957,6 @@ def load_pixweight_recarray(inmapfile, nside, pixmap=None):
           if a column `HPXPIXEL` is passed. That column is reassigned the appropriate
           pixel number at the new nside.
     """
-    import healpy as hp
-    from desiutil.log import get_logger
-    log = get_logger()
-
     if pixmap is not None:
         log.debug('Using input pixel weight map of length {}.'.format(len(pixmap)))
     else:
@@ -1052,7 +1023,10 @@ def read_external_file(filename, header=False, columns=["RA", "DEC"]):
 
     Returns
     -------
-    :class:`numpy.ndarray``
+    :class:`~numpy.ndarray`
+        The output data array.
+    :class:`~numpy.ndarray`, optional
+        The output file header, if input `header` was ``True``.
 
     Notes
     -----
@@ -1131,3 +1105,66 @@ def decode_sweep_name(sweepname, nside=None, inclusive=True, fact=4):
                        inclusive=inclusive, fact=fact)
 
     return pixnum
+
+
+def check_hp_targets_dir(hpdirname):
+    """Check fidelity of a directory of HEALPixel-partitioned targets.
+
+    Parameters
+    ----------
+    hpdirname : :class:`str`
+        Full path to a directory of targets that have been split by
+        HEALPixel.
+
+    Returns
+    -------
+    :class:`int`
+        The HEALPixel NSIDE for the files in the passed directory.
+    :class:`~numpy.ndarray`
+        An array of HEALPixel numbers touched by the files.
+
+    Notes
+    -----
+        - Checks that all files are at the same NSIDE.
+        - Checks that no two files contain the same HEALPixels.
+        - Checks that HEALPixel numbers are consistent with NSIDE.
+    """
+    # ADM glob all the files in the directory, read the pixel
+    # ADM numbers and NSIDEs.
+    nside = []
+    pixlist = []
+    fns = glob(os.path.join(hpdirname,"*fits"))
+    for fn in fns:
+        hdr = fitsio.read_header(fn, "TARGETS")
+        nside.append(hdr["FILENSID"])
+        pixlist.append(hdr["FILEHPX"])
+    nside = np.array(nside)
+    # ADM as well as having just an array of all the pixels.
+    pixlist = np.hstack(pixlist)
+
+    msg = None
+    # ADM check all NSIDEs are the same.
+    if not np.all(nside == nside[0]):
+        msg = 'Not all files in {} are at the same NSIDE'     \
+            .format(hpdirname)
+
+    # ADM check that no two files contain the same HEALPixels.
+    if not len(set(pixlist)) == len(pixlist):
+        dup = set([pix for pix in pixlist if list(pixlist).count(pix) > 1])
+        msg = 'Duplicate pixel ({}) in files in {}'           \
+            .format(dup, hpdirname)
+
+    # ADM check that the pixels are consistent with the nside.
+    goodpix = np.arange(hp.nside2npix(nside[0]))
+    badpix = set(pixlist) - set(goodpix)
+    if len(badpix) > 0:
+        msg = 'Pixel ({}) not allowed at NSIDE={} in {}'.     \
+              format(badpix, nside[0], hpdirname)
+
+    if msg is not None:
+        log.critical(msg)
+        raise AssertionError(msg)
+
+    pixlist.sort()
+
+    return nside[0], pixlist

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -18,6 +18,7 @@ import numpy.lib.recfunctions as rfn
 import healpy as hp
 
 from desiutil import depend
+from desitarget.geomask import hp_in_box
 
 # ADM this is a lookup dictionary to map RELEASE to a simpler "North" or "South".
 # ADM photometric system. This will expand with the definition of RELEASE in the
@@ -1097,17 +1098,7 @@ def decode_sweep_name(sweepname, nside=None, inclusive=True, fact=4):
     if nside is None:
         return [ramin, ramax, decmin, decmax]
     
-    # ADM convert RA/Dec to co-latitude and longitude in radians.
-    rapairs = np.array([ramin, ramin, ramax, ramax])
-    decpairs = np.array([decmin, decmax, decmax, decmin])
-    thetapairs, phipairs = np.radians(90.-decpairs), np.radians(rapairs)
-
-    # ADM convert the colatitudes to Cartesian vectors remembering to
-    # ADM transpose to pass the array to query_polygon in the correct order.
-    vecs = hp.dir2vec(thetapairs, phipairs).T
-
-    # ADM determine the pixels that touch the box.                                                                                                                                                       
-    pixnum = hp.query_polygon(nside, vecs, 
-                              inclusive=inclusive, fact=fact, nest=True)
+    pixnum = hp_in_box(nside, [ramin, ramax, decmin, decmax], 
+                       inclusive=inclusive, fact=fact)
 
     return pixnum

--- a/py/desitarget/myRF.py
+++ b/py/desitarget/myRF.py
@@ -70,7 +70,7 @@ class myRF(object):
         leftCond = (self.data[indices, feature] <= threshold)
         leftChildIndices = indices[leftCond]
 #        rightCond = (self.data[indices,feature] > threshold)
-        rightChildIndices = indices[leftCond is False]
+        rightChildIndices = indices[~leftCond]
 
         self.searchNodes(leftChildIndices, nodeId=leftChildId)
         self.searchNodes(rightChildIndices, nodeId=rightChildId)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -16,7 +16,7 @@ import healpy as hp
 import fitsio
 from glob import glob
 from desitarget.gaiamatch import _get_gaia_dir
-from desitarget.geomask import bundle_bricks
+from desitarget.geomask import bundle_bricks, box_area
 from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
 
 # ADM the parallelization script
@@ -107,12 +107,10 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
     # ADM sizes of 0.25 x 0.25 sq. deg., or not much larger than that
     if ramax - ramin > 350.:
         ramax -= 360.
-    sindecmin, sindecmax = np.sin(np.radians(decmin)), np.sin(np.radians(decmax))
-    spharea = (ramax-ramin)*np.degrees(sindecmax-sindecmin)
+    spharea = box_area([ramin, ramax, decmin, decmax])
 
     if poisson:
         nrand = int(np.random.poisson(spharea*density))
-
     else:
         nrand = int(spharea*density)
 #    log.info('Full area covered by brick is {:.5f} sq. deg....t = {:.1f}s'
@@ -176,8 +174,8 @@ def randoms_in_a_brick_from_name(brickname, density=100000,
     # ADM guard against potential wraparound bugs
     if ramax - ramin > 350.:
         ramax -= 360.
-    sindecmin, sindecmax = np.sin(np.radians(decmin)), np.sin(np.radians(decmax))
-    spharea = (ramax-ramin)*np.degrees(sindecmax-sindecmin)
+    spharea = box_area([ramin, ramax, decmin, decmax])
+
     nrand = int(spharea*density)
     # log.info('Full area covered by brick {} is {:.5f} sq. deg....t = {:.1f}s'
     #          .format(brickname,spharea,time()-start))

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -435,7 +435,6 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=1
     # ADM retrieve the E(B-V) values for each random point
     ebv = get_dust(ras, decs, dustdir=dustdir)
 
-
     # ADM convert the dictionary to a structured array
     qinfo = np.zeros(len(ras),
                      dtype=[('RA', 'f8'), ('DEC', 'f8'), ('BRICKNAME', 'S8'),

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1,4 +1,4 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+B41;281;0c# Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 """
 ==========================
@@ -116,6 +116,7 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
 #    log.info('Full area covered by brick is {:.5f} sq. deg....t = {:.1f}s'
 #              .format(spharea,time()-start))
     ras = np.random.uniform(ramin, ramax, nrand)
+    sindecmin, sindecmax = np.sin(np.radians(decmin)), np.sin(np.radians(decmax))
     decs = np.degrees(np.arcsin(1.-np.random.uniform(1-sindecmax, 1-sindecmin, nrand)))
 
     nrand = len(ras)
@@ -180,6 +181,7 @@ def randoms_in_a_brick_from_name(brickname, density=100000,
     # log.info('Full area covered by brick {} is {:.5f} sq. deg....t = {:.1f}s'
     #          .format(brickname,spharea,time()-start))
     ras = np.random.uniform(ramin, ramax, nrand)
+    sindecmin, sindecmax = np.sin(np.radians(decmin)), np.sin(np.radians(decmax))
     decs = np.degrees(np.arcsin(1.-np.random.uniform(1-sindecmax, 1-sindecmin, nrand)))
 
     nrand = len(ras)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1,4 +1,4 @@
-B41;281;0c# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 """
 ==========================

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -16,7 +16,7 @@ import healpy as hp
 import fitsio
 from glob import glob
 from desitarget.gaiamatch import _get_gaia_dir
-
+from desitarget.geomask import bundle_bricks
 from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
 
 # ADM the parallelization script
@@ -437,6 +437,7 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=1
     # ADM retrieve the E(B-V) values for each random point
     ebv = get_dust(ras, decs, dustdir=dustdir)
 
+
     # ADM convert the dictionary to a structured array
     qinfo = np.zeros(len(ras),
                      dtype=[('RA', 'f8'), ('DEC', 'f8'), ('BRICKNAME', 'S8'),
@@ -771,139 +772,6 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
     return hpxinfo
 
 
-def bundle_bricks(pixnum, maxpernode, nside, brickspersec=2.5,
-                  surveydir="/global/project/projectdirs/cosmo/data/legacysurvey/dr6"):
-    """Determine the optimal packing for bricks collected by HEALpixel integer
-
-    Parameters
-    ----------
-    pixnum : :class:`np.array`
-        List of integers, e.g., HEALPixel numbers occupied by a set of bricks
-        (e.g. array([16, 16, 16...12 , 13, 19]) ).
-    maxpernode : :class:`int`
-        The maximum number of pixels to bundle together (e.g., if you were
-        trying to pass maxpernode bricks, delineated by the HEALPixels they
-        occupy, parallelized across a set of nodes).
-    nside : :class:`int`
-        The HEALPixel nside number that was used to generate `pixnum` (NESTED scheme).
-    brickspersec : :class:`float`, optional, defaults to 2.5
-        The rough number of bricks processed per second by the code (parallelized across
-        a chosen number of nodes)
-    surveydir : :class:`str`, optional, defaults to the DR6 directory at NERSC
-        The root directory pointing to a Data Release from the Legacy Surveys,
-        (e.g. "/global/project/projectdirs/cosmo/data/legacysurvey/dr6").
-
-    Returns
-    -------
-    Nothing, but prints commands to screen that would facilitate running a
-    set of bricks by HEALPixel integer with the total number of bricks not
-    to exceed maxpernode. Also prints how many bricks would be on each node.
-
-    Notes
-    -----
-    h/t https://stackoverflow.com/questions/7392143/python-implementations-of-packing-algorithm
-    """
-    # ADM the number of pixels (numpix) in each pixel (pix)
-    pix, numpix = np.unique(pixnum, return_counts=True)
-
-    # ADM the indices needed to reverse-sort the array on number of pixels
-    reverse_order = np.flipud(np.argsort(numpix))
-    numpix = numpix[reverse_order]
-    pix = pix[reverse_order]
-
-    # ADM iteratively populate lists of the numbers of pixels
-    # ADM and the corrsponding pixel numbers
-    bins = []
-
-    for index, num in enumerate(numpix):
-        # Try to fit this sized number into a bin
-        for bin in bins:
-            if np.sum(np.array(bin)[:, 0]) + num <= maxpernode:
-                # print 'Adding', item, 'to', bin
-                bin.append([num, pix[index]])
-                break
-        else:
-            # item didn't fit into any bin, start a new bin
-            bin = []
-            bin.append([num, pix[index]])
-            bins.append(bin)
-
-    # ADM print to screen in the form of a slurm bash script, and
-    # ADM other useful information
-    print("#######################################################")
-    print("Numbers of bricks in each set of healpixels:")
-    print("")
-    # ADM margin of 30 minutes for writing to disk
-    margin = 30./60
-    maxeta = 0
-    for bin in bins:
-        num = np.array(bin)[:, 0]
-        pix = np.array(bin)[:, 1]
-        wpix = np.where(num > 0)[0]
-        if len(wpix) > 0:
-            goodpix, goodnum = pix[wpix], num[wpix]
-            sorter = goodpix.argsort()
-            goodpix, goodnum = goodpix[sorter], goodnum[sorter]
-            outnote = ['{}: {}'.format(pix, num) for pix, num in zip(goodpix, goodnum)]
-            # ADM add the total across all of the pixels
-            outnote.append('Total: {}'.format(np.sum(goodnum)))
-            # ADM a crude estimate of how long the script will take to run
-            # ADM brickspersec is bricks/sec. Extra delta is minutes to write to disk
-            delta = 3./60.
-            eta = delta + np.sum(goodnum)/brickspersec/3600
-            outnote.append('Estimated time to run in hours (for 32 processors per node): {:.2f}h'
-                           .format(eta))
-            # ADM track the maximum estimated time for shell scripts, etc.
-            if (eta+margin).astype(int) + 1 > maxeta:
-                maxeta = (eta+margin).astype(int) + 1
-            print(outnote)
-
-    print("")
-    print('Estimated additional margin for writing to disk in hours: {:.2f}h'.format(margin))
-
-    print("")
-    print("#######################################################")
-    print("Possible salloc command if you want to run on the interactive queue:")
-    print("")
-    print("salloc -N {} -C haswell -t 0{}:00:00 --qos interactive -L SCRATCH,project"
-          .format(len(bins), maxeta))
-
-    print("")
-    print("#######################################################")
-    print('Example shell script for slurm:')
-    print('')
-    print('#!/bin/bash -l')
-    print('#SBATCH -q regular')
-    print('#SBATCH -N {}'.format(len(bins)))
-    print('#SBATCH -t 0{}:00:00'.format(maxeta))
-    print('#SBATCH -L SCRATCH,project')
-    print('#SBATCH -C haswell')
-    print('')
-
-    # ADM extract the Data Release number from the survey directory
-    dr = surveydir.split('dr')[-1][0]
-
-    outfiles = []
-    for bin in bins:
-        num = np.array(bin)[:, 0]
-        pix = np.array(bin)[:, 1]
-        wpix = np.where(num > 0)[0]
-        if len(wpix) > 0:
-            goodpix = pix[wpix]
-            goodpix.sort()
-            strgoodpix = ",".join([str(pix) for pix in goodpix])
-            outfile = "$CSCRATCH/randoms-dr{}-hp-{}.fits".format(dr, strgoodpix)
-            outfiles.append(outfile)
-            print("srun -N 1 select_randoms {} {} --numproc 32 --nside {} --healpixels {} &"
-                  .format(surveydir, outfile, nside, strgoodpix))
-    print("wait")
-    print("")
-    print("gather_targets '{}' $CSCRATCH/randoms-dr{}.fits randoms".format(";".join(outfiles), dr))
-    print("")
-
-    return
-
-
 def select_randoms(density=100000, numproc=32, nside=4, pixlist=None,
                    bundlebricks=None, brickspersec=2.5,
                    drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/",
@@ -978,8 +846,8 @@ def select_randoms(density=100000, numproc=32, nside=4, pixlist=None,
 
     # ADM if the bundlebricks option was sent, call the packing code
     if bundlebricks is not None:
-        bundle_bricks(pixnum, bundlebricks, nside,
-                      brickspersec=brickspersec, surveydir=drdir)
+        bundle_bricks(pixnum, bundlebricks, nside, brickspersec=brickspersec,
+                      prefix='randoms', surveydir=drdir)
         return
 
     # ADM restrict to only bricks in a set of HEALPixels, if requested

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -491,7 +491,7 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, rfiberfl
 
     Notes
     -----
-    - Current version (11/05/18) is version 24 on `the SV wiki`_.
+    - Current version (02/06/19) is version 36 on `the SV wiki`_.
     - See :func:`~desitarget.sv1.sv1_cuts.set_target_bits` for other parameters.
     """
     _check_BGS_targtype_sv(targtype)

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from desitarget import io, cuts
 from desitarget.targetmask import desi_mask
-
+from desitarget.geomask import hp_in_box, pixarea2nside, box_area
 
 class TestCuts(unittest.TestCase):
 
@@ -220,7 +220,7 @@ class TestCuts(unittest.TestCase):
     def test_select_targets(self):
         """Test select targets works with either data or filenames
         """
-        # ADM only test the ELG cuts for speed. There's a
+        # ADM only test the LRG cuts for speed. There's a
         # ADM full run through all classes in test_cuts_basic.
         tc = ["LRG"]
 
@@ -313,6 +313,65 @@ class TestCuts(unittest.TestCase):
                 bgs2 = targets['BGS_TARGET'] != 0
                 self.assertTrue(np.all(bgs1 == bgs2))
 
+    def test_targets_spatial(self):
+        """Test applying RA/Dec/HEALpixel inputs to sweeps recovers same targets
+        """
+        # ADM only test some of the galaxy cuts for speed. There's a
+        # ADM full run through all classes in test_cuts_basic.
+        tc = ["LRG", "ELG", "BGS"]
+        infiles = self.sweepfiles[2]
+
+        targets = cuts.select_targets(infiles, numproc=1, tcnames=tc)
+
+        # ADM test the RA/Dec box input.
+        radecbox = [np.min(targets["RA"])-0.01, np.max(targets["RA"])+0.01, 
+                    np.min(targets["DEC"])-0.01, np.max(targets["DEC"]+0.01)]
+        t1 = cuts.select_targets(infiles, numproc=1, tcnames=tc, radecbox=radecbox)
+
+        # ADM test the RA/Dec/radius cap input.
+        centra, centdec = 0.5*(radecbox[0]+radecbox[1]), 0.5*(radecbox[2]+radecbox[3])
+        # ADM 20 degrees should be a large enough radius for the sweeps.
+        maxrad = 20.
+        radecrad = centra, centdec, maxrad
+        t2 = cuts.select_targets(infiles, numproc=1, tcnames=tc, radecrad=radecrad)
+
+        # ADM test the pixel input.
+        nside = pixarea2nside(box_area(radecbox))
+        pixlist = hp_in_box(nside, radecbox)
+        t3 = cuts.select_targets(infiles, numproc=1, tcnames=tc, 
+                                 nside=nside, pixlist=pixlist)
+
+        # ADM sort each set of targets on TARGETID to compare them.
+        targets = targets[np.argsort(targets["TARGETID"])]
+        t1 = t1[np.argsort(t1["TARGETID"])]
+        t2 = t2[np.argsort(t2["TARGETID"])]
+        t3 = t3[np.argsort(t3["TARGETID"])]
+
+        # ADM test the same targets were recovered and that
+        # ADM each recovered target has the same bits set.
+        for targs in t1, t2, t3:
+            for col in "TARGETID", "DESI_TARGET", "BGS_TARGET", "MWS_TARGET":
+                self.assertTrue(np.all(targs[col] == targets[col]))
+
+    def test_targets_spatial_inputs(self):
+        """Test the code fails if more than one spatial input is passed
+        """
+        # ADM set up some fake inputs.
+        pixlist = [0,1]
+        radecbox = [2,3,4,5]
+        radecrad = [6,7,8]
+        # ADM we should throw an error every time we pass 2 inputs that aren't NoneType.
+        timesthrown = 0
+        for i in range(3):
+            inputs = [pixlist, radecbox, radecrad]
+            inputs[i] = None
+            try:
+                cuts.select_targets(self.sweepfiles, numproc=1,
+                                    pixlist=inputs[0], radecbox=inputs[1], radecrad=inputs[2])
+            except ValueError:
+                timesthrown += 1
+
+        self.assertEqual(timesthrown, 3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -17,6 +17,7 @@ from desitarget import io, cuts
 from desitarget.targetmask import desi_mask
 from desitarget.geomask import hp_in_box, pixarea2nside, box_area
 
+
 class TestCuts(unittest.TestCase):
 
     @classmethod
@@ -324,7 +325,7 @@ class TestCuts(unittest.TestCase):
         targets = cuts.select_targets(infiles, numproc=1, tcnames=tc)
 
         # ADM test the RA/Dec box input.
-        radecbox = [np.min(targets["RA"])-0.01, np.max(targets["RA"])+0.01, 
+        radecbox = [np.min(targets["RA"])-0.01, np.max(targets["RA"])+0.01,
                     np.min(targets["DEC"])-0.01, np.max(targets["DEC"]+0.01)]
         t1 = cuts.select_targets(infiles, numproc=1, tcnames=tc, radecbox=radecbox)
 
@@ -338,7 +339,7 @@ class TestCuts(unittest.TestCase):
         # ADM test the pixel input.
         nside = pixarea2nside(box_area(radecbox))
         pixlist = hp_in_box(nside, radecbox)
-        t3 = cuts.select_targets(infiles, numproc=1, tcnames=tc, 
+        t3 = cuts.select_targets(infiles, numproc=1, tcnames=tc,
                                  nside=nside, pixlist=pixlist)
 
         # ADM sort each set of targets on TARGETID to compare them.
@@ -357,9 +358,9 @@ class TestCuts(unittest.TestCase):
         """Test the code fails if more than one spatial input is passed
         """
         # ADM set up some fake inputs.
-        pixlist = [0,1]
-        radecbox = [2,3,4,5]
-        radecrad = [6,7,8]
+        pixlist = [0, 1]
+        radecbox = [2, 3, 4, 5]
+        radecrad = [6, 7, 8]
         # ADM we should throw an error every time we pass 2 inputs that aren't NoneType.
         timesthrown = 0
         for i in range(3):
@@ -372,6 +373,7 @@ class TestCuts(unittest.TestCase):
                 timesthrown += 1
 
         self.assertEqual(timesthrown, 3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Includes:

- Many new spatial query capabilities in ```desitarget.geomask```.
- Capability to parallelize target selection by splitting across HEALPixels on different nodes.
- Wrappers to read in the resulting HEALPixel-split target files including by
    * HEALPixels.
    * RA/Dec boxes.
    * RA/Dec/radius caps.
    * subsets of column names.
- Capability to only process subsets of targets in small regions of space, again including:
    * HEALPixels
    * RA/Dec boxes
    * RA/Dec/radius caps.
- New unit tests to check these spatial queries.
- An updated notebook that includes some tutorials regarding these spatial queries.

If you're interested in testing these capabilities, see the [How to run target selection](https://github.com/desihub/desitarget/blob/ADMhptargets/doc/nb/how-to-run-target-selection.ipynb) notebook under **Parallelizing target files across nodes** and **Useful commands for reading and producing subsets of targets**.
