### PR TITLE
fix desitarget.mock.build.targets_truth

### DIFF
--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -935,7 +935,7 @@ def targets_truth(params, healpixels=None, nside=None, output_dir='.',
                             seed=healseed)
         
 def finish_catalog(targets, truth, objtruth, skytargets, skytruth, healpix,
-                   nside, log, seed=None, survey='main'):
+                   nside, log, seed=None):
     """Add hpxpixel, brick_objid, targetid, subpriority, priority, and numobs to the
     target catalog.
     
@@ -959,11 +959,7 @@ def finish_catalog(targets, truth, objtruth, skytargets, skytruth, healpix,
        Logger object.
     seed : :class:`int`, optional
         Seed for the random number generation.  Defaults to None.
-    survey : :class:`str`
-        Specifies which target masks yaml file to use. Options are `main`, `cmx`
-        and `sv` for the main survey, commissioning and SV, respectively.
-        Defaults to `main`.
-            
+
     Returns
     -------
     Updated versions of targets, truth, objtruth, skytargets, and skytruth.
@@ -1013,8 +1009,8 @@ def finish_catalog(targets, truth, objtruth, skytargets, skytruth, healpix,
                 log.warning('Mismatching TARGETIDs!')
                 raise ValueError                
                     
-        targets['PRIORITY_INIT'], targets['NUMOBS_INIT'] = initial_priority_numobs(
-            targets, survey=survey)
+        targets['PRIORITY_INIT'], targets['NUMOBS_INIT'] = \
+                initial_priority_numobs(targets)
 
         # Rename TYPE --> MORPHTYPE
         targets.rename_column('TYPE', 'MORPHTYPE')
@@ -1028,8 +1024,8 @@ def finish_catalog(targets, truth, objtruth, skytargets, skytruth, healpix,
         skytargets['SUBPRIORITY'][:] = subpriority[nobj:]
         skytruth['TARGETID'][:] = targetid[nobj:]
 
-        skytargets['PRIORITY_INIT'], skytargets['NUMOBS_INIT'] = initial_priority_numobs(
-            skytargets, survey=survey)
+        skytargets['PRIORITY_INIT'], skytargets['NUMOBS_INIT'] = \
+                initial_priority_numobs(skytargets)
 
         # Rename TYPE --> MORPHTYPE
         skytargets.rename_column('TYPE', 'MORPHTYPE')

--- a/py/desitarget/test/test_mock_build.py
+++ b/py/desitarget/test/test_mock_build.py
@@ -3,19 +3,75 @@
 """Test desitarget.mock.build, but only add_mock_shapes_and_fluxes for now.
 """
 import unittest
+import tempfile
+import os
+import shutil
+from pkg_resources import resource_filename
 import numpy as np
 from astropy.table import Table
 import healpy as hp
+import fitsio
 
 import desimodel.footprint
 
 from desitarget.mock.sky import random_sky
+from desitarget.mock.build import targets_truth
 from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
 
 class TestMockBuild(unittest.TestCase):
     
     def setUp(self):
-        pass
+        self.outdir = tempfile.mkdtemp()
+        print('Output directory {}'.format(self.outdir))
+
+    def tearDown(self):
+        if os.path.exists(self.outdir):
+            shutil.rmtree(self.outdir)
+
+    @unittest.skipUnless('DESITARGET_RUN_MOCK_UNITTEST' in os.environ, '$DESITARGET_RUN_MOCK_UNITTEST not set; skipping expensive mock tests')
+    def test_targets_truth(self):
+        configfile = resource_filename('desitarget.mock', 'data/select-mock-targets.yaml')
+
+        import yaml
+        with open(configfile) as fx:
+            params = yaml.load(fx)
+
+        #- Trim for faster initial testing
+        px = dict()
+        px['targets'] = dict()
+        px['targets']['ELG'] = params['targets']['ELG']
+        px['contaminants'] = dict()
+        px['contaminants']['targets'] = dict()
+        px['contaminants']['targets']['ELG'] = params['contaminants']['targets']['ELG']
+        params = px
+
+        for targettype in params['targets'].keys():
+            mockfile = params['targets'][targettype]['mockfile'].format(**os.environ)
+            self.assertTrue(os.path.isfile(mockfile), 'Missing {}'.format(mockfile))
+
+        #- Test without spectra
+        targets_truth(px, healpixels=[99737,], nside=256, output_dir=self.outdir, no_spectra=True)
+        targetfile = self.outdir + '/997/99737/targets-256-99737.fits'
+        truthfile = self.outdir + '/997/99737/truth-256-99737.fits'
+        self.assertTrue(os.path.exists(targetfile))
+        self.assertTrue(os.path.exists(truthfile))
+
+        with fitsio.FITS(truthfile) as fx:
+            self.assertTrue('TRUTH' in fx)
+            self.assertTrue('WAVE' not in fx)
+            self.assertTrue('FLUX' not in fx)
+
+        #- Test with spectra
+        shutil.rmtree(self.outdir+'/997')
+
+        targets_truth(px, healpixels=[99737,], nside=256, output_dir=self.outdir, no_spectra=False)
+        self.assertTrue(os.path.exists(targetfile))
+        self.assertTrue(os.path.exists(truthfile))
+
+        with fitsio.FITS(truthfile) as fx:
+            self.assertTrue('TRUTH' in fx)
+            self.assertTrue('WAVE' in fx)
+            self.assertTrue('FLUX' in fx)
 
     @unittest.skip('This test is deprecated, so skip for now.')
     def test_shapes_and_fluxes(self):


### PR DESCRIPTION
PR #456 updated `desitarget.targets.initial_priority_numobs()` to no longer need a `survey` parameter, but this broke `desitarget.mock.build.targets_truth()` which was still passing in a `survey` parameter.  This PR fixes that.

Non-mock desitarget updates often break `desitarget.mock.build.targets_truth()`, so I've finally added a unittest for that.  Since this is an expensive test and requires big mock file inputs, it only runs if `$DESITARGET_RUN_MOCK_UNITTEST` is set.  The intension is that we would *not* run this on Travis, but I would include it in the nightly NERSC tests so that we would at least catch any problems within 24 hours.  I don't think it is worth maintaining stripped down versions of the input mocks for testing, since the input mocks themselves frequently change and we really want to test that those files still work too.

@geordie666 or @moustakas please take a look (though if you can't look with a day or so, I may go ahead and self-merge since this is a blocking factor for end-to-end integration tests)