### PR TITLE
Select GFAs for commissioning across wider sky areas.

### DIFF
--- a/bin/select_cmx_gfas
+++ b/bin/select_cmx_gfas
@@ -18,11 +18,11 @@ nside = 64 #ADM default HEALPix Nside used throughout desitarget
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Generates a file of GFA (Guide/Focus/Alignment) targets via matching to Gaia')
-ap.add_argument("surveydir", 
+ap.add_argument("surveydir",
                 help="Base directory for a Legacy Surveys Data Release (e.g. '/global/project/projectdirs/cosmo/data/legacysurvey/dr6/' at NERSC)")
-ap.add_argument("dest", 
+ap.add_argument("dest",
                 help="Output GFA targets file (e.g. '/project/projectdirs/desi/target/catalogs/cmx-gfas-dr6-0.20.0.fits' at NERSC)")
-ap.add_argument('-m', '--maglim', type=float, 
+ap.add_argument('-m', '--maglim', type=float,
                 help='Magnitude limit on GFA targets in Gaia G-band (defaults to [18])',
                 default=18)
 ap.add_argument("--gaiamatch", action='store_true',
@@ -62,6 +62,6 @@ bgood = is_in_gal_box(gfas, [0., 360., -ns.mingalb, ns.mingalb])
 # ADM limit to requested Dec range.
 decgood = is_in_box(gfas, [0., 360., ns.mindec, 90.])
 
-io.write_gfas(ns.dest, gfas[bgood & decgood], indir=ns.surveydir, nside=nside, cmx=True)
+io.write_gfas(ns.dest, gfas[bgood & decgood], indir=ns.surveydir, nside=nside, survey='cmx')
 
 log.info('{} cmx GFAs written to {}...t={:.1f}mins'.format(len(gfas), ns.dest, (time()-time0)/60.))

--- a/bin/select_cmx_gfas
+++ b/bin/select_cmx_gfas
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+import sys
+import numpy as np
+import argparse
+from desitarget.gfa import select_gfas
+from desitarget.geomask import is_in_gal_box, is_in_box
+from desitarget import io
+from time import time
+time0 = time()
+
+from desiutil.log import get_logger
+log = get_logger()
+
+import multiprocessing
+nproc = multiprocessing.cpu_count() // 2
+nside = 64 #ADM default HEALPix Nside used throughout desitarget
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Generates a file of GFA (Guide/Focus/Alignment) targets via matching to Gaia')
+ap.add_argument("surveydir", 
+                help="Base directory for a Legacy Surveys Data Release (e.g. '/global/project/projectdirs/cosmo/data/legacysurvey/dr6/' at NERSC)")
+ap.add_argument("dest", 
+                help="Output GFA targets file (e.g. '/project/projectdirs/desi/target/catalogs/cmx-gfas-dr6-0.20.0.fits' at NERSC)")
+ap.add_argument('-m', '--maglim', type=float, 
+                help='Magnitude limit on GFA targets in Gaia G-band (defaults to [18])',
+                default=18)
+ap.add_argument("--gaiamatch", action='store_true',
+                help="DO match to Gaia DR2 chunks files in order to populate Gaia columns for the GFA locations")
+ap.add_argument('-n', "--numproc", type=int,
+                help='number of concurrent processes to use (defaults to [{}])'.format(nproc),
+                default=nproc)
+ap.add_argument('-s2', "--surveydir2",
+                help='Additional Legacy Surveys Data Release directory (useful for combining, e.g., DR6 and DR7 into one file)',
+                default=None)
+ap.add_argument('-dec', "--mindec", type=float,
+                help='Minimum declination to include in output file (degrees; defaults to [-25])',
+                default=-25)
+ap.add_argument('-b', "--mingalb", type=float,
+                help='Closest latitude to Galactic plane to include in output file (e.g. send 20 to limit to areas beyond -20o <= b < -20o)',
+                default=20)
+
+ns = ap.parse_args()
+
+infiles = io.list_sweepfiles(ns.surveydir)
+if ns.surveydir2 is not None:
+    infiles2 = io.list_sweepfiles(ns.surveydir2)
+    infiles += infiles2
+
+if len(infiles) == 0:
+    infiles = io.list_tractorfiles(ns.surveydir)
+if len(infiles) == 0:
+    log.critical('no sweep or tractor files found')
+    sys.exit(1)
+
+log.info('running on {} processors...t={:.1f}mins'.format(ns.numproc, (time()-time0)/60.))
+
+gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, gaiamatch=ns.gaiamatch, cmx=True)
+
+# ADM limit to requesed Galactic latitude range.
+bgood = is_in_gal_box(gfas, [0., 360., -ns.mingalb, ns.mingalb])
+# ADM limit to requested Dec range.
+decgood = is_in_box(gfas, [0., 360., ns.mindec, 90.])
+
+io.write_gfas(ns.dest, gfas[bgood & decgood], indir=ns.surveydir, nside=nside, cmx=True)
+
+log.info('{} cmx GFAs written to {}...t={:.1f}mins'.format(len(gfas), ns.dest, (time()-time0)/60.))

--- a/bin/select_cmx_gfas
+++ b/bin/select_cmx_gfas
@@ -7,7 +7,7 @@ from desitarget.gfa import select_gfas
 from desitarget.geomask import is_in_gal_box, is_in_box
 from desitarget import io
 from time import time
-time0 = time()
+t0 = time()
 
 from desiutil.log import get_logger
 log = get_logger()
@@ -37,7 +37,7 @@ ap.add_argument('-dec', "--mindec", type=float,
                 help='Minimum declination to include in output file (degrees; defaults to [-25])',
                 default=-25)
 ap.add_argument('-b', "--mingalb", type=float,
-                help='Closest latitude to Galactic plane to include in output file (e.g. send 20 to limit to areas beyond -20o <= b < -20o)',
+                help='Closest latitude to Galactic plane to output (e.g. send the default [20] to limit to areas beyond -20o <= b < -20o)',
                 default=20)
 
 ns = ap.parse_args()
@@ -53,15 +53,20 @@ if len(infiles) == 0:
     log.critical('no sweep or tractor files found')
     sys.exit(1)
 
-log.info('running on {} processors...t={:.1f}mins'.format(ns.numproc, (time()-time0)/60.))
+log.info('running on {} processors...t = {:.1f} mins'.format(ns.numproc, (time()-t0)/60.))
 
 gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, gaiamatch=ns.gaiamatch, cmx=True)
 
-# ADM limit to requesed Galactic latitude range.
-bgood = is_in_gal_box(gfas, [0., 360., -ns.mingalb, ns.mingalb])
-# ADM limit to requested Dec range.
+log.info('limiting to Dec > {}o and areas beyond -{}o <= Galactic b < {}o...t = {:.1f} mins'
+         .format(ns.mindec, ns.mingalb, ns.mingalb, (time()-t0)/60.))
+# ADM limit by Dec first to speed transformation to Galactic coordinates.
 decgood = is_in_box(gfas, [0., 360., ns.mindec, 90.])
+gfas = gfas[decgood]
+# ADM limit to requesed Galactic latitude range.
+bbad = is_in_gal_box(gfas, [0., 360., -ns.mingalb, ns.mingalb])
+gfas = gfas[~bbad]
 
-io.write_gfas(ns.dest, gfas[bgood & decgood], indir=ns.surveydir, nside=nside, survey='cmx')
+log.info('Begin writing {} cmx GFAs...t = {:.1f} mins'.format(len(gfas), (time()-t0)/60.))
+io.write_gfas(ns.dest, gfas, indir=ns.surveydir, nside=nside, survey='cmx')
 
-log.info('{} cmx GFAs written to {}...t={:.1f}mins'.format(len(gfas), ns.dest, (time()-time0)/60.))
+log.info('{} cmx GFAs written to {}...t = {:.1f} mins'.format(len(gfas), ns.dest, (time()-t0)/60.))

--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -17,11 +17,11 @@ nside = 64 #ADM default HEALPix Nside used throughout desitarget
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Generates a file of GFA (Guide/Focus/Alignment) targets via matching to Gaia')
-ap.add_argument("surveydir", 
+ap.add_argument("surveydir",
                 help="Base directory for a Legacy Surveys Data Release (e.g. '/global/project/projectdirs/cosmo/data/legacysurvey/dr6/' at NERSC)")
-ap.add_argument("dest", 
+ap.add_argument("dest",
                 help="Output GFA targets file (e.g. '/project/projectdirs/desi/target/catalogs/gfas-dr6-0.20.0.fits' at NERSC)")
-ap.add_argument('-m', '--maglim', type=float, 
+ap.add_argument('-m', '--maglim', type=float,
                 help='Magnitude limit on GFA targets in Gaia G-band (defaults to [18])',
                 default=18)
 ap.add_argument("--gaiamatch", action='store_true',
@@ -50,6 +50,6 @@ log.info('running on {} processors...t={:.1f}mins'.format(ns.numproc, (time()-ti
 
 gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, gaiamatch=ns.gaiamatch)
 
-io.write_gfas(ns.dest, gfas, indir=ns.surveydir, nside=nside)
+io.write_gfas(ns.dest, gfas, indir=ns.surveydir, nside=nside, survey='main')
 
 log.info('{} GFAs written to {}...t={:.1f}mins'.format(len(gfas), ns.dest, (time()-time0)/60.))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,14 +2,17 @@
 desitarget Change Log
 =====================
 
-0.27.1 (unreleased)
+0.28.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Add code to select GFAs for cmx across wider sky areas [`PR #461`_].
+
+.. _`PR #461`: https://github.com/desihub/desitarget/pull/461
 
 0.28.0 (2019-02-28)
 -------------------
 
+* `desitarget.mock.build.targets_truth` fixes for new priority calcs [`PR #460`_].
 * Updates to GFAs and skies for some cmx issues [`PR #459`_]. Includes:
     * Assign ``BADSKY`` using ``BLOBDIST`` rather than aperture fluxes.
     * Increase default density at which sky locations are generated.
@@ -34,7 +37,6 @@ desitarget Change Log
 * Deprecate :func:`targets.calc_priority` that had table copy [`PR #452`_].
 * Update SV QSO selections, add seed and DUST_DIR for randoms [`PR #449`_].
 * Style changes to conform to PEP 8 [`PR #446`_], [`PR #447`_], [`PR #448`_].
-* `desitarget.mock.build.targets_truth` fixes for new priority calcs [`PR #460`_].
 
 .. _`PR #446`: https://github.com/desihub/desitarget/pull/446
 .. _`PR #447`: https://github.com/desihub/desitarget/pull/447

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1105,3 +1105,42 @@ def nside2nside(nside, nsidenew, pixlist):
         pixlistnew = np.hstack(pixlistnew)
 
     return pixlistnew
+
+
+def is_in_gal_box(objs, lbbox):
+    """Determine which of an array of objects are in a Galactic l, b box.
+
+    Parameters
+    ----------
+    objs : :class:`~numpy.ndarray`
+        An array of objects. Must include at least the columns "RA" and "DEC".
+    radecbox : :class:`list`
+        4-entry list of coordinates [lmin, lmax, bmin, bmax] forming the
+        edges of a box in Galactic l, b (degrees).
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        ``True`` for objects in the box, ``False`` for objects outside of the box.
+
+    Notes
+    -----
+        - Tests the minimum l/b with >= and the maximum with <
+    """
+    lmin, lmax, bmin, bmax = lbbox
+
+    # ADM check for some common mistakes.
+    if bmin < -90. or bmax > 90. or bmax <= bmin or lmax <= lmin:
+        msg = "Strange input: [lmin, lmax, bmin, bmax] = {}".format(lbbox)
+        log.critical(msg)
+        raise ValueError(msg)
+
+    # ADM convert input RA/Dec to Galactic coordinates.
+    c = SkyCoord(objs["RA"]*u.degree, objs["DEC"]*u.degree)
+    gal = c.galactic
+
+    # ADM and limit to (l, b) ranges.
+    ii = ((gal.l.value >= lmin) & (gal.l.value < lmax)
+          & (gal.b.value >= bmin) & (gal.b.value < bmax))
+
+    return ii

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -416,7 +416,7 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False):
         Magnitude limit for GFAs in Gaia G-band.
     numproc : :class:`int`, optional, defaults to 4
         The number of parallel processes to use.
-    allsky :class:`bool`,  defaults to ``False``
+    allsky : :class:`bool`,  defaults to ``False``
         If ``True``, assume that the DESI tiling footprint is the
         entire sky (i.e. return *all* Gaia objects across the sky).
 
@@ -483,7 +483,7 @@ def select_gfas(infiles, maglim=18, numproc=4, cmx=False, gaiamatch=False):
         Magnitude limit for GFAs in Gaia G-band.
     numproc : :class:`int`, optional, defaults to 4
         The number of parallel processes to use.
-    cmx :class:`bool`,  defaults to ``False``
+    cmx : :class:`bool`,  defaults to ``False``
         If ``True``, do not limit output to DESI tiling footprint.
         Used for selecting wider-ranging commissioning targets.
     gaiamatch : defaults to ``False``

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -450,8 +450,10 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False):
         """wrapper function for the critical reduction operation,
         that occurs on the main parallel process"""
         if nfile % 1000 == 0 and nfile > 0:
-            rate = nfile / (time() - t0)
-            log.info('{}/{} files; {:.1f} files/sec'.format(nfile, nfiles, rate))
+            elapsed = (time()-t0)/60.
+            rate = nfile/elapsed/60.
+            log.info('{}/{} files; {:.1f} files/sec...t = {:.1f} mins'
+                     .format(nfile, nfiles, rate, elapsed))
         nfile[...] += 1    # this is an in-place modification.
         return result
 
@@ -526,8 +528,10 @@ def select_gfas(infiles, maglim=18, numproc=4, cmx=False, gaiamatch=False):
         """wrapper function for the critical reduction operation,
         that occurs on the main parallel process"""
         if nfile % 50 == 0 and nfile > 0:
-            rate = nfile / (time() - t0)
-            log.info('{}/{} files; {:.1f} files/sec'.format(nfile, nfiles, rate))
+            elapsed = (time()-t0)/60.
+            rate = nfile/elapsed/60.
+            log.info('{}/{} files; {:.1f} files/sec...t = {:.1f} mins'
+                     .format(nfile, nfiles, rate, elapsed))
         nfile[...] += 1    # this is an in-place modification.
         return result
 
@@ -544,7 +548,7 @@ def select_gfas(infiles, maglim=18, numproc=4, cmx=False, gaiamatch=False):
     gfas = np.concatenate(gfas)
 
     # ADM retrieve all Gaia objects in the DESI footprint.
-    log.info('Retrieving additional Gaia objects...t={:.1f}mins'
+    log.info('Retrieving additional Gaia objects...t = {:.1f} mins'
              .format((time()-t0)/60))
     gaia = all_gaia_in_tiles(maglim=maglim, numproc=numproc, allsky=cmx)
     # ADM and limit them to just any missing bricks...

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -17,8 +17,8 @@ from desimodel.footprint import is_point_in_desi
 
 import desitarget.io
 from desitarget.internal import sharedmem
-from desitarget.gaiamatch import match_gaia_to_primary
-from desitarget.gaiamatch import find_gaia_files_tiles, read_gaia_file
+from desitarget.gaiamatch import match_gaia_to_primary, read_gaia_file
+from desitarget.gaiamatch import find_gaia_files_tiles, find_gaia_files_box
 from desitarget.targets import encode_targetid
 
 from desiutil import brick
@@ -407,7 +407,7 @@ def gaia_in_file(infile, maglim=18):
     return gfas
 
 
-def all_gaia_in_tiles(maglim=18, numproc=4):
+def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False):
     """An array of all Gaia objects in the DESI tiling footprint
 
     Parameters
@@ -416,6 +416,9 @@ def all_gaia_in_tiles(maglim=18, numproc=4):
         Magnitude limit for GFAs in Gaia G-band.
     numproc : :class:`int`, optional, defaults to 4
         The number of parallel processes to use.
+    allsky :class:`bool`,  defaults to ``False``
+        If ``True``, assume that the DESI tiling footprint is the
+        entire sky (i.e. return *all* Gaia objects across the sky).
 
     Returns
     -------
@@ -427,16 +430,19 @@ def all_gaia_in_tiles(maglim=18, numproc=4):
     -----
        - The environment variables $GAIA_DIR and $DESIMODEL must be set.
     """
-    # ADM paths to all of the Gaia files in the DESI footprint.
-    infiles = find_gaia_files_tiles(neighbors=False)
+    # ADM grab paths to Gaia files in the sky or the DESI footprint.
+    if allsky:
+        infiles = find_gaia_files_box([0, 360, -90, 90])
+    else:
+        infiles = find_gaia_files_tiles(neighbors=False)
     nfiles = len(infiles)
 
-    # ADM the critical function to run on every file
+    # ADM the critical function to run on every file.
     def _get_gaia_gfas(fn):
         '''wrapper on gaia_in_file() given a file name'''
         return gaia_in_file(fn, maglim=maglim)
 
-    # ADM this is just to count sweeps files in _update_status
+    # ADM this is just to count sweeps files in _update_status.
     nfile = np.zeros((), dtype='i8')
     t0 = time()
 
@@ -446,10 +452,10 @@ def all_gaia_in_tiles(maglim=18, numproc=4):
         if nfile % 1000 == 0 and nfile > 0:
             rate = nfile / (time() - t0)
             log.info('{}/{} files; {:.1f} files/sec'.format(nfile, nfiles, rate))
-        nfile[...] += 1    # this is an in-place modification
+        nfile[...] += 1    # this is an in-place modification.
         return result
 
-    # - Parallel process input files
+    # - Parallel process input files.
     if numproc > 1:
         pool = sharedmem.MapReduce(np=numproc)
         with pool:
@@ -464,7 +470,7 @@ def all_gaia_in_tiles(maglim=18, numproc=4):
     return gfas
 
 
-def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
+def select_gfas(infiles, maglim=18, numproc=4, cmx=False, gaiamatch=False):
     """Create a set of GFA locations using Gaia.
 
     Parameters
@@ -475,6 +481,9 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
         Magnitude limit for GFAs in Gaia G-band.
     numproc : :class:`int`, optional, defaults to 4
         The number of parallel processes to use.
+    cmx :class:`bool`,  defaults to ``False``
+        If ``True``, do not limit output to DESI tiling footprint.
+        Used for selecting wider-ranging commissioning targets.
     gaiamatch : defaults to ``False``
         If ``True``, match to Gaia DR2 chunks files and populate
         Gaia columns, otherwise assume those columns already exist.
@@ -489,27 +498,27 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
     -----
         - if numproc==1, use the serial code instead of the parallel code.
     """
-    # ADM convert a single file, if passed to a list of files
+    # ADM convert a single file, if passed to a list of files.
     if isinstance(infiles, str):
         infiles = [infiles, ]
 
-    # ADM check that files exist before proceeding
+    # ADM check that files exist before proceeding.
     for filename in infiles:
         if not os.path.exists(filename):
             raise ValueError("{} doesn't exist".format(filename))
 
     nfiles = len(infiles)
 
-    # ADM the critical function to run on every file
+    # ADM the critical function to run on every file.
     def _get_gfas(fn):
         '''wrapper on gaia_gfas_from_sweep() given a file name'''
-        # ADM we may need to pass the boundaries of the sweeps file, too
+        # ADM we may need to pass the boundaries of the sweeps file, too.
         bounds = desitarget.io.decode_sweep_name(fn)
         return gaia_gfas_from_sweep(
             fn, maglim=maglim, gaiamatch=gaiamatch, gaiabounds=bounds
         )
 
-    # ADM this is just to count sweeps files in _update_status
+    # ADM this is just to count sweeps files in _update_status.
     nfile = np.zeros((), dtype='i8')
     t0 = time()
 
@@ -519,10 +528,10 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
         if nfile % 50 == 0 and nfile > 0:
             rate = nfile / (time() - t0)
             log.info('{}/{} files; {:.1f} files/sec'.format(nfile, nfiles, rate))
-        nfile[...] += 1    # this is an in-place modification
+        nfile[...] += 1    # this is an in-place modification.
         return result
 
-    # - Parallel process input files
+    # - Parallel process input files.
     if numproc > 1:
         pool = sharedmem.MapReduce(np=numproc)
         with pool:
@@ -537,14 +546,15 @@ def select_gfas(infiles, maglim=18, numproc=4, gaiamatch=False):
     # ADM retrieve all Gaia objects in the DESI footprint.
     log.info('Retrieving additional Gaia objects...t={:.1f}mins'
              .format((time()-t0)/60))
-    gaia = all_gaia_in_tiles(maglim=maglim, numproc=numproc)
+    gaia = all_gaia_in_tiles(maglim=maglim, numproc=numproc, allsky=cmx)
     # ADM and limit them to just any missing bricks...
     brickids = set(gfas['BRICKID'])
     ii = [gbrickid not in brickids for gbrickid in gaia["BRICKID"]]
     gaia = gaia[ii]
-    # ADM ...and also to the DESI footprint
-    tiles = desimodel.io.load_tiles()
-    ii = is_point_in_desi(tiles, gaia["RA"], gaia["DEC"])
-    gaia = gaia[ii]
+    # ADM ...and also to the DESI footprint, if we're not cmx'ing.
+    if not cmx:
+        tiles = desimodel.io.load_tiles()
+        ii = is_point_in_desi(tiles, gaia["RA"], gaia["DEC"])
+        gaia = gaia[ii]
 
     return np.concatenate([gfas, gaia])

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -586,7 +586,8 @@ def write_skies(filename, data, indir=None, apertures_arcsec=None,
     fitsio.write(filename, data, extname='SKY_TARGETS', header=hdr, clobber=True)
 
 
-def write_gfas(filename, data, indir=None, nside=None, gaiaepoch=None):
+def write_gfas(filename, data, indir=None, nside=None, survey="?",
+               gaiaepoch=None):
     """Write a catalogue of Guide/Focus/Alignment targets.
 
     Parameters
@@ -601,6 +602,8 @@ def write_gfas(filename, data, indir=None, nside=None, gaiaepoch=None):
     nside: :class:`int`, defaults to None.
         If passed, add a column to the GFAs array popluated with HEALPixels
         at resolution `nside`.
+    survey : :class:`str`, optional, defaults to "?"
+        Written to output file header as the keyword `SURVEY`.
     gaiaepoch: :class:`float`, defaults to None
         Gaia proper motion reference epoch. If not None, write to header of
         output file. If None, default to an epoch of 2015.5.
@@ -629,6 +632,10 @@ def write_gfas(filename, data, indir=None, nside=None, gaiaepoch=None):
         hdr['HPXNSIDE'] = nside
         hdr['HPXNEST'] = True
 
+    # ADM add the type of survey (main, or commissioning "cmx") to the header.
+    hdr["SURVEY"] = survey
+
+    # ADM add the Gaia reference epoch, or pass 2015.5 if not included.
     hdr['REFEPOCH'] = {'name': 'REFEPOCH',
                        'value': 2015.5,
                        'comment': "Gaia Proper Motion Reference Epoch"}


### PR DESCRIPTION
This PR updates the GFAs code to select targets from Gaia across large sky areas (rather than just the DESI tiling footprint). 

The main functionality is through the executable `select_cmx_gfas`, which allows cuts on Gaia G-band, minimum Dec and Galactic latitude. Information from DESI imaging is still returned in areas that overlap the Legacy Surveys.
