### PR TITLE
Resolve duplicate targets across 2 imaging releases in preparation for DR8

### DIFF
--- a/bin/select_cmx_gfas
+++ b/bin/select_cmx_gfas
@@ -25,8 +25,6 @@ ap.add_argument("dest",
 ap.add_argument('-m', '--maglim', type=float,
                 help='Magnitude limit on GFA targets in Gaia G-band (defaults to [18])',
                 default=18)
-ap.add_argument("--gaiamatch", action='store_true',
-                help="DO match to Gaia DR2 chunks files in order to populate Gaia columns for the GFA locations")
 ap.add_argument('-n', "--numproc", type=int,
                 help='number of concurrent processes to use (defaults to [{}])'.format(nproc),
                 default=nproc)
@@ -55,7 +53,7 @@ if len(infiles) == 0:
 
 log.info('running on {} processors...t = {:.1f} mins'.format(ns.numproc, (time()-t0)/60.))
 
-gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, gaiamatch=ns.gaiamatch, cmx=True)
+gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, cmx=True)
 
 log.info('limiting to Dec > {}o and areas beyond -{}o <= Galactic b < {}o...t = {:.1f} mins'
          .format(ns.mindec, ns.mingalb, ns.mingalb, (time()-t0)/60.))

--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -24,8 +24,6 @@ ap.add_argument("dest",
 ap.add_argument('-m', '--maglim', type=float,
                 help='Magnitude limit on GFA targets in Gaia G-band (defaults to [18])',
                 default=18)
-ap.add_argument("--gaiamatch", action='store_true',
-                help="DO match to Gaia DR2 chunks files in order to populate Gaia columns for the GFA locations")
 ap.add_argument('-n', "--numproc", type=int,
                 help='number of concurrent processes to use (defaults to [{}])'.format(nproc),
                 default=nproc)
@@ -48,7 +46,7 @@ if len(infiles) == 0:
 
 log.info('running on {} processors...t={:.1f}mins'.format(ns.numproc, (time()-time0)/60.))
 
-gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, gaiamatch=ns.gaiamatch)
+gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc)
 
 io.write_gfas(ns.dest, gfas, indir=ns.surveydir, nside=nside, survey='main')
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,10 @@ desitarget Change Log
 0.28.1 (unreleased)
 -------------------
 
-* Add resolve capability for post-DR7 imaging [`PR #462`_]. Includes:
+* New resolve capability for post-DR7 imaging [`PR #462`_]. Includes:
+    * Add ``RELEASE`` to GFA data model to help resolve duplicates.
     * Resolve N/S duplicates by combining ``RELEASE`` and areal cuts.
-    * Apply this resolve code (:func:`targets.resolve`) to GFAs.
+    * Apply the new resolve code (:func:`targets.resolve`) to GFAs.
     * Deprecate Gaia-matching code for GFAs, as we no longer need it.
 * Add code to select GFAs for cmx across wider sky areas [`PR #461`_].
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,14 @@ desitarget Change Log
 0.28.1 (unreleased)
 -------------------
 
+* Add resolve capability for post-DR7 imaging [`PR #462`_]. Includes:
+    * Resolve N/S duplicates by combining ``RELEASE`` and areal cuts.
+    * Apply this resolve code (:func:`targets.resolve`) to GFAs.
+    * Deprecate Gaia-matching code for GFAs, as we no longer need it.
 * Add code to select GFAs for cmx across wider sky areas [`PR #461`_].
 
 .. _`PR #461`: https://github.com/desihub/desitarget/pull/461
+.. _`PR #462`: https://github.com/desihub/desitarget/pull/462
 
 0.28.0 (2019-02-28)
 -------------------
@@ -19,7 +24,7 @@ desitarget Change Log
     * Store only aperture fluxes that match the DESI fiber radius.
     * Ensure GFAs exist throughout the spectroscopic footprint.
 * Refactor SV/main targeting for spatial queries [`PR #458`_]. Includes:
-    * Many new spatial query capabilities in :func:`desitarget.geomask`.
+    * Many new spatial query capabilities in :mod:`desitarget.geomask`.
     * Parallelize target selection by splitting across HEALPixels.
     * Wrappers to read in HEALPix-split target files split by:
         * HEALPixels, RA/Dec boxes, RA/Dec/radius caps, column names.

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1143,7 +1143,7 @@ def is_in_gal_box(objs, lbbox, radec=False):
         ra, dec = objs
     else:
         ra, dec = objs["RA"], objs["DEC"]
-    
+
     c = SkyCoord(ra*u.degree, dec*u.degree)
     gal = c.galactic
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1107,16 +1107,19 @@ def nside2nside(nside, nsidenew, pixlist):
     return pixlistnew
 
 
-def is_in_gal_box(objs, lbbox):
+def is_in_gal_box(objs, lbbox, radec=False):
     """Determine which of an array of objects are in a Galactic l, b box.
 
     Parameters
     ----------
-    objs : :class:`~numpy.ndarray`
+    objs : :class:`~numpy.ndarray` or `list`
         An array of objects. Must include at least the columns "RA" and "DEC".
     radecbox : :class:`list`
         4-entry list of coordinates [lmin, lmax, bmin, bmax] forming the
         edges of a box in Galactic l, b (degrees).
+    radec : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then the passed `objs` is an [RA, Dec] list instead of
+        a rec array.
 
     Returns
     -------
@@ -1136,7 +1139,12 @@ def is_in_gal_box(objs, lbbox):
         raise ValueError(msg)
 
     # ADM convert input RA/Dec to Galactic coordinates.
-    c = SkyCoord(objs["RA"]*u.degree, objs["DEC"]*u.degree)
+    if radec:
+        ra, dec = objs
+    else:
+        ra, dec = objs["RA"], objs["DEC"]
+    
+    c = SkyCoord(ra*u.degree, dec*u.degree)
     gal = c.galactic
 
     # ADM and limit to (l, b) ranges.

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -19,7 +19,7 @@ import desitarget.io
 from desitarget.internal import sharedmem
 from desitarget.gaiamatch import read_gaia_file
 from desitarget.gaiamatch import find_gaia_files_tiles, find_gaia_files_box
-from desitarget.targets import encode_targetid
+from desitarget.targets import encode_targetid, resolve
 
 from desiutil import brick
 from desiutil.log import get_logger
@@ -469,6 +469,9 @@ def select_gfas(infiles, maglim=18, numproc=4, cmx=False):
             gfas.append(_update_status(_get_gfas(file)))
 
     gfas = np.concatenate(gfas)
+
+    # ADM resolve any duplicates between imaging data releases.
+    gfas = resolve(gfas)
 
     # ADM retrieve all Gaia objects in the DESI footprint.
     log.info('Retrieving additional Gaia objects...t = {:.1f} mins'

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -32,7 +32,8 @@ start = time()
 
 # ADM the current data model for columns in the GFA files.
 gfadatamodel = np.array([], dtype=[
-    ('TARGETID', 'i8'),  ('BRICKID', 'i4'), ('BRICK_OBJID', 'i4'),
+    ('RELEASE', '>i4'), ('TARGETID', 'i8'),
+    ('BRICKID', 'i4'), ('BRICK_OBJID', 'i4'),
     ('RA', 'f8'), ('DEC', 'f8'), ('RA_IVAR', 'f4'), ('DEC_IVAR', 'f4'),
     ('TYPE', 'S4'),
     ('FLUX_G', 'f4'), ('FLUX_R', 'f4'), ('FLUX_Z', 'f4'),
@@ -217,9 +218,8 @@ def add_gfa_info_to_fa_tiles(gfa_file_path="./", fa_file_path=None, output_path=
             fitsio.write(tileout, gfa_data, extname='GFA')
 
 
-def gaia_gfas_from_sweep(objects, maglim=18.,
-                         gaiamatch=False, gaiabounds=[0., 360., -90., 90.]):
-    """Create a set of GFAs from Gaia-matching for one sweep file or sweep objects
+def gaia_gfas_from_sweep(objects, maglim=18.)
+    """Create a set of GFAs for one sweep file or sweep objects.
 
     Parameters
     ----------
@@ -228,37 +228,15 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
         a string corresponding to a sweep filename.
     maglim : :class:`float`, optional, defaults to 18
         Magnitude limit for GFAs in Gaia G-band.
-    gaiamatch : defaults to ``False``
-        If ``True``, match to Gaia DR2 chunks files and populate
-        Gaia columns, otherwise assume those columns already exist
-    gaiabounds : :class:`list`, optional, defaults to the whole sky
-        The area over which to retrieve Gaia objects that don't match a sweeps object.
-        Pass a 4-entry list to form a box bounded by [RAmin, RAmax, DECmin, DECmax].
 
     Returns
     -------
     :class:`~numpy.ndarray`
-        GFA objects from Gaia for the region bounded by `gaiabounds`, formatted
-        according to `desitarget.gfa.gfadatamodel`.
+        GFA objects from Gaia, formatted according to `desitarget.gfa.gfadatamodel`.
     """
-    # ADM read in objects if a filename was passed instead of the actual data
+    # ADM read in objects if a filename was passed instead of the actual data.
     if isinstance(objects, str):
         objects = desitarget.io.read_tractor(objects)
-
-    # ADM issue a warning if gaiamatch was not sent but there's no Gaia information
-    if np.max(objects['PARALLAX']) == 0. and not gaiamatch:
-        log.warning("Zero objects have a parallax. Did you mean to send gaiamatch?")
-
-    # ADM add the Gaia coordinate columns if they don't exist and
-    # ADM if Gaia-matching was requested
-    if gaiamatch and "GAIA_RA" not in objects.dtype.names:
-        gc = np.array([], dtype=[('GAIA_RA', '>f8'), ('GAIA_DEC', '>f8')])
-        dt = objects.dtype.descr + gc.dtype.descr
-        nrows = len(objects)
-        objectswgc = np.zeros(nrows, dtype=dt)
-        for col in objects.dtype.names:
-            objectswgc[col] = objects[col]
-        objects = objectswgc
 
     # ADM As a mild speed up, only consider sweeps objects brighter than 3 mags
     # ADM fainter than the passed Gaia magnitude limit. Note that Gaia G-band
@@ -267,92 +245,35 @@ def gaia_gfas_from_sweep(objects, maglim=18.,
                  (objects["FLUX_R"] > 10**((22.5-(maglim+3))/2.5)) |
                  (objects["FLUX_Z"] > 10**((22.5-(maglim+3))/2.5)))[0]
     objects = objects[w]
-
     nobjs = len(objects)
 
-    # ADM match the sweeps objects to Gaia retaining Gaia objects that do not
-    # ADM have a match in the sweeps, if Gaia matching was requested
-#    log.info('Starting Gaia match for {} objects...t = {:.1f}s'
-#             .format(nobjs,time()-start))
-    if gaiamatch:
-        # ADM match with a fairly discriminating radius (0.1 arcsec) to just
-        # ADM get the best sweeps-Gaia correspondence
-        gaiainfo = match_gaia_to_primary(objects, matchrad=0.1,
-                                         retaingaia=True, gaiabounds=gaiabounds)
-        log.info('Done with Gaia match...t = {:.1f}s'.format(time()-start))
-        # ADM add the Gaia column information to the primary array
-        for col in gaiainfo.dtype.names:
-            objects[col] = gaiainfo[col][:nobjs]
-
-        # ADM an additional array to hold the Gaia objects that have no sweeps match
-        supg = np.zeros(len(gaiainfo) - nobjs, dtype=objects.dtype)
-        # ADM make sure all of these additional columns have "ridiculous" numbers
-        supg[...] = -1
-        # ADM but default the IVARs that would appear in the sweeps (g/r/z) to 0
-        for col in ["FLUX_IVAR_G", "FLUX_IVAR_R", "FLUX_IVAR_Z"]:
-            supg[col] = 0.
-        # ADM and then TYPE to PSF
-        supg["TYPE"] = 'PSF'
-        # ADM populate these additional objects
-        for col in gaiainfo.dtype.names:
-            supg[col] = gaiainfo[col][nobjs:]
-
-        # ADM combine the primary and supplemental arrays
-        objects = np.hstack([objects, supg])
-
-        # ADM store the Gaia RA/DEC as the default for matched objects
-        # ADM as it's really the Gaia astrometry we want
-        for col in ["RA", "DEC"]:
-            objects[col] = objects["GAIA_"+col]
-
-    # ADM only retain objects with Gaia matches
-    # ADM it's fine to propagate an empty array if there are no matches
-    # ADM note that the sweeps use 0 for objects with no REF_ID
-    # ADM and desitarget.gaiamatch uses -1. So, > 0 checks both.
+    # ADM only retain objects with Gaia matches.
+    # ADM It's fine to propagate an empty array if there are no matches
+    # ADM The sweeps use 0 for objects with no REF_ID.
     w = np.where(objects["REF_ID"] > 0)[0]
     objects = objects[w]
 
-    # ADM it's possible that a Gaia object matches two sweeps objects, so
-    # ADM only record unique Gaia IDs
-    _, ind = np.unique(objects["REF_ID"], return_index=True)
-#    log.info('Removed {} duplicated Gaia objects...t = {:.1f}s'
-#             .format(len(objects)-len(ind),time()-start))
-    objects = objects[ind]
-
-    # ADM determine a TARGETID for any objects on a brick (this should
-    # ADM end up as -1 for anything that is Gaia-only (from Gaia-matching)
-    # ADM as all of objid, brickid and release should be -1
-    targetid = encode_targetid(objid=objects['OBJID'],
-                               brickid=objects['BRICKID'],
-                               release=objects['RELEASE'])
-
-    # ADM format everything according to the data model
+    # ADM format everything according to the data model.
     gfas = np.zeros(len(objects), dtype=gfadatamodel.dtype)
     # ADM make sure all columns initially have "ridiculous" numbers
     gfas[...] = -99.
-    # ADM remove the TARGETID and BRICK_OBJID columns and populate them later
-    # ADM as they require special treatment
+    # ADM remove the BRICK_OBJID column and populate it later as it
+    # ADM requires special treatment.
     cols = list(gfadatamodel.dtype.names)
-    for col in ["TARGETID", "BRICK_OBJID"]:
-        cols.remove(col)
+    cols.remove("BRICK_OBJID")
     for col in cols:
         gfas[col] = objects[col]
-    # ADM populate the TARGETID column
-    gfas["TARGETID"] = targetid
-    # ADM populate the BRICK_OBJID column
     gfas["BRICK_OBJID"] = objects["OBJID"]
 
     # ADM cut the GFAs by a hard limit on magnitude
-    w = np.where(gfas['GAIA_PHOT_G_MEAN_MAG'] < maglim)[0]
-    gfas = gfas[w]
+    ii = gfas['GAIA_PHOT_G_MEAN_MAG'] < maglim
+    gfas = gfas[ii]
 
     # ADM a final clean-up to remove columns that are Nan (from
     # ADM Gaia-matching) or are 0 (in the sweeps)
     for col in ["PMRA", "PMDEC"]:
-        w = np.where(~np.isnan(gfas[col]) & (gfas[col] != 0))[0]
-        gfas = gfas[w]
-#    log.info('Removed {} Gaia objects with NaN columns...t = {:.1f}s'
-#             .format(len(objects)-len(gfas),time()-start))
+        ii = ~np.isnan(gfas[col]) & (gfas[col] != 0)
+        gfas = gfas[ii]
 
     return gfas
 
@@ -472,7 +393,7 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False):
     return gfas
 
 
-def select_gfas(infiles, maglim=18, numproc=4, cmx=False, gaiamatch=False):
+def select_gfas(infiles, maglim=18, numproc=4, cmx=False):
     """Create a set of GFA locations using Gaia.
 
     Parameters
@@ -486,9 +407,6 @@ def select_gfas(infiles, maglim=18, numproc=4, cmx=False, gaiamatch=False):
     cmx : :class:`bool`,  defaults to ``False``
         If ``True``, do not limit output to DESI tiling footprint.
         Used for selecting wider-ranging commissioning targets.
-    gaiamatch : defaults to ``False``
-        If ``True``, match to Gaia DR2 chunks files and populate
-        Gaia columns, otherwise assume those columns already exist.
 
     Returns
     -------
@@ -515,10 +433,7 @@ def select_gfas(infiles, maglim=18, numproc=4, cmx=False, gaiamatch=False):
     def _get_gfas(fn):
         '''wrapper on gaia_gfas_from_sweep() given a file name'''
         # ADM we may need to pass the boundaries of the sweeps file, too.
-        bounds = desitarget.io.decode_sweep_name(fn)
-        return gaia_gfas_from_sweep(
-            fn, maglim=maglim, gaiamatch=gaiamatch, gaiabounds=bounds
-        )
+        return gaia_gfas_from_sweep(fn, maglim=maglim)
 
     # ADM this is just to count sweeps files in _update_status.
     nfile = np.zeros((), dtype='i8')

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -89,7 +89,7 @@ def desitarget_nside():
 
 def desitarget_resolve_dec():
     """Default Dec cut to separate targets in BASS/MzLS from DECaLS."""
-    dec = 30.
+    dec = 32.
     return dec
 
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -445,7 +445,7 @@ def write_targets(filename, data, indir=None, qso_selection=None,
     ----------
     filename : :class:`str`
         output target selection file.
-    data : :class:`str`
+    data : :class:`~numpy.ndarray`
         numpy structured array of targets to save.
     indir, qso_selection : :class:`str`, optional, default to `None`
         If passed, note these as the input directory and

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -89,7 +89,7 @@ def desitarget_nside():
 
 def desitarget_resolve_dec():
     """Default Dec cut to separate targets in BASS/MzLS from DECaLS."""
-    dec = 32.
+    dec = 32.375
     return dec
 
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -82,9 +82,15 @@ dr7datamodel = np.array([], dtype=[
 
 
 def desitarget_nside():
-    """Default HEALPix Nside for all target selection algorithms. """
+    """Default HEALPix Nside for all target selection algorithms."""
     nside = 64
     return nside
+
+
+def desitarget_resolve_dec():
+    """Default Dec cut to separate targets in BASS/MzLS from DECaLS."""
+    dec = 30.
+    return dec
 
 
 def convert_from_old_data_model(fx, columns=None):

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -648,7 +648,7 @@ def resolve(targets):
     split = desitarget_resolve_dec()
 
     # ADM determine which targets are north of the Galactic plane. As
-    # ADM a speed-up, bin in ~1 sq.deg. HEALPixels and determine 
+    # ADM a speed-up, bin in ~1 sq.deg. HEALPixels and determine
     # ADM which of those pixels are north of the Galactic plane.
     # ADM We should never be as close as ~1o to the plane.
     from desitarget.geomask import is_in_gal_box, pixarea2nside

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -663,7 +663,7 @@ def resolve(targets):
     # ADM which targets are in pixels north of the Galactic plane.
     galn = pixn[pixnum]
 
-    # ADM which rargets are in the northern imaging area.
+    # ADM which targets are in the northern imaging area.
     arean = (targets["DEC"] >= split) & galn
 
     # ADM retain 'N' targets in 'N' area and 'S' in 'S' area.


### PR DESCRIPTION
This PR adds a new `desitarget.targets.resolve` function to resolve duplicate N/S targets, which will be useful for DR8 imaging (and beyond). It includes:

- Resolve N/S duplicates by combining `RELEASE` (was the photometric system N/S?) with defined areal cuts (is the footprint officially N/S?).
- Add the `RELEASE` column to the GFA data model as its needed to resolve duplicates.
- Apply the new resolve code to GFAs.
- Deprecate Gaia-matching code for GFAs, as we no longer need it.

Although the resolve code is only applied to GFAs in this PR, it should only require one line of code (one function call) to apply it to other target classes in future updates.