### PR TITLE
Initial updates for DR8

### DIFF
--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -21,7 +21,7 @@ ap.add_argument("infiles",
                 help="SEMI-COLON separated list of input files, which may have to be enclosed by quotes (e.g. 'file1;file2;file3;file4')")
 ap.add_argument("outfile", 
                 help="Output file name")
-ap.add_argument("targtype",choices=['skies', 'randoms', 'targets'],
+ap.add_argument("targtype", choices=['skies', 'randoms', 'targets'],
                 help="Type of target run with parallelization/multiprocessing code to gather")
 
 ns = ap.parse_args()

--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -28,18 +28,23 @@ ap.add_argument('-n', "--numproc", type=int,
                 help='number of concurrent processes to use (defaults to [{}])'.format(nproc),
                 default=nproc)
 ap.add_argument('-s2', "--surveydir2",
-                help='Additional Legacy Surveys Data Release directory (useful for combining, e.g., DR6 and DR7 into one file)',
+                help='Additional Legacy Surveys Data Release directory (useful for combining, e.g., DR8 into one file of GFAs)',
                 default=None)
 
 ns = ap.parse_args()
 
 infiles = io.list_sweepfiles(ns.surveydir)
+indir = ns.surveydir
 if ns.surveydir2 is not None:
     infiles2 = io.list_sweepfiles(ns.surveydir2)
     infiles += infiles2
-
+    indir = "{} {}".format(ns.surveydir, ns.surveydir2)
 if len(infiles) == 0:
     infiles = io.list_tractorfiles(ns.surveydir)
+    if ns.surveydir2 is not None:
+        infiles2 = io.list_tractorfiles(ns.surveydir2)
+        infiles += infiles2
+        indir = "{} {}".format(ns.surveydir, ns.surveydir2)
 if len(infiles) == 0:
     log.critical('no sweep or tractor files found')
     sys.exit(1)
@@ -48,6 +53,6 @@ log.info('running on {} processors...t={:.1f}mins'.format(ns.numproc, (time()-ti
 
 gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc)
 
-io.write_gfas(ns.dest, gfas, indir=ns.surveydir, nside=nside, survey='main')
+io.write_gfas(ns.dest, gfas, indir=indir, nside=nside, survey='main')
 
 log.info('{} GFAs written to {}...t={:.1f}mins'.format(len(gfas), ns.dest, (time()-time0)/60.))

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -64,10 +64,10 @@ if not os.path.exists(ns.surveydir):
 if ns.bundlebricks is None:
     log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc,time()-start))
 
-randoms = select_randoms(density=ns.density, numproc=ns.numproc, 
-                         nside=ns.nside, pixlist=pixlist, 
+randoms = select_randoms(ns.surveydir, density=ns.density, numproc=ns.numproc,
+                         nside=ns.nside, pixlist=pixlist,
                          bundlebricks=ns.bundlebricks, brickspersec=ns.brickspersec,
-                         drdir=ns.surveydir, dustdir=ns.dustdir)
+                         dustdir=ns.dustdir)
 
 if ns.bundlebricks is None:
     io.write_randoms(ns.dest, randoms, indir=ns.surveydir, nside=nside, density=ns.density)

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -71,5 +71,6 @@ randoms = select_randoms(ns.surveydir, density=ns.density, numproc=ns.numproc,
 
 if ns.bundlebricks is None:
     io.write_randoms(ns.dest, randoms, indir=ns.surveydir, nside=nside, density=ns.density)
-    log.info('wrote file of randoms to {}...t = {:.1f}s'.format(ns.dest,time()-start))
+    log.info('wrote file of {} randoms to {}...t = {:.1f}s'
+             .format(len(randoms), ns.dest,time()-start))
 

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -9,6 +9,8 @@ start = time()
 
 from desitarget import io
 from desitarget.randoms import pixweight, select_randoms
+from glob import iglob
+import fitsio
 
 #import warnings
 #warnings.simplefilter('error')
@@ -64,13 +66,30 @@ if not os.path.exists(ns.surveydir):
 if ns.bundlebricks is None:
     log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc,time()-start))
 
+# ADM go looking for a maskbits file to steal the header for the
+# ADM bit names. Try a couple of configurations (pre/post DR7).
+gen = iglob(os.path.join(ns.surveydir, "*", "coadd", "*", "*", "*maskbits*"))
+try:
+    fn = next(gen)
+except StopIteration:
+    gen = iglob(os.path.join(ns.surveydir, "coadd", "*", "*", "*maskbits*"))
+    fn = next(gen)
+hdrall = fitsio.read_header(fn, 1)
+# ADM retrieve the record dictionary for the entire header.
+rmhdr = vars(hdrall)
+# ADM write only the maskbits-relevant headers to a new header.
+hdr = fitsio.FITSHDR()
+for record in rmhdr['_record_map']:
+    if 'BITNM' in record:
+        hdr[record] = rmhdr['_record_map'][record]
+
 randoms = select_randoms(ns.surveydir, density=ns.density, numproc=ns.numproc,
                          nside=ns.nside, pixlist=pixlist,
                          bundlebricks=ns.bundlebricks, brickspersec=ns.brickspersec,
                          dustdir=ns.dustdir)
 
 if ns.bundlebricks is None:
-    io.write_randoms(ns.dest, randoms, indir=ns.surveydir, nside=nside, density=ns.density)
+    io.write_randoms(ns.dest, randoms, indir=ns.surveydir, hdr=hdr, nside=nside, density=ns.density)
     log.info('wrote file of {} randoms to {}...t = {:.1f}s'
              .format(len(randoms), ns.dest,time()-start))
 

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -27,10 +27,13 @@ log = get_logger()
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Generates DESI target bits from Legacy Surveys sweeps or tractor files')
-ap.add_argument("src",
+ap.add_argument("sweepdir",
                 help="Tractor/sweeps file or root directory with tractor/sweeps files")
 ap.add_argument("dest",
                 help="Output target selection file")
+ap.add_argument('-s2', "--sweepdir2",
+                help='Additional Tractor/sweeps file or directory (useful for combining, e.g., DR8 into one file of targets)',
+                default=None)
 ap.add_argument('-c', "--check", action='store_true',
                 help="Process tractor/sweeps files to check for corruption, without running full target selection")
 ap.add_argument('-m', "--mask",
@@ -71,9 +74,19 @@ ap.add_argument('--radecrad',
                 default=None)
 
 ns = ap.parse_args()
-infiles = io.list_sweepfiles(ns.src)
+
+infiles = io.list_sweepfiles(ns.sweepdir)
+indir = ns.sweepdir
+if ns.sweepdir2 is not None:
+    infiles2 = io.list_sweepfiles(ns.sweepdir2)
+    infiles += infiles2
+    indir = "{} {}".format(ns.sweepdir, ns.sweepdir2)
 if len(infiles) == 0:
-    infiles = io.list_tractorfiles(ns.src)
+    infiles = io.list_tractorfiles(ns.sweepdir)
+    if ns.sweepdir2 is not None:
+        infiles2 = io.list_tractorfiles(ns.sweepdir2)
+        infiles += infiles2
+        indir = "{} {}".format(ns.sweepdir, ns.sweepdir2)
 if len(infiles) == 0:
     log.critical('no sweep or tractor files found')
     sys.exit(1)
@@ -112,6 +125,6 @@ else:
 
     if ns.bundlefiles is None:
         io.write_targets(ns.dest, targets,
-                         indir=ns.src, survey="main", nsidefile=ns.nside, hpxlist=pixlist,
+                         indir=indir, survey="main", nsidefile=ns.nside, hpxlist=pixlist,
                          qso_selection=ns.qsoselection, sandboxcuts=ns.sandbox, nside=nside)
         log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -28,7 +28,7 @@ from desitarget import io
 from desitarget.internal import sharedmem
 from desitarget.gaiamatch import match_gaia_to_primary
 from desitarget.gaiamatch import pop_gaia_coords, pop_gaia_columns
-from desitarget.targets import finalize
+from desitarget.targets import finalize, resolve
 from desitarget.geomask import bundle_bricks, pixarea2nside, check_nside
 from desitarget.geomask import box_area, hp_in_box, is_in_box, is_in_hp
 from desitarget.geomask import cap_area, hp_in_cap, is_in_cap
@@ -2394,6 +2394,8 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         # - Add *_target mask columns
         targets = finalize(objects, desi_target, bgs_target, mws_target,
                            survey=survey)
+        # ADM resolve any duplicates between imaging data releases.
+        targets = resolve(targets)
 
         return targets
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1564,7 +1564,7 @@ def _prepare_gaia(objects, colnames=None):
     gaiarmag = objects['GAIA_PHOT_RP_MEAN_MAG']
     gaiaaen = objects['GAIA_ASTROMETRIC_EXCESS_NOISE']
     # ADM a mild hack, as GAIA_DUPLICATED_SOURCE was a 0/1 integer at some point.
-    if len(set(np.atleast_1d(objects['GAIA_DUPLICATED_SOURCE'])) - set([0,1])) == 0:
+    if len(set(np.atleast_1d(objects['GAIA_DUPLICATED_SOURCE'])) - set([0, 1])) == 0:
         gaiadupsource = objects['GAIA_DUPLICATED_SOURCE'].astype(bool)
     else:
         gaiadupsource = objects['GAIA_DUPLICATED_SOURCE']

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1564,10 +1564,10 @@ def _prepare_gaia(objects, colnames=None):
     gaiarmag = objects['GAIA_PHOT_RP_MEAN_MAG']
     gaiaaen = objects['GAIA_ASTROMETRIC_EXCESS_NOISE']
     # ADM a mild hack, as GAIA_DUPLICATED_SOURCE was a 0/1 integer at some point.
-    if len(set(np.atleast_1d(objects['GAIA_DUPLICATED_SOURCE'])) - set([0, 1])) == 0:
-        gaiadupsource = objects['GAIA_DUPLICATED_SOURCE'].astype(bool)
-    else:
-        gaiadupsource = objects['GAIA_DUPLICATED_SOURCE']
+    gaiadupsource = objects['GAIA_DUPLICATED_SOURCE']
+    if issubclass(gaiadupsource.dtype.type, np.integer):
+        if len(set(np.atleast_1d(gaiadupsource)) - set([0, 1])) == 0:
+            gaiadupsource = objects['GAIA_DUPLICATED_SOURCE'].astype(bool)
 
     # For BGS target selection
     Grr = gaiagmag - 22.5 + 2.5*np.log10(objects['FLUX_R'])

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1512,16 +1512,16 @@ def _prepare_optical_wise(objects, colnames=None):
     w1snr = objects['FLUX_W1'] * np.sqrt(objects['FLUX_IVAR_W1'])
     w2snr = objects['FLUX_W2'] * np.sqrt(objects['FLUX_IVAR_W2'])
 
-    # For BGS target selection
-    brightstarinblob = (objects['BRIGHTBLOB'] & 2**1) != 0
+    # For BGS target selection.
+    brightstarinblob = (objects['BRIGHTBLOB'] & 2**0) != 0
 
     # Delta chi2 between PSF and SIMP morphologies; note the sign....
     dchisq = objects['DCHISQ']
     deltaChi2 = dchisq[..., 0] - dchisq[..., 1]
 
-    # ADM remove handful of NaN values from DCHISQ values and make them unselectable
+    # ADM remove handful of NaN values from DCHISQ values and make them unselectable.
     w = np.where(deltaChi2 != deltaChi2)
-    # ADM this is to catch the single-object case for unit tests
+    # ADM this is to catch the single-object case for unit tests.
     if len(w[0]) > 0:
         deltaChi2[w] = -1e6
 
@@ -1563,7 +1563,11 @@ def _prepare_gaia(objects, colnames=None):
     gaiabmag = objects['GAIA_PHOT_BP_MEAN_MAG']
     gaiarmag = objects['GAIA_PHOT_RP_MEAN_MAG']
     gaiaaen = objects['GAIA_ASTROMETRIC_EXCESS_NOISE']
-    gaiadupsource = objects['GAIA_DUPLICATED_SOURCE']
+    # ADM a mild hack, as GAIA_DUPLICATED_SOURCE was a 0/1 integer at some point.
+    if len(set(np.atleast_1d(objects['GAIA_DUPLICATED_SOURCE'])) - set([0,1])) == 0:
+        gaiadupsource = objects['GAIA_DUPLICATED_SOURCE'].astype(bool)
+    else:
+        gaiadupsource = objects['GAIA_DUPLICATED_SOURCE']
 
     # For BGS target selection
     Grr = gaiagmag - 22.5 + 2.5*np.log10(objects['FLUX_R'])

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1513,7 +1513,7 @@ def _prepare_optical_wise(objects, colnames=None):
     w2snr = objects['FLUX_W2'] * np.sqrt(objects['FLUX_IVAR_W2'])
 
     # For BGS target selection
-    brightstarinblob = objects['BRIGHTSTARINBLOB']
+    brightstarinblob = (objects['BRIGHTBLOB'] & 2**1) != 0
 
     # Delta chi2 between PSF and SIMP morphologies; note the sign....
     dchisq = objects['DCHISQ']

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -711,7 +711,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets', 
 
     print("")
     print("#######################################################")
-    print("Possible salloc command if you want to run on the interactive queue:")
+    print("Possible salloc command if you want to run on the Cori interactive queue:")
     print("")
     print("salloc -N {} -C haswell -t 0{}:00:00 --qos interactive -L SCRATCH,project"
           .format(len(bins), maxeta))

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -210,7 +210,7 @@ def add_gaia_columns(indata):
     return outdata
 
 
-def add_dr_columns(indata):
+def add_dr8_columns(indata):
     """Add columns that are in dr7/dr8 that weren't in dr6.
 
     Parameters
@@ -234,7 +234,7 @@ def add_dr_columns(indata):
     if 'BRIGHTSTARINBLOB' in indata.dtype.names:
         newt = dr8datamodel["BRIGHTBLOB"].dtype.str
         newdt = ("BRIGHTBLOB", newt)
-        dt = [fld if fld[0] != 'BRIGHTSTARINBLOB' else newdt 
+        dt = [fld if fld[0] != 'BRIGHTSTARINBLOB' else newdt
               for fld in indata.dtype.descr]
     else:
         # ADM otherwise, create the combined data model.
@@ -378,7 +378,7 @@ def read_tractor(filename, header=False, columns=None):
     # ADM add DR8 data model updates (with zero/False) columns if not passed.
     if (columns is None) and \
        (('BRIGHTBLOB' not in fxcolnames) and ('brightblob' not in fxcolnames)):
-        data = add_dr_columns(data)
+        data = add_dr8_columns(data)
 
     # ADM Empty (length 0) files have dtype='>f8' instead of 'S8' for brickname.
     if len(data) == 0:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -51,8 +51,8 @@ oldtscolumns = [
 # ADM this is an empty array of the full TS data model columns and dtypes
 # ADM other columns can be added in read_tractor.
 tsdatamodel = np.array([], dtype=[
-    ('RELEASE', '>i4'), ('BRICKID', '>i4'), ('BRICKNAME', 'S8'),
-    ('OBJID', '<i4'), ('TYPE', 'S4'), ('RA', '>f8'), ('RA_IVAR', '>f4'),
+    ('RELEASE', '>i2'), ('BRICKID', '>i4'), ('BRICKNAME', 'S8'),
+    ('OBJID', '>i4'), ('TYPE', 'S4'), ('RA', '>f8'), ('RA_IVAR', '>f4'),
     ('DEC', '>f8'), ('DEC_IVAR', '>f4'), ('DCHISQ', '>f4', (5,)), ('EBV', '>f4'),
     ('FLUX_G', '>f4'), ('FLUX_R', '>f4'), ('FLUX_Z', '>f4'),
     ('FLUX_IVAR_G', '>f4'), ('FLUX_IVAR_R', '>f4'), ('FLUX_IVAR_Z', '>f4'),

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -673,7 +673,11 @@ def write_gfas(filename, data, indir=None, nside=None, survey="?",
     fitsio.write(filename, data, extname='GFA_TARGETS', header=hdr, clobber=True)
 
 
-def write_randoms(filename, data, indir=None, nside=None, density=None):
+    # ADM add the SCXDIR to the file header.                                                                                                                                                          
+    hdr["SCXDIR"] = scxdir
+
+
+def write_randoms(filename, data, indir=None, hdr=None, nside=None, density=None):
     """Write a catalogue of randoms and associated pixel-level information.
 
     Parameters
@@ -685,6 +689,8 @@ def write_randoms(filename, data, indir=None, nside=None, density=None):
     indir : :class:`str`, optional, defaults to None
         Name of input Legacy Survey Data Release directory, write to header
         of output file if passed (and if not None).
+    hdr : :class:`str`, optional, defaults to `None`
+        If passed, use this header to start the header of the output `filename`.
     nside: :class:`int`
         If passed, add a column to the randoms array popluated with HEALPixels
         at resolution `nside`.
@@ -692,8 +698,10 @@ def write_randoms(filename, data, indir=None, nside=None, density=None):
         Number of points per sq. deg. at which the catalog was generated,
         write to header of the output file if not None.
     """
-    # ADM create header to include versions, etc.
-    hdr = fitsio.FITSHDR()
+    # ADM create header to include versions, etc. If a `hdr` was
+    # ADM passed, then use it, if not then create a new header.
+    if hdr is None:
+        hdr = fitsio.FITSHDR()
     depend.setdep(hdr, 'desitarget', desitarget_version)
     depend.setdep(hdr, 'desitarget-git', gitversion())
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -673,10 +673,6 @@ def write_gfas(filename, data, indir=None, nside=None, survey="?",
     fitsio.write(filename, data, extname='GFA_TARGETS', header=hdr, clobber=True)
 
 
-    # ADM add the SCXDIR to the file header.                                                                                                                                                          
-    hdr["SCXDIR"] = scxdir
-
-
 def write_randoms(filename, data, indir=None, hdr=None, nside=None, density=None):
     """Write a catalogue of randoms and associated pixel-level information.
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -921,7 +921,7 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
                 raise ValueError(msg)
     bricknames = np.concatenate(bricknames)
     brickinfo = np.concatenate(brickinfo)
-        
+
     # ADM if the pixlist or bundlebricks option was sent, we'll need the HEALPixel
     # ADM information for each brick.
     if pixlist is not None or bundlebricks is not None:

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -929,7 +929,7 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
             qinfo.append(_update_status(_get_quantities(brickname)))
 
     qinfo = np.concatenate(qinfo)
-    
+
     # ADM one last shuffle to randomize across brick boundaries.
     np.random.seed(616)
     np.random.shuffle(qinfo)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -37,27 +37,28 @@ log = get_logger()
 start = time()
 
 
-def dr_extension(drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"):
+def dr_extension(drdir):
     """Determine the extension information for files in a legacy survey coadd directory
 
     Parameters
     ----------
-    drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
+    drdir : :class:`str`
        The root directory pointing to a Data Release from the Legacy Surveys
+       e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
 
     Returns
     -------
     :class:`str`
-        Whether the file extension is 'gz' or 'fz'
+        Whether the file extension is 'gz' or 'fz'.
     :class:`int`
-        The corresponding FITS extension number that needs to be read (0 or 1)
+        The corresponding FITS extension number that needs to be read (0 or 1).
     """
 
     from glob import iglob
 
-    # ADM for speed, create a generator of all of the nexp files in the coadd directory
+    # ADM for speed, create a generator of all of the nexp files in the coadd directory.
     gen = iglob(drdir+"/coadd/*/*/*nexp*")
-    # ADM and pop the first one
+    # ADM and pop the first one.
     anexpfile = next(gen)
     extn = anexpfile[-2:]
 
@@ -74,20 +75,20 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
     Parameters
     ----------
     ramin : :class:`float`
-        The minimum "edge" of the brick in Right Ascension
+        The minimum "edge" of the brick in Right Ascension.
     ramax : :class:`float`
-        The maximum "edge" of the brick in Right Ascension
+        The maximum "edge" of the brick in Right Ascension.
     decmin : :class:`float`
-        The minimum "edge" of the brick in Declination
+        The minimum "edge" of the brick in Declination.
     decmax : :class:`float`
-        The maximum "edge" of the brick in Declination
+        The maximum "edge" of the brick in Declination.
     density : :class:`int`, optional, defaults to 100,000
         The number of random points to return per sq. deg. As a typical brick is
-        ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned
+        ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned.
     poisson : :class:`boolean`, optional, defaults to True
         Modify the number of random points in the brick so that instead of simply
         being the brick area x the density, it is a number drawn from a Poisson
-        distribution with the expectation being the brick area x the density
+        distribution with the expectation being the brick area x the density.
 
     Returns
     -------
@@ -127,30 +128,30 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
     return ras, decs
 
 
-def randoms_in_a_brick_from_name(brickname, density=100000,
-                                 drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"):
-    """For a given brick name, return random (RA/Dec) positions in the brick
+def randoms_in_a_brick_from_name(brickname, drdir, density=100000):
+    """For a given brick name, return random (RA/Dec) positions in the brick.
 
     Parameters
     ----------
     brickname : :class:`str`
-        Name of brick in which to generate random points
+        Name of brick in which to generate random points.
+    drdir : :class:`str`
+       The root directory pointing to a Data Release from the Legacy Surveys
+       e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
     density : :class:`int`, optional, defaults to 100,000
         The number of random points to return per sq. deg. As a typical brick is
-        ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned
-    drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
-       The root directory pointing to a Data Release from the Legacy Surveys
+        ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned.
 
     Returns
     -------
     :class:`~numpy.array`
-        Right Ascensions of random points in brick
+        Right Ascensions of random points in brick.
     :class:`~numpy.array`
-        Declinations of random points in brick
+        Declinations of random points in brick.
 
     Notes
     -----
-        - First version copied shamelessly from Anand Raichoor
+        - First version copied shamelessly from Anand Raichoor.
     """
     # ADM read in the survey bricks file to determine the brick boundaries
     hdu = fits.open(drdir+'survey-bricks.fits.gz')
@@ -192,8 +193,7 @@ def randoms_in_a_brick_from_name(brickname, density=100000,
     return ras, decs
 
 
-def quantities_at_positions_in_a_brick(ras, decs, brickname,
-                                       drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"):
+def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir):
     """Return NOBS, GALDEPTH, PSFDEPTH (per-band) at positions in one brick of the Legacy Surveys
 
     Parameters
@@ -204,8 +204,9 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname,
         Declinations of interest (degrees).
     brickname : :class:`str`
         Name of brick which contains RA/Dec positions, e.g., '1351p320'.
-    drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
-       The root directory pointing to a Data Release from the Legacy Surveys.
+    drdir : :class:`str`
+       The root directory pointing to a Data Release from the Legacy Surveys
+       e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
 
     Returns
     -------
@@ -216,32 +217,34 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname,
 
     Notes
     -----
-        - First version copied shamelessly from Anand Raichoor
+        - First version copied shamelessly from Anand Raichoor.
     """
     npts = len(ras)
 
-    # ADM determine whether the coadd files have extension .gz or .fz based on the DR directory
+    # ADM determine whether the coadd files have extension .gz or .fz based on the DR directory.
     extn, extn_nb = dr_extension(drdir)
 
-    # ADM the output dictionary
+    # ADM the output dictionary.
     qdict = {}
 
     # as a speed up, we assume all images in different filters for the brick have the same WCS
     # -> if we have read it once (iswcs=True), we use this info
     iswcs = False
 
+    rootdir = os.path.join(drdir, 'coadd', brickname[:3], brickname)
     # ADM loop through each of the filters and store the number of observations at the
-    # ADM RA and Dec positions of the passed points
+    # ADM RA and Dec positions of the passed points.
     for filt in ['g', 'r', 'z']:
         # ADM the input file labels, and output column names and output formats
-        # ADM for each of the quantities of interest
+        # ADM for each of the quantities of interest.
         qnames = zip(['nexp', 'depth', 'galdepth'],
                      ['nobs', 'psfdepth', 'galdepth'],
                      ['i2', 'f4', 'f4'])
         for qin, qout, qform in qnames:
-            fn = (drdir+'/coadd/'+brickname[:3]+'/'+brickname+'/' +
-                  'legacysurvey-'+brickname+'-'+qin+'-'+filt+'.fits.'+extn)
-            # ADM only process the WCS if there is a file corresponding to this filter
+            fn = os.path.join(
+                rootdir, 'legacysurvey-{}-{}-{}.fits.{}'.format(brickname, qin, filt, extn)
+                )
+            # ADM only process the WCS if there is a file corresponding to this filter.
             if os.path.exists(fn):
                 img = fits.open(fn)
                 if not iswcs:
@@ -256,25 +259,24 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname,
             else:
                 # log.info('no {} file at {}...t = {:.1f}s'
                 #          .format(qin+'_'+filt,fn,time()-start))
-                # ADM if the file doesn't exist, set the relevant quantities to zero
-                # ADM for all of the passed
+                # ADM if the file doesn't exist, set the relevant quantities to zero.
                 qdict[qout+'_'+filt] = np.zeros(npts, dtype=qform)
 
-    # ADM add the mask bits information
-    fn = (drdir+'/coadd/'+brickname[:3]+'/'+brickname+'/' +
-          'legacysurvey-'+brickname+'-maskbits.fits.gz')
-    # ADM only process the WCS if there is a file corresponding to this filter
+    # ADM add the mask bits information.
+    fn = os.path.join(rootdir,
+                      'legacysurvey-{}-maskbits.fits.{}'.format(brickname, extn))
+    # ADM only process the WCS if there is a file corresponding to this filter.
     if os.path.exists(fn):
         img = fits.open(fn)
-        # ADM use the WCS calculated for the per-filter quantities above, if it exists
+        # ADM use the WCS calculated for the per-filter quantities above, if it exists.
         if not iswcs:
-            w = WCS(img[0].header)
+            w = WCS(img[extn_nb].header)
             x, y = w.all_world2pix(ras, decs, 0)
             iswcs = True
-        # ADM add the maskbits to the dictionary
-        qdict['maskbits'] = img[0].data[y.astype("int"), x.astype("int")]
+        # ADM add the maskbits to the dictionary.
+        qdict['maskbits'] = img[extn_nb].data[y.astype("int"), x.astype("int")]
     else:
-        # ADM if there is no maskbits file, populate with zeros
+        # ADM if there is no maskbits file, populate with zeros.
         qdict['maskbits'] = np.zeros(npts, dtype='i2')
 
 #    log.info('Recorded quantities for each point in brick {}...t = {:.1f}s'
@@ -283,30 +285,30 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname,
     return qdict
 
 
-def hp_with_nobs_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=100000, nside=256,
-                            drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"):
-    """Given a brick's edges/name, count randoms with NOBS > 1 in HEALPixels touching that brick
+def hp_with_nobs_in_a_brick(ramin, ramax, decmin, decmax, brickname, drdir,
+                            density=100000, nside=256):
+    """Given a brick's edges/name, count randoms with NOBS > 1 in HEALPixels touching that brick.
 
     Parameters
     ----------
     ramin : :class:`float`
-        The minimum "edge" of the brick in Right Ascension
+        The minimum "edge" of the brick in Right Ascension.
     ramax : :class:`float`
         The maximum "edge" of the brick in Right Ascension
     decmin : :class:`float`
-        The minimum "edge" of the brick in Declination
+        The minimum "edge" of the brick in Declination.
     decmax : :class:`float`
-        The maximum "edge" of the brick in Declination
+        The maximum "edge" of the brick in Declination.
     brickname : :class:`~numpy.array`
-        Brick names that corresponnds to the brick edges, e.g., '1351p320'
+        Brick names that corresponnds to the brick edges, e.g., '1351p320'.
+    drdir : :class:`str`
+       The root directory pointing to a Data Release from the Legacy Surveys
+       e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
     density : :class:`int`, optional, defaults to 100,000
         The number of random points to return per sq. deg. As a typical brick is
-        ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned
+        ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned.
     nside : :class:`int`, optional, defaults to nside=256 (~0.0525 sq. deg. or "brick-sized")
-        The resolution (HEALPixel NESTED nside number) at which to build the map
-    drdir : :class:`str`, optional, defaults to the DR4 root directory at NERSC
-        The root directory pointing to a Data Release of the Legacy Surveys, e.g.:
-        "/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"
+        The resolution (HEALPixel NESTED nside number) at which to build the map.
 
     Returns
     -------
@@ -314,33 +316,33 @@ def hp_with_nobs_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=100
         a numpy structured array with the following columns:
             HPXPIXEL: Integer numbers of (only) those HEALPixels that overlap the passed brick
             HPXCOUNT: Numbers of random points with one or more observations (NOBS > 0) in the
-                passed Data Release of the Legacy Surveys for each returned HPXPIXEL
+                passed Data Release of the Legacy Surveys for each returned HPXPIXEL.
 
     Notes
     -----
-        - The HEALPixel numbering uses the NESTED scheme
+        - The HEALPixel numbering uses the NESTED scheme.
         - In the event that there are no pixels with one or more observations in the passed
-          brick, and empty structured array will be returned
+          brick, and empty structured array will be returned.
     """
-    # ADM this is only intended to work on one brick, so die if a larger array is passed
+    # ADM this is only intended to work on one brick, so die if a larger array is passed.
     if not isinstance(brickname, str):
         log.fatal("Only one brick can be passed at a time!")
         raise ValueError
 
     # ADM generate an empty structured array to return in the event that no pixels with
-    # ADM counts were found
+    # ADM counts were found.
     hpxinfo = np.zeros(0, dtype=[('HPXPIXEL', '>i4'), ('HPXCOUNT', '>i4')])
 
-    # ADM generate random points within the brick at the requested density
+    # ADM generate random points within the brick at the requested density.
     ras, decs = randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax, density=density)
 
-    # ADM retrieve the number of observations for each random point
+    # ADM retrieve the number of observations for each random point.
     nobs_g, nobs_r, nobs_z = nobs_at_positions_in_a_brick(ras, decs, brickname, drdir=drdir)
 
-    # ADM only retain points with one or more observations in all bands
+    # ADM only retain points with one or more observations in all bands.
     w = np.where((nobs_g > 0) & (nobs_r > 0) & (nobs_z > 0))
 
-    # ADM if there were some non-zero observations, populate the pixel numbers and counts
+    # ADM if there were some non-zero observations, populate the pixel numbers and counts.
     if len(w[0]) > 0:
         pixnums = hp.ang2pix(nside, np.radians(90.-decs[w]), np.radians(ras[w]), nest=True)
         pixnum, pixcnt = np.unique(pixnums, return_counts=True)
@@ -376,9 +378,8 @@ def get_dust(ras, decs, scaling=1, dustdir=None):
     return SFDMap(mapdir=dustdir).ebv(ras, decs, scaling=scaling)
 
 
-def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=100000,
-                              drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/",
-                              dustdir=None):
+def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, drdir,
+                              density=100000, dustdir=None):
     """NOBS, DEPTHS etc. (per-band) for random points in a brick of the Legacy Surveys
 
     Parameters
@@ -393,12 +394,12 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=1
         The maximum "edge" of the brick in Declination
     brickname : :class:`~numpy.array`
         Brick names that corresponnds to the brick edges, e.g., '1351p320'
+    drdir : :class:`str`
+       The root directory pointing to a Data Release from the Legacy Surveys
+       e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
     density : :class:`int`, optional, defaults to 100,000
         The number of random points to return per sq. deg. As a typical brick is
         ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned
-    drdir : :class:`str`, optional, defaults to the DR4 root directory at NERSC
-        The root directory pointing to a Data Release of the Legacy Surveys, e.g.:
-        "/global/project/projectdirs/cosmo/data/legacysurvey/dr4/"
     dustdir : :class:`str`, optional, defaults to $DUST_DIR+'/maps'
         The root directory pointing to SFD dust maps. If not
         sent the code will try to use $DUST_DIR+'/maps' before failing.
@@ -432,7 +433,7 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, density=1
     ras, decs = randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax, density=density)
 
     # ADM retrieve the dictionary of quantities for each random point
-    qdict = quantities_at_positions_in_a_brick(ras, decs, brickname, drdir=drdir)
+    qdict = quantities_at_positions_in_a_brick(ras, decs, brickname, drdir)
 
     # ADM retrieve the E(B-V) values for each random point
     ebv = get_dust(ras, decs, dustdir=dustdir)
@@ -771,14 +772,16 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
     return hpxinfo
 
 
-def select_randoms(density=100000, numproc=32, nside=4, pixlist=None,
+def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
                    bundlebricks=None, brickspersec=2.5,
-                   drdir="/global/project/projectdirs/cosmo/data/legacysurvey/dr4/",
                    dustdir=None):
     """NOBS, GALDEPTH, PSFDEPTH (per-band) for random points in a DR of the Legacy Surveys
 
     Parameters
     ----------
+    drdir : :class:`str`
+       The root directory pointing to a Data Release from the Legacy Surveys
+       e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
     density : :class:`int`, optional, defaults to 100,000
         The number of random points to return per sq. deg. As a typical brick is
         ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned
@@ -803,8 +806,6 @@ def select_randoms(density=100000, numproc=32, nside=4, pixlist=None,
         The rough number of bricks processed per second by the code (parallelized across
         a chosen number of nodes). Used in conjunction with `bundlebricks` for the code
         to estimate time to completion when parallelizing across pixels.
-    drdir : :class:`str`, optional, defaults to dr4 root directory on NERSC
-       The root directory pointing to a Data Release from the Legacy Surveys.
     dustdir : :class:`str`, optional, defaults to $DUST_DIR+'maps'
         The root directory pointing to SFD dust maps. If not
         sent the code will try to use $DUST_DIR+'maps')
@@ -832,10 +833,26 @@ def select_randoms(density=100000, numproc=32, nside=4, pixlist=None,
     """
     # ADM read in the survey bricks file, which lists the bricks of interest for this DR
     from glob import glob
-    sbfile = glob(drdir+'/*bricks-dr*')[0]
-    hdu = fits.open(sbfile)
-    brickinfo = hdu[1].data
-    bricknames = brickinfo['brickname']
+    sbfile = glob(drdir+'/*bricks-dr*')
+    if len(sbfile) > 0:
+        sbfile = sbfile[0]
+        hdu = fits.open(sbfile)
+        brickinfo = hdu[1].data
+        bricknames = brickinfo['brickname']
+    # ADM this is a hack for test bricks where we don't always generate the bricks
+    # ADM file. It's probably safe to remove it at some point.
+    else:
+        # ADM read in the test brick file list.
+        tbrxfns = glob(os.path.join(drdir, "brick-lists", "test*"))
+        tbrx = []
+        for fn in tbrxfns:
+            tbrx.append(np.loadtxt(fn, dtype='str'))
+        bricknames = np.concatenate(tbrx)
+        if pixlist is not None or bundlebricks is not None:
+            msg = 'DR-specific bricks file not found'
+            msg += 'and pixlist of bundlebricks passed!!!'
+            log.critical(msg)
+            raise ValueError(msg)        
 
     # ADM if the pixlist or bundlebricks option was sent, we'll need the HEALPixel
     # ADM information for each brick
@@ -883,8 +900,8 @@ def select_randoms(density=100000, numproc=32, nside=4, pixlist=None,
 
         # ADM populate the brick with random points, and retrieve the quantities
         # ADM of interest at those points
-        return get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
-                                         density=density, drdir=drdir, dustdir=dustdir)
+        return get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname, drdir,
+                                         density=density, dustdir=dustdir)
 
     # ADM this is just to count bricks in _update_status
     nbrick = np.zeros((), dtype='i8')

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -929,5 +929,9 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
             qinfo.append(_update_status(_get_quantities(brickname)))
 
     qinfo = np.concatenate(qinfo)
+    
+    # ADM one last shuffle to randomize across brick boundaries.
+    np.random.seed(616)
+    np.random.shuffle(qinfo)
 
     return qinfo

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -839,15 +839,12 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
         hdu = fits.open(sbfile)
         brickinfo = hdu[1].data
         bricknames = brickinfo['brickname']
-    # ADM this is a hack for test bricks where we don't always generate the bricks
-    # ADM file. It's probably safe to remove it at some point.
     else:
-        # ADM read in the test brick file list.
-        tbrxfns = glob(os.path.join(drdir, "brick-lists", "test*"))
-        tbrx = []
-        for fn in tbrxfns:
-            tbrx.append(np.loadtxt(fn, dtype='str'))
-        bricknames = np.concatenate(tbrx)
+        # ADM this is a hack for test bricks where we don't always generate the
+        # ADM bricks file. It's probably safe to remove it at some point.
+        fns = glob(os.path.join(drdir, 'tractor', '*', '*fits'))
+        from desitarget.io import brickname_from_filename
+        bricknames =[brickname_from_filename(fn) for fn in fns]
         if pixlist is not None or bundlebricks is not None:
             msg = 'DR-specific bricks file not found'
             msg += 'and pixlist of bundlebricks passed!!!'

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -627,7 +627,8 @@ def resolve(targets):
     Parameters
     ----------
     targets : :class:`~numpy.ndarray`
-        Rec array of targets. Must have columns "RELEASE", "RA" and "DEC".
+        Rec array of targets. Must have columns "RA" and "DEC" and
+        either "RELEASE" or "PHOTSYS".
 
     Returns
     -------
@@ -638,7 +639,10 @@ def resolve(targets):
     """
     # ADM retrieve the photometric system from the RELEASE.
     from desitarget.io import release_to_photsys, desitarget_resolve_dec
-    photsys = release_to_photsys(targets["RELEASE"])
+    if 'PHOTSYS' in targets.dtype.names:
+        photsys = targets["PHOTSYS"]
+    else:
+        photsys = release_to_photsys(targets["RELEASE"])
 
     # ADM a flag of which targets are from the 'N' photometry.
     from desitarget.cuts import _isonnorthphotsys

--- a/py/desitarget/test/test_cmx.py
+++ b/py/desitarget/test/test_cmx.py
@@ -52,7 +52,7 @@ class TestCMX(unittest.TestCase):
         """
         # ADM add the DR7/DR8 data columns if they aren't there yet.
         # ADM can remove this once DR8 is finalized.
-        if not "BRIGHTBLOB" in targets.dtype.names:
+        if "BRIGHTBLOB" not in targets.dtype.names:
             targets = io.add_dr8_columns(targets)
 
         cmx, pshift = cuts.apply_cuts(targets,

--- a/py/desitarget/test/test_cmx.py
+++ b/py/desitarget/test/test_cmx.py
@@ -50,6 +50,11 @@ class TestCMX(unittest.TestCase):
     def _test_table_row(self, targets):
         """Test cuts work with tables from several I/O libraries
         """
+        # ADM add the DR7/DR8 data columns if they aren't there yet.
+        # ADM can remove this once DR8 is finalized.
+        if not "BRIGHTBLOB" in targets.dtype.names:
+            targets = io.add_dr8_columns(targets)
+
         cmx, pshift = cuts.apply_cuts(targets,
                                       cmxdir=self.cmxdir)
         self.assertEqual(len(cmx), len(targets))

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -188,7 +188,7 @@ class TestCuts(unittest.TestCase):
         tc = ["ELG"]
         # ADM add the DR7/DR8 data columns if they aren't there yet.
         # ADM can remove this once DR8 is finalized.
-        if not "BRIGHTBLOB" in targets.dtype.names:
+        if "BRIGHTBLOB" not in targets.dtype.names:
             targets = io.add_dr8_columns(targets)
 
         self.assertFalse(cuts._is_row(targets))

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -186,6 +186,10 @@ class TestCuts(unittest.TestCase):
         # ADM only test the ELG cuts for speed. There's a
         # ADM full run through all classes in test_cuts_basic.
         tc = ["ELG"]
+        # ADM add the DR7/DR8 data columns if they aren't there yet.
+        # ADM can remove this once DR8 is finalized.
+        if not "BRIGHTBLOB" in targets.dtype.names:
+            targets = io.add_dr8_columns(targets)
 
         self.assertFalse(cuts._is_row(targets))
         self.assertTrue(cuts._is_row(targets[0]))

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -78,7 +78,7 @@ class TestIO(unittest.TestCase):
         tscolumns = list(io.tsdatamodel.dtype.names)     \
             + ['BRICK_PRIMARY', 'PHOTSYS']               \
             + list(gaiadatamodel.dtype.names)            \
-            + list(io.dr7datamodel.dtype.names)
+            + list(io.dr8datamodel.dtype.names)
         tractorfile = io.list_tractorfiles(self.datadir)[0]
         data = io.read_tractor(tractorfile)
         self.assertEqual(set(data.dtype.names), set(tscolumns))


### PR DESCRIPTION
This PR handles changes for moving to DR8 of the imaging surveys. It's possible that additional tweaks will be needed for the final DR8 imaging release, but this should be the vast majority of the updates and I don't want this branch to go stale waiting for the final version of DR8. Includes:

- Update the Data Model (e.g. boolean `BRIGHTSTARBLOB` -> bitmask `BRIGHTBLOB`)
- Resolve targets and randoms for duplicate bricks in regions where the imaging surveys overlap.
- Handle the "dual" file structure where BASS/MzLS and DECaLS exist in the same directory.

Still to do:

- Resolve skies so that we don't have additional sky locations in the overlap regions.