### PR TITLE
work around deprecated unsafe yaml.load

### DIFF
--- a/py/desitarget/targetmask.py
+++ b/py/desitarget/targetmask.py
@@ -19,7 +19,7 @@ def load_mask_bits(prefix=""):
     fn = "{}/data/{}targetmask.yaml".format(prefix, prename)
     _filepath = resource_filename('desitarget', fn)
     with open(_filepath) as fx:
-        bitdefs = yaml.load(fx)
+        bitdefs = yaml.safe_load(fx)
         try:
             bitdefs = _load_mask_priorities(bitdefs, handle="priorities", prename=prename)
         except TypeError:

--- a/py/desitarget/test/test_mock_build.py
+++ b/py/desitarget/test/test_mock_build.py
@@ -33,7 +33,7 @@ class TestMockBuild(unittest.TestCase):
 
         import yaml
         with open(configfile) as fx:
-            params = yaml.load(fx)
+            params = yaml.safe_load(fx)
 
         for targettype in params['targets'].keys():
             mockfile = params['targets'][targettype]['mockfile'].format(**os.environ)


### PR DESCRIPTION
Starting with pyyaml 5.1, `yaml.load` without specifying a specific Loader is deprecated, due to security issues with the default loader potentially running arbitrary code when given untrusted input.  That doesn't apply to how we are using yaml to load our own files, but it generates scary warning messages and at some future version it would break.  This PR works around that by replacing `yaml.load` with `yaml.safe_load`.

See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation for more background on this security issue.