### PR TITLE
Various bug and feature fixes

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,18 +5,22 @@ desitarget Change Log
 0.29.2 (unreleased)
 -------------------
 
-* no changes yet.
+* Various bug and feature fixes [`PR #484`_]. Includes:
+    * Fix crash when using sv_select_targets with `--tcnames`.
+    * Only import matplotlib where needed in :mod:`desitarget.cuts`.
+* Update `select_mock_targets` to (current) DR8 data model [`PR #480`_].
+
+.. _`PR #480`: https://github.com/desihub/desitarget/pull/480
+.. _`PR #484`: https://github.com/desihub/desitarget/pull/484
 
 0.29.1 (2019-03-26)
 -------------------
 
-* Update `select_mock_targets` to (current) DR8 data model [`PR #480`_].
 * Add ``REF_CAT``, ``WISEMASK_W1/W2`` to DR8 data model [`PR #479`_].
 * Use speed of light from scipy [`PR #478`_].
 
 .. _`PR #478`: https://github.com/desihub/desitarget/pull/478
 .. _`PR #479`: https://github.com/desihub/desitarget/pull/479
-.. _`PR #480`: https://github.com/desihub/desitarget/pull/480
 
 0.29.0 (2019-03-22)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,7 +7,7 @@ desitarget Change Log
 
 * Various bug and feature fixes [`PR #484`_]. Includes:
     * Fix crash when using sv_select_targets with `--tcnames`.
-    * Only import matplotlib where needed in :mod:`desitarget.cuts`.
+    * Only import matplotlib where explicitly needed.
 * Update `select_mock_targets` to (current) DR8 data model [`PR #480`_].
 
 .. _`PR #480`: https://github.com/desihub/desitarget/pull/480

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -30,13 +30,6 @@ import healpy as hp
 from desiutil.log import get_logger
 log = get_logger()
 
-# ADM fake the matplotlib display so it doesn't die on allocated nodes.
-import matplotlib   # noqa: E402
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt   # noqa: E402
-from matplotlib.patches import Circle, Ellipse, Rectangle  # noqa: E402
-from matplotlib.collections import PatchCollection  # noqa: E402
-
 
 def ellipse_matrix(r, e1, e2):
     """Calculate transformation matrix from half-light-radius to ellipse
@@ -343,6 +336,9 @@ def circles(x, y, s, c='b', vmin=None, vmax=None, **kwargs):
     ----------
     With thanks to https://gist.github.com/syrte/592a062c562cd2a98a83
     """
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Circle
+    from matplotlib.collections import PatchCollection
 
     if np.isscalar(c):
         kwargs.setdefault('color', c)
@@ -416,6 +412,9 @@ def ellipses(x, y, w, h=None, rot=0.0, c='b', vmin=None, vmax=None, **kwargs):
     ----------
     With thanks to https://gist.github.com/syrte/592a062c562cd2a98a83
     """
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Ellipse
+    from matplotlib.collections import PatchCollection
 
     if np.isscalar(c):
         kwargs.setdefault('color', c)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -26,11 +26,6 @@ from desitarget.internal import sharedmem
 # ADM set up the DESI default logger
 from desiutil.log import get_logger
 
-# ADM fake the matplotlib display so it doesn't die on allocated nodes.
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt   # noqa: E402
-
 # ADM set up the default logger from desiutil
 log = get_logger()
 
@@ -577,6 +572,8 @@ def pixweight(randoms, density, nobsgrz=[0, 0, 0], nside=256, outplot=None, outa
         - `0 < WEIGHT < 1` for pixels that partially cover LS DR area with one or more observations.
         - The index of the array is the HEALPixel integer.
     """
+    import matplotlib.pyplot as plt
+
     # ADM if a file name was passed for the random catalog, read it in
     if isinstance(randoms, str):
         randoms = fitsio.read(randoms)

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -33,11 +33,6 @@ from desitarget.internal import sharedmem
 # ADM set up the DESI default logger
 from desiutil.log import get_logger
 
-# ADM fake the matplotlib display so it doesn't die on allocated nodes.
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt   # noqa: E402
-
 # ADM initialize the logger
 log = get_logger()
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1257,9 +1257,9 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     else:
         # ADM if not running the LRG selection, set everything to arrays of False
         lrg_north, lrginit_n, lrglowz_n, lrghighz_n, lrgrelax_n, lrgsuper_n = \
-            ~primary, ~primary, ~primary, ~primary, ~primary
+            ~primary, ~primary, ~primary, ~primary, ~primary, ~primary
         lrg_south, lrginit_s, lrglowz_s, lrghighz_s, lrgrelax_s, lrgsuper_s = \
-            ~primary, ~primary, ~primary, ~primary, ~primary
+            ~primary, ~primary, ~primary, ~primary, ~primary, ~primary
 
     # ADM combine LRG target bits for an LRG target based on any imaging
     lrg = (lrg_north & photsys_north) | (lrg_south & photsys_south)


### PR DESCRIPTION
A few fixes and improvements that have come up since DR8, some discovered in off-list discussions with users:

- Fix crash when using sv_select_targets with `--tcnames`.
- Only import matplotlib where explicitly needed.

Should address #481.