### PR TITLE
Remove GFA/Gaia duplicates using Gaia REF_ID

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.29.2 (unreleased)
 -------------------
 
+* Remove GFA/Gaia duplicates on ``REF_ID`` not ``BRICKID`` [`PR #488`_].
 * Various bug and feature fixes [`PR #484`_]. Includes:
     * Fix crash when using sv_select_targets with `--tcnames`.
     * Only import matplotlib where explicitly needed.
@@ -12,6 +13,7 @@ desitarget Change Log
 
 .. _`PR #480`: https://github.com/desihub/desitarget/pull/480
 .. _`PR #484`: https://github.com/desihub/desitarget/pull/484
+.. _`PR #488`: https://github.com/desihub/desitarget/pull/488
 
 0.29.1 (2019-03-26)
 -------------------

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -626,8 +626,8 @@ def find_gaia_files_box(gaiabounds, neighbors=True):
         A region of the sky bounded by RA/Dec. Pass as a 4-entry list to
         represent an area bounded by [RAmin, RAmax, DECmin, DECmax]
     neighbors : :class:`bool`, optional, defaults to ``True``
-        Also return files corresponding to all neighboring pixels that touch 
-        the files that touch the box in order to prevent edge effects (e.g. if a Gaia 
+        Also return files corresponding to all neighboring pixels that touch
+        the files that touch the box in order to prevent edge effects (e.g. if a Gaia
         source might be 1 arcsec outside of the box and so in an adjacent pixel)
 
     Returns

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -626,9 +626,9 @@ def find_gaia_files_box(gaiabounds, neighbors=True):
         A region of the sky bounded by RA/Dec. Pass as a 4-entry list to
         represent an area bounded by [RAmin, RAmax, DECmin, DECmax]
     neighbors : :class:`bool`, optional, defaults to ``True``
-        Also return all neighboring pixels that touch the files of interest
-        in order to prevent edge effects (e.g. if a Gaia source is 1 arcsec
-        away from a primary source and so in an adjacent pixel)
+        Also return files corresponding to all neighboring pixels that touch 
+        the files that touch the box in order to prevent edge effects (e.g. if a Gaia 
+        source might be 1 arcsec outside of the box and so in an adjacent pixel)
 
     Returns
     -------

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -20,7 +20,7 @@ from desitarget.internal import sharedmem
 from desitarget.gaiamatch import read_gaia_file
 from desitarget.gaiamatch import find_gaia_files_tiles, find_gaia_files_box
 from desitarget.targets import encode_targetid, resolve
-from desitarget.geomatch import is_in_box
+from desitarget.geomask import is_in_box
 
 from desiutil import brick
 from desiutil.log import get_logger

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -308,24 +308,6 @@ def gaia_gfas_from_sweep(filename, maglim=18.):
     ii = gfas['GAIA_PHOT_G_MEAN_MAG'] < maglim
     gfas = gfas[ii]
 
-    # ADM add any Gaia objects within the boundary of the sweep file. NOTE
-    # ADM THAT THIS WILL DUPLICATE Gaia objects that are already in the gfas.
-    radecbox = desitarget.io.decode_sweep_name(filename)
-    gfiles = find_gaia_files_box(radecbox, neighbors=False)
-    gobjs = []
-    for gfile in gfiles:
-        gobjs.append(gaia_in_file(gfile, maglim=maglim))
-    gobjs = np.concatenate(gobjs)
-    ii = is_in_box(gobjs, radecbox)
-    gobjs = gobjs[ii]
-
-    # ADM remove any duplicates. Order is important here, as np.unique keeps
-    # ADM The first occurence of an object, and we want to retain sweeps
-    # ADM information as much as possible.
-    gfas = np.concatenate([gfas, gobjs])
-    _, ind = np.unique(gfas["REF_ID"], return_index=True)
-    gfas = gfas[ind]
-
     # ADM a final clean-up to remove columns that are NaN (from
     # ADM Gaia-matching) or are exactly 0 (in the sweeps).
     for col in ["PMRA", "PMDEC"]:

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -307,12 +307,6 @@ def gaia_gfas_from_sweep(filename, maglim=18.):
     ii = gfas['GAIA_PHOT_G_MEAN_MAG'] < maglim
     gfas = gfas[ii]
 
-    # ADM a final clean-up to remove columns that are NaN (from
-    # ADM Gaia-matching) or are exactly 0 (in the sweeps).
-    for col in ["PMRA", "PMDEC"]:
-        ii = ~np.isnan(gfas[col]) & (gfas[col] != 0)
-        gfas = gfas[ii]
-
     return gfas
 
 
@@ -535,6 +529,12 @@ def select_gfas(infiles, maglim=18, numproc=4, tilesfile=None, cmx=False):
     gfas = np.concatenate([gfas, gaia])
     _, ind = np.unique(gfas["REF_ID"], return_index=True)
     gfas = gfas[ind]
+
+    # ADM a final clean-up to remove columns that are NaN (from
+    # ADM Gaia-matching) or that are exactly 0 (in the sweeps).
+    for col in ["PMRA", "PMDEC"]:
+        ii = ~np.isnan(gfas[col]) & (gfas[col] != 0)
+        gfas = gfas[ii]
 
     # ADM limit to DESI footprint or passed tiles, if not cmx'ing.
     if not cmx:

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -529,12 +529,14 @@ def select_gfas(infiles, maglim=18, numproc=4, tilesfile=None, cmx=False):
              .format((time()-t0)/60))
     gaia = all_gaia_in_tiles(maglim=maglim, numproc=numproc, allsky=cmx,
                              tiles=tiles)
-    # ADM and limit them to just any missing bricks...
-    brickids = set(gfas['BRICKID'])
-    ii = [gbrickid not in brickids for gbrickid in gaia["BRICKID"]]
-    gaia = gaia[ii]
 
+    # ADM remove any duplicates. Order is important here, as np.unique
+    # ADM keeps the first occurence, and we want to retain sweeps
+    # ADM information as much as possible.
     gfas = np.concatenate([gfas, gaia])
+    _, ind = np.unique(gfas["REF_ID"], return_index=True)
+    gfas = gfas[ind]
+
     # ADM limit to DESI footprint or passed tiles, if not cmx'ing.
     if not cmx:
         ii = is_point_in_desi(tiles, gfas["RA"], gfas["DEC"])

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -20,7 +20,6 @@ from desitarget.internal import sharedmem
 from desitarget.gaiamatch import read_gaia_file
 from desitarget.gaiamatch import find_gaia_files_tiles, find_gaia_files_box
 from desitarget.targets import encode_targetid, resolve
-from desitarget.geomask import is_in_box
 
 from desiutil import brick
 from desiutil.log import get_logger

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -452,17 +452,21 @@ def release_to_photsys(release):
 
     Notes
     -----
-    Defaults to 'U' if the system is not recognized.
+    Flags an error if the system is not recognized.
     """
     # ADM arrays of the key (RELEASE) and value (PHOTSYS) entries in the releasedict.
     releasenums = np.array(list(releasedict.keys()))
     photstrings = np.array(list(releasedict.values()))
 
+    # ADM explicitly check no unknown release numbers were passed.
+    unknown = set(release) - set(releasenums)
+    if bool(unknown):
+        msg = 'Unknown release number {}'.format(unknown)
+        log.critical(msg)
+        raise ValueError(msg)
+
     # ADM an array with indices running from 0 to the maximum release number + 1.
     r2p = np.empty(np.max(releasenums)+1, dtype='|S1')
-
-    # ADM set each entry to 'U' for an unidentified photometric system.
-    r2p[:] = 'U'
 
     # ADM populate where the release numbers exist with the PHOTSYS.
     r2p[releasenums] = photstrings

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -340,6 +340,10 @@ def read_tractor(filename, header=False, columns=None):
        (('BRIGHTSTARINBLOB' in fxcolnames) or ('brightstarinblob' in fxcolnames)):
         for col in dr7datamodel.dtype.names:
             readcolumns.append(col)
+        # ADM deal with some custom files I made that don't contain WISEMASK.
+        if 'WISEMASK_W1' not in fxcolnames:
+            readcolumns.remove('WISEMASK_W1')
+            readcolumns.remove('WISEMASK_W2')
     # ADM if BRIGHTBLOB exists (it does for DR8, not for DR7) add it and
     # ADM the other DR6->DR8 data model updates.
     else:


### PR DESCRIPTION
This PR updates the `select_gfas` framework to remove duplicates between Gaia and sweeps sources on `REF_ID` not `BRICKID`.

This addresses https://github.com/desihub/desitarget/issues/473.

An example file is at `/global/cscratch1/sd/adamyers/cmx-gfas-PR488.fits`.