### PR TITLE
apply the same declination cut to the mocks as to the data

### DIFF
--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -30,7 +30,6 @@ parser.add_argument('--nside', help='Divide the DESI footprint into this healpix
 parser.add_argument('--tiles', help='Path to file with tiles to cover', type=str)
 parser.add_argument('--healpixels', help='Integer list of healpix pixels (corresponding to nside) to process.', type=int, nargs='*', default=None)
 parser.add_argument('--join', action='store_true', help='Join the target and truth files in output_dir.')
-parser.add_argument('--qa', action='store_true', help='Generate QA plots from the joined target and truth files in output_dir.')
 parser.add_argument('-v','--verbose', action='store_true', help='Enable verbose output.')
 parser.add_argument('--no-spectra', action='store_true', help='Do not generate spectra.')
 parser.add_argument('--overwrite', action='store_true', help='Overwrite existing files.')
@@ -86,14 +85,7 @@ else:
 if args.join:
     from desitarget.mock.build import join_targets_truth
     join_targets_truth(mockdir=args.output_dir, outdir=args.output_dir, overwrite=args.overwrite)
-    if not args.qa:
-        sys.exit(1)
 
-if args.qa:
-    from desitarget.QA import qa_targets_truth
-    qa_targets_truth(args.output_dir, verbose=args.verbose)
-    sys.exit(1)
-    
 # Construct Targets and Truth files
 if not os.path.exists(args.config):
     log.fatal('No configuration file {} found.'.format(args.config))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.29.2 (unreleased)
 -------------------
 
+* Apply the same declination cut to the mocks as to the data [`PR #501`_]. 
 * Add SV support to select_mock_targets [`PR #496`_]
 * A few more updates and enhancements for DR8 [`PR #494`_]. Includes:
     * Add ``WISEMASK_W1`` and ``WISEMASK_W2`` to random catalogs.

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -1204,7 +1204,8 @@ class SelectTargets(object):
             Declination of candidate targets (decimal degrees). 
 
         """
-        return dec <= 32.125
+        from desitarget.io import desitarget_resolve_dec
+        return dec <= desitarget_resolve_dec()
 
     def remove_north_south_bits(self, desi_target, bgs_target, mws_target):
         """Remove all the "north" and "south" targeting bits.  See the discussion here


### PR DESCRIPTION
* Use `io.desitarget_resolve_dec` in `mock.mockmaker` to resolve the north-south photometric systems (resolves #500).
* Remove rotted code (resolves #499).
