### PR TITLE
Fix I/O bug on some operating systems when using Python 3.6

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desitarget Change Log
 0.29.2 (unreleased)
 -------------------
 
-* Apply the same declination cut to the mocks as to the data [`PR #501`_]. 
+* Drop Gaia fields with np.rfn to fix Python 3.6/macOS bug [`PR #502`_].
+* Apply the same declination cut to the mocks as to the data [`PR #501`_].
 * Add information to GFA files [`PR #498`_]. Includes:
     * Add columns ``PARALLAX``, ``PARALLAX_IVAR``, ``REF_EPOCH``.
     * Remove ``REF_EPOCH`` from GFA file header, as it's now a column.
@@ -61,6 +62,7 @@ desitarget Change Log
 .. _`PR #497`: https://github.com/desihub/desitarget/pull/497
 .. _`PR #498`: https://github.com/desihub/desitarget/pull/498
 .. _`PR #501`: https://github.com/desihub/desitarget/pull/501
+.. _`PR #502`: https://github.com/desihub/desitarget/pull/502
 
 0.29.1 (2019-03-26)
 -------------------

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -10,6 +10,7 @@ Useful Gaia matching routines, in case Gaia isn't absorbed into the Legacy Surve
 import os
 import sys
 import numpy as np
+import numpy.lib.recfunctions as rfn
 import fitsio
 import requests
 import pickle
@@ -472,33 +473,18 @@ def pop_gaia_coords(inarr):
     :class:`~numpy.ndarray`
         Input array with columns called "GAIA_RA" and/or "GAIA_DEC" removed.
     """
-    # ADM list of the column names of the passed array
-    names = list(inarr.dtype.names)
 
-    # ADM pop off any instances of GAIA_RA, GAIA_DEC be forgiving if they
-    # ADM aren't in the array.
-    try:
-        names.remove("GAIA_RA")
-    except ValueError:
-        pass
-
-    try:
-        names.remove("GAIA_DEC")
-    except ValueError:
-        pass
-
-    # ADM return the array without GAIA_RA, GAIA_DEC
-    return inarr[names]
+    return rfn.drop_fields(inarr, ['GAIA_RA', 'GAIA_DEC'])
 
 
-def pop_gaia_columns(inarr, cols):
+def pop_gaia_columns(inarr, popcols):
     """Convenience function to pop columns of an input array.
 
     Parameters
     ----------
     inarr : :class:`~numpy.ndarray`
         Structured array with various column names.
-    cols : :class:`list`
+    popcols : :class:`list`
         List of columns to remove from the input array.
 
     Returns
@@ -506,19 +492,8 @@ def pop_gaia_columns(inarr, cols):
     :class:`~numpy.ndarray`
         Input array with columns in cols removed.
     """
-    # ADM list of the column names of the passed array
-    names = list(inarr.dtype.names)
 
-    # ADM pop off any instances of GAIA_RA, GAIA_DEC be forgiving if they
-    # ADM aren't in the array.
-    for col in cols:
-        try:
-            names.remove(col)
-        except ValueError:
-            pass
-
-    # ADM return the array without GAIA_RA, GAIA_DEC
-    return inarr[names]
+    return rfn.drop_fields(inarr, popcols)
 
 
 def read_gaia_file(filename, header=False):

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -158,6 +158,7 @@ def read_tractor(filename, header=False, columns=None):
     from desitarget.gaiamatch import gaiadatamodel
     from desitarget.gaiamatch import pop_gaia_coords, pop_gaia_columns
     gaiadatamodel = pop_gaia_coords(gaiadatamodel)
+
     # ADM special handling of the pre-DR7 Data Model.
     for gaiacol in ['GAIA_PHOT_BP_RP_EXCESS_FACTOR',
                     'GAIA_ASTROMETRIC_SIGMA5D_MAX',


### PR DESCRIPTION
This PR fixes an I/O bug resulting from how Gaia fields were being dropped in some rec arrays. The fix was to default to using `numpy.lib.recfunctions` (this will make the custom functions that needed to be fixed slower for large arrays, but the functions in question typically do not operate on large arrays).

The bug was identified by @Cyeche running `select_targets` on his laptop. The bug wasn't affecting Python 3.5 or Python 3.6 at NERSC, but I could recreate it in a custom environment for Python 3.6.8, on my Mac.