### PR TITLE
fix normalization bug in QSO tracer/Lya mock target densities

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,7 @@ desitarget Change Log
 0.30.0 (2019-05-30)
 -------------------
 
+* Fix normalization bug in QSO tracer/Lya mock target densities [`PR #509`_].  
 * Follow-up PR to `PR #496`_ with two changes and bug fixes [`PR #505`_]:
     * Select QSO targets using random forest by default.
     * Bug fix: Correctly populate ``REF_CAT`` column (needed to correctly set
@@ -73,6 +74,7 @@ desitarget Change Log
 .. _`PR #501`: https://github.com/desihub/desitarget/pull/501
 .. _`PR #502`: https://github.com/desihub/desitarget/pull/502
 .. _`PR #505`: https://github.com/desihub/desitarget/pull/505
+.. _`PR #509`: https://github.com/desihub/desitarget/pull/509
 
 0.29.1 (2019-03-26)
 -------------------

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -97,7 +97,7 @@ def initialize_targets_truth(params, healpixels=None, nside=None, output_dir='.'
     return log, healpixseeds
     
 def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
-              nside=None, nside_chunk=128, MakeMock=None):
+              nside=None, nside_chunk=128, MakeMock=None, dndz=None):
     """Read a mock catalog.
     
     Parameters
@@ -118,6 +118,9 @@ def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
     nside_chunk : :class:`int`, optional
         Healpix resolution for chunking the sample to avoid memory problems.
         (NB: nside_chunk must be <= nside).  Defaults to 128.
+    dndz : :class:`dict`, optional
+        Expected redshift distributions for all target classes.  Defaults to
+        None.
             
     Returns
     -------
@@ -180,6 +183,16 @@ def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
         
         data['DENSITY'] = params['density']
         data['DENSITY_FACTOR'] = data['DENSITY'] / data['MOCK_DENSITY']
+
+        # Note: the tracer and Lya QSO target densities are defined relative to
+        # a z=2.1 redshift cut-off which, in general, is different from the
+        # cut-offs defined in the select_mock_targets parameter file (typically
+        # ZMAX_QSO and ZMIN_LYA).  So we need to adjust the desired target
+        # densities here by the appropriate ratio given by the desired redshift
+        # distribution.
+
+        import pdb ; pdb.set_trace()
+        
         if data['DENSITY_FACTOR'] > 1:
             log.warning('Density factor {} should not be > 1!'.format(data['DENSITY_FACTOR']))
             data['DENSITY_FACTOR'] = 1.0
@@ -808,10 +821,12 @@ def targets_truth(params, healpixels=None, nside=None, output_dir='.',
 
     """
     from desitarget.mock import mockmaker
+    from desitarget.QA import _load_dndz
 
     log, healpixseeds = initialize_targets_truth(
         params, verbose=verbose, seed=seed, nside=nside,
         output_dir=output_dir, healpixels=healpixels)
+    dndz = _load_dndz()
 
     # Read (and cache) the MockMaker classes we need.
     log.info('Initializing and caching all MockMaker classes.')
@@ -873,7 +888,7 @@ def targets_truth(params, healpixels=None, nside=None, output_dir='.',
             data, MakeMock = read_mock(params['targets'][target_name], log, target_name,
                                        seed=healseed, healpixels=healpix,
                                        nside=nside, nside_chunk=nside_chunk,
-                                       MakeMock=AllMakeMock[ii])
+                                       MakeMock=AllMakeMock[ii], dndz=dndz)
             
             if not bool(data):
                 continue


### PR DESCRIPTION
Addresses #508.  

Below is the updated distribution from just a couple `nside=32` healpixels, which has the correct/expected shift (more *mock* Lya QSOs relative to *mock* tracer QSOs).

<img width="688" alt="Screen Shot 2019-06-06 at 8 09 47 AM" src="https://user-images.githubusercontent.com/1431820/59031848-cff20d80-8832-11e9-9d51-93e925837e14.png">
