### PR TITLE
Further updates to generating random catalogs for DR8.

### DIFF
--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -54,7 +54,7 @@ ap.add_argument("--dustdir",
 ap.add_argument("--noresolve", action='store_true',
                 help="Do NOT resolve into northern randoms in northern regions and southern randoms in southern regions")
 ap.add_argument("--aprad", type=float,
-                help="Radius of aperture in arcsec in which to generated sky background flux levels (defaults to 0.75; the DESI fiber radius)",
+                help="Radius of aperture in arcsec in which to generate sky background flux levels (defaults to 0.75; the DESI fiber radius)",
                 default=0.75)
 
 
@@ -69,7 +69,7 @@ if not os.path.exists(ns.surveydir):
     sys.exit(1)
 
 if ns.bundlebricks is None:
-    log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc,time()-start))
+    log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-start))
 
 # ADM go looking for a maskbits file to steal the header for the
 # ADM bit names. Try a couple of configurations (pre/post DR8).

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function, division
+import os, sys
 
 from desitarget.skyutilities.legacypipe.util import LegacySurveyData
 from desitarget.skyfibers import select_skies, density_of_sky_fibers, get_brick_info
@@ -60,6 +60,14 @@ ap.add_argument("--numproc", type=int,
                 default=nproc)
 
 ns = ap.parse_args()
+
+if not os.path.exists(ns.surveydir):
+    log.critical('Input directory ({}) does not exist'.format(ns.surveydir))
+    sys.exit(1)
+
+if not os.path.exists(ns.surveydir2) and ns.surveydir2 is not None:
+    log.critical('Input directory ({}) does not exist'.format(ns.surveydir2))
+    sys.exit(1)
 
 # ADM convert passed csv strings to lists.
 bands = [ band for band in ns.bands.split(',') ]

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -32,7 +32,7 @@ ap.add_argument("dest",
 ap.add_argument('-s2', "--surveydir2",
                 help='Additional Legacy Surveys directory (useful for combining, e.g., DR8 into one file of sky locations)',
                 default=None)
-ap.add_argument("--nskiespersqdeg", 
+ap.add_argument("--nskiespersqdeg", type=float,
                 help="Number of sky locations to generate per sq. deg. (don't pass to read the default from desimodel.io with a 4x margin)",
                 default=None)
 ap.add_argument("--bands", 

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -104,6 +104,7 @@ else:
             bands=bands, apertures_arcsec=apertures,
             nside=ns.nside, pixlist=pixlist, writebricks=ns.writebricks)
         )
+
     # ADM redact empty output (where there were no bricks in a survey).
     skies = np.array(skies) 
     ii = [sk is not None for sk in skies]

--- a/bin/split_randoms
+++ b/bin/split_randoms
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import os, sys
+import numpy as np
+import fitsio
+from time import time
+start = time()
+import fitsio
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Split a random catalog into N smaller catalogs. Shuffle the random catalog first to ensure randomness.')
+ap.add_argument("randomcat",
+                help='A random catalog (e.g /project/projectdirs/desi/target/catalogs/randoms-dr4-0.20.0.fits). For an input catalog /X/X.fits N smaller catalogs will be written to /X/X-[1:N].fits')
+ap.add_argument("-n", "--nchunks", type=int,
+                help='Number of smaller catalog to split the random catalog into. Defaults to [10].',
+                default="10")
+
+ns = ap.parse_args()
+
+if not os.path.exists(ns.randomcat):
+    log.critical('Input directory does not exist: {}'.format(ns.randomcat))
+    sys.exit(1)
+
+log.info("Read in randoms from {} and split into {} catalogs...t = {:.1f}s"
+         .format(ns.randomcat, ns.nchunks, time()-start))
+rands, hdr = fitsio.read(ns.randomcat, header=True)
+nrands = len(rands)
+
+# ADM shuffle to ensure randomness.
+log.info("Read in {:.1e} randoms. Shuffling indexes...t = {:.1f}s"
+         .format(nrands, time()-start))
+indexes = np.arange(nrands)
+np.random.seed(626)
+np.random.shuffle(indexes)
+
+#ADM write in chunks to save memory.
+chunk = nrands//ns.nchunks
+# ADM remember that the density has effectively gone down.
+hdr["DENSITY"] //= ns.nchunks
+
+#ADM write out smaller files one-by-one.
+for i in range(ns.nchunks):
+    #ADM open the file for writing.
+    outfile = "{}-{}.fits".format(os.path.splitext(ns.randomcat)[0], i+1)
+    log.info("Writing chunk {} from index {} to {}...t = {:.1f}s"
+             .format(i+1, i*chunk, (i+1)*chunk, time()-start))
+    fitsio.write(outfile, rands[indexes[i*chunk:(i+1)*chunk]], extname='RANDOMS', header=hdr, clobber=True)
+
+print("Done...t = {:.1f}s".format(time()-start))
+
+

--- a/bin/supplement_randoms
+++ b/bin/supplement_randoms
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import os, sys
+import numpy as np
+from time import time
+start = time()
+
+from desitarget import io
+from desitarget.randoms import supplement_randoms
+import fitsio
+
+#import warnings
+#warnings.simplefilter('error')
+
+import multiprocessing
+nproc = multiprocessing.cpu_count() // 2
+# ADM default HEALPix Nside used throughout desitarget.
+# ADM don't confuse this with the ns.nside parallelization input that is parsed below!!!
+nside = io.desitarget_nside()
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Make a random catalog with "zeros" for pixel-level quantities in missing (i.e. outside-of-the-footprint) bricks')
+ap.add_argument("randomcat", 
+                help='An existing "inside-of-the-footprint" random catalog. Must contain at least the column "BRICKNAME" (e.g /project/projectdirs/desi/target/catalogs/randoms-dr4-0.20.0.fits)')
+ap.add_argument("dest", 
+                help='Output file name to write random catalog (e.g. /project/projectdirs/desi/target/catalogs/supp-randoms-dr4-0.20.0.fits)')
+ap.add_argument("--density", type=int,
+                help='Number of points per sq. deg. at which to Monte Carlo the imaging masks (defaults to 10,000)',
+                default="10000")
+ap.add_argument("--numproc", type=int,
+                help='number of concurrent processes to use [{}]'.format(nproc),
+                default=nproc)
+ap.add_argument("--dustdir",
+                help="Directory of SFD dust maps (defaults to the equivalent of $DUST_DIR+'/maps')",
+                default=None)
+
+ns = ap.parse_args()
+
+if not os.path.exists(ns.randomcat):
+    log.critical('Input directory does not exist: {}'.format(ns.surveydir))
+    sys.exit(1)
+    
+log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-start))
+
+# ADM just the filename for the input random catalog.
+rancatfn = os.path.basename(ns.randomcat)
+
+# ADM determine the bricknames that are already covered by the existing random catalog.
+donebns = fitsio.read(ns.randomcat, columns="BRICKNAME")
+
+# ADM make the array of "zerod" bricks.
+randoms = supplement_randoms(
+    donebns, density=ns.density, numproc=ns.numproc, dustdir=ns.dustdir)
+
+# ADM write out the supplemental random catalog.
+io.write_randoms(ns.dest, randoms, indir=ns.surveydir, supp=True,
+                 rancatfn=rancatfn, nside=nside, density=ns.density)
+    
+log.info('wrote file of {} randoms to {}...t = {:.1f}s'
+         .format(len(randoms), ns.dest,time()-start))

--- a/bin/supplement_randoms
+++ b/bin/supplement_randoms
@@ -37,7 +37,7 @@ ap.add_argument("--dustdir",
 ns = ap.parse_args()
 
 if not os.path.exists(ns.randomcat):
-    log.critical('Input directory does not exist: {}'.format(ns.surveydir))
+    log.critical('Input directory does not exist: {}'.format(ns.randomcat))
     sys.exit(1)
 
 log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-start))

--- a/bin/supplement_randoms
+++ b/bin/supplement_randoms
@@ -23,9 +23,9 @@ log = get_logger()
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Make a random catalog with "zeros" for pixel-level quantities in missing (i.e. outside-of-the-footprint) bricks')
-ap.add_argument("randomcat", 
+ap.add_argument("randomcat",
                 help='An existing "inside-of-the-footprint" random catalog. Must contain at least the column "BRICKNAME" (e.g /project/projectdirs/desi/target/catalogs/randoms-dr4-0.20.0.fits)')
-ap.add_argument("dest", 
+ap.add_argument("dest",
                 help='Output file name to write random catalog (e.g. /project/projectdirs/desi/target/catalogs/supp-randoms-dr4-0.20.0.fits)')
 ap.add_argument("--density", type=int,
                 help='Number of points per sq. deg. at which to Monte Carlo the imaging masks (defaults to 10,000)',
@@ -42,7 +42,7 @@ ns = ap.parse_args()
 if not os.path.exists(ns.randomcat):
     log.critical('Input directory does not exist: {}'.format(ns.surveydir))
     sys.exit(1)
-    
+
 log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-start))
 
 # ADM just the filename for the input random catalog.
@@ -58,6 +58,6 @@ randoms = supplement_randoms(
 # ADM write out the supplemental random catalog.
 io.write_randoms(ns.dest, randoms, indir=ns.surveydir, supp=True,
                  rancatfn=rancatfn, nside=nside, density=ns.density)
-    
+
 log.info('wrote file of {} randoms to {}...t = {:.1f}s'
          .format(len(randoms), ns.dest,time()-start))

--- a/bin/supplement_randoms
+++ b/bin/supplement_randoms
@@ -14,9 +14,6 @@ import fitsio
 
 import multiprocessing
 nproc = multiprocessing.cpu_count() // 2
-# ADM default HEALPix Nside used throughout desitarget.
-# ADM don't confuse this with the ns.nside parallelization input that is parsed below!!!
-nside = io.desitarget_nside()
 
 from desiutil.log import get_logger
 log = get_logger()
@@ -56,8 +53,8 @@ randoms = supplement_randoms(
     donebns, density=ns.density, numproc=ns.numproc, dustdir=ns.dustdir)
 
 # ADM write out the supplemental random catalog.
-io.write_randoms(ns.dest, randoms, indir=ns.surveydir, supp=True,
-                 rancatfn=rancatfn, nside=nside, density=ns.density)
+io.write_randoms(ns.dest, randoms, indir=ns.randomcat, supp=True,
+                 density=ns.density)
 
 log.info('wrote file of {} randoms to {}...t = {:.1f}s'
          .format(len(randoms), ns.dest,time()-start))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,8 +7,9 @@ desitarget Change Log
 
 * Further updates to generating randoms for DR8. [`PR #512`_]. Includes:
     * Add WISE depth maps to random catalogs and pixweight files.
-    * Executable to generate additional files of supplemental randoms.
-        * "Supplemental" randoms fill the sky outside of the footprint.
+    * Code to generate additional supplemental randoms catalogs.
+        * Supplemental, here, means (all-sky) outside of the footprint.
+    * Executable to split a random catalog into N smaller catalogs.
     * Fixes a bug in :func:`targets.main_cmx_or_sv()`.
         * Secondary columns now aren't the default if rename is ``True``.
     * Better aligns data model with expected DR8 directory structure.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,14 @@ desitarget Change Log
 0.30.2 (unreleased)
 -------------------
 
+* Further updates to generating randoms for DR8. [`PR #512`_]. Includes:
+    * Add WISE depth maps to random catalogs and pixweight files.
+    * Executable to generate additional files of supplemental randoms.
+        * "Supplemental" randoms fill the sky outside of the footprint.
+    * Fixes a bug in :func:`targets.main_cmx_or_sv()`.
+        * Secondary columns now aren't the default if rename is ``True``.
+    * Better aligns data model with expected DR8 directory structure.
+        * Also fixes directory-not-found bugs when generating skies.
 * First implementation for secondary targets [`PR #507`_]. Includes:
     * Framework and design for secondary targeting process.
     * Works automatically for both Main Survey and SV files.
@@ -24,6 +32,7 @@ desitarget Change Log
         * ``TARGETID`` and ``SCND_TARGET`` correspond for matches.
 
 .. _`PR #507`: https://github.com/desihub/desitarget/pull/507
+.. _`PR #512`: https://github.com/desihub/desitarget/pull/512
 
 0.30.1 (2019-06-18)
 -------------------

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -687,7 +687,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     if prefix == 'skies':
         margin = 5
     if prefix == 'randoms':
-        margin = 75
+        margin = 90
     margin /= 60.
 
     maxeta = 0

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -686,6 +686,8 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     margin = 30
     if prefix == 'skies':
         margin = 5
+    if prefix == 'randoms':
+        margin = 75
     margin /= 60.
 
     maxeta = 0

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -557,7 +557,7 @@ def write_gfas(filename, data, indir=None, indir2=None, nside=None,
 
 
 def write_randoms(filename, data, indir=None, hdr=None, nside=None, supp=False,
-                  rancatfn=None, density=None, resolve=True, aprad=None):
+                  density=None, resolve=True, aprad=None):
     """Write a catalogue of randoms and associated pixel-level information.
 
     Parameters
@@ -578,9 +578,6 @@ def write_randoms(filename, data, indir=None, hdr=None, nside=None, supp=False,
         Written to the header of the output file to indicate whether
         this is a supplemental file (i.e. random locations that are
         outside the Legacy Surveys footprint).
-    rancatfn : :class:`book`, optional
-        File name of the random catalog that is being "supplemented". Only
-        written to the output file header if `supp` is True.
     density: :class:`int`
         Number of points per sq. deg. at which the catalog was generated,
         write to header of the output file if not None.
@@ -597,12 +594,15 @@ def write_randoms(filename, data, indir=None, hdr=None, nside=None, supp=False,
     depend.setdep(hdr, 'desitarget-git', gitversion())
 
     if indir is not None:
-        depend.setdep(hdr, 'input-data-release', indir)
-        # ADM note that if 'dr' is not in the indir DR
-        # ADM directory structure, garbage will
-        # ADM be rewritten gracefully in the header.
-        drstring = 'dr'+indir.split('dr')[-1][0]
-        depend.setdep(hdr, 'photcat', drstring)
+        if supp:
+            depend.setdep(hdr, 'input-random-catalog', indir)
+        else:
+            depend.setdep(hdr, 'input-data-release', indir)
+            # ADM note that if 'dr' is not in the indir DR
+            # ADM directory structure, garbage will
+            # ADM be rewritten gracefully in the header.
+            drstring = 'dr'+indir.split('dr')[-1][0]
+            depend.setdep(hdr, 'photcat', drstring)
 
     # ADM add HEALPix column, if requested by input.
     if nside is not None:
@@ -614,8 +614,6 @@ def write_randoms(filename, data, indir=None, hdr=None, nside=None, supp=False,
 
     # ADM note if this is a supplemental (outside-of-footprint) file.
     hdr['SUPP'] = supp
-    if supp:
-        hdr['RANCATFN'] = rancatfn
 
     # ADM add density of points if requested by input.
     if density is not None:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -556,8 +556,8 @@ def write_gfas(filename, data, indir=None, indir2=None, nside=None,
     fitsio.write(filename, data, extname='GFA_TARGETS', header=hdr, clobber=True)
 
 
-def write_randoms(filename, data, indir=None, hdr=None, nside=None,
-                  density=None, resolve=True, aprad=None):
+def write_randoms(filename, data, indir=None, hdr=None, nside=None, supp=False,
+                  rcfn=None, density=None, resolve=True, aprad=None):
     """Write a catalogue of randoms and associated pixel-level information.
 
     Parameters
@@ -574,6 +574,13 @@ def write_randoms(filename, data, indir=None, hdr=None, nside=None,
     nside: :class:`int`
         If passed, add a column to the randoms array popluated with HEALPixels
         at resolution `nside`.
+    supp : :class:`bool`, optional, defaults to ``False``
+        Written to the header of the output file to indicate whether
+        this is a supplemental file (i.e. random locations that are
+        outside the Legacy Surveys footprint).
+    rancatfn : :class:`book`, optional
+        File name of the random catalog that is being "supplemented". Only
+        written to the output file header if `supp` is True.
     density: :class:`int`
         Number of points per sq. deg. at which the catalog was generated,
         write to header of the output file if not None.
@@ -604,6 +611,11 @@ def write_randoms(filename, data, indir=None, hdr=None, nside=None,
         data = rfn.append_fields(data, 'HPXPIXEL', hppix, usemask=False)
         hdr['HPXNSIDE'] = nside
         hdr['HPXNEST'] = True
+
+    # ADM note if this is a supplemental (outside-of-footprint) file.
+    hdr['SUPP'] = supp
+    if supp:
+        hdr['RANCATFN'] = rancatfn
 
     # ADM add density of points if requested by input.
     if density is not None:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -557,7 +557,7 @@ def write_gfas(filename, data, indir=None, indir2=None, nside=None,
 
 
 def write_randoms(filename, data, indir=None, hdr=None, nside=None, supp=False,
-                  rcfn=None, density=None, resolve=True, aprad=None):
+                  rancatfn=None, density=None, resolve=True, aprad=None):
     """Write a catalogue of randoms and associated pixel-level information.
 
     Parameters

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -322,7 +322,7 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
                 # ADM get the quantity of interest at each location and
                 # ADM store in a dictionary with the filter and quantity.
                 if qout == 'apflux':
-                    # ADM special treatment to photometer sky. 
+                    # ADM special treatment to photometer sky.
                     # ADM Read in the ivar image.
                     fnivar = fileform.format(brickname, 'invvar', filt, extn)
                     ivar = fits.open(fnivar)[extn_nb].data
@@ -410,7 +410,7 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
                 # decam-chatter mailing list on 06/20/19, 1:59PM MST:
                 # psfdepth_Wx_AB = invvar_Wx * norm_Wx**2 / fluxfactor_Wx**2
                 # where fluxfactor = 10.** (dm / -2.5), dm = vega_to_ab[band]
-                ff = 10.** (vega_to_ab[band] / -2.5)
+                ff = 10.**(vega_to_ab[band] / -2.5)
                 # ADM store in a dictionary with the band and quantity.
                 qdict[qout+'_'+band] = ivar * norm[band]**2 / ff**2
             # ADM if the file doesn't exist, set quantities to zero.
@@ -817,7 +817,7 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
         Catalog or file of randoms as made by :func:`select_randoms()` or
         :func:`quantities_at_positions_in_a_brick()`.
     targets : :class:`~numpy.ndarray` or `str`
-        Corresponding (i.e. same Data Release) catalog or file of targets 
+        Corresponding (i.e. same Data Release) catalog or file of targets
         as made by, e.g., :func:`desitarget.cuts.select_targets()`, or
         the the name of a directory containing HEALPix-split targets that
         can be read by :func:`desitarget.io.read_targets_in_box()`.

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -218,23 +218,24 @@ def _pre_or_post_dr8(drdir):
 
 def dr8_quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
                                            aprad=0.75):
-    """Wrapper on `quantities_at_positions_in_a_brick` for DR8 imaging and beyond.
+    """Wrap `quantities_at_positions_in_a_brick` for DR8 and beyond.
 
     Notes
     -----
-        - See :func:`~desitarget.randoms.quantities_at_positions_in_a_brick`
-          for details. This function detects whether we have TWO coadd directories
-          in the `drdir` (e.g. one for DECaLS and one for MzLS/BASS) and, if so,
-          creates randoms for both surveys within the the passed brick. If not, it
-          defaults to the behavior for only having one survey.
+    - See :func:`~desitarget.randoms.quantities_at_positions_in_a_brick`
+      for details. This wrapper looks for TWO coadd directories in
+      `drdir` (one for DECaLS, one for MzLS/BASS) and, if it finds two,
+      creates randoms for both surveys within the the passed brick. The
+      wrapper also defaults to the behavior for only having one survey.
     """
-    # ADM determine whether we have to traverse two sets of brick directories.
+    # ADM determine if we must traverse two sets of brick directories.
     drdirs = _pre_or_post_dr8(drdir)
 
-    # ADM determine the dictionary of quantities for one or two directories.
+    # ADM make the dictionary of quantities for one or two directories.
     qall = []
     for dd in drdirs:
-        q = quantities_at_positions_in_a_brick(ras, decs, brickname, dd, aprad=aprad)
+        q = quantities_at_positions_in_a_brick(ras, decs, brickname, dd,
+                                               aprad=aprad)
         # ADM don't count bricks where we never read a file header.
         if q is not None:
             qall.append(q)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -247,8 +247,12 @@ def dr8_quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
 
     # ADM concatenate everything in qall into one dictionary.
     qcombine = {}
-    for k in qall[0].keys():
-        qcombine[k] = np.concatenate([q[k] for q in qall])
+    # ADM catch the case where a coadd directory is completely missing.
+    if len(qall) == 0:
+        log.warning("missing brick: {}".format(brickname))
+    else:
+        for k in qall[0].keys():
+            qcombine[k] = np.concatenate([q[k] for q in qall])
 
     return qcombine
 
@@ -592,11 +596,13 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
         qdict = dr8_quantities_at_positions_in_a_brick(ras, decs, brickname,
                                                        drdir, aprad=aprad)
 
-        # ADM if 2 different camera combinations overlapped a brick
-        # ADM then we need to duplicate the ras, decs as well.
-        if len(qdict['photsys']) == 2*len(ras):
-            ras = np.concatenate([ras, ras])
-            decs = np.concatenate([decs, decs])
+        # ADM catch the case where a coadd directory is completely missing.
+        if len(qdict) > 0:
+            # ADM if 2 different camera combinations overlapped a brick
+            # ADM then we need to duplicate the ras, decs as well.
+            if len(qdict['photsys']) == 2*len(ras):
+                ras = np.concatenate([ras, ras])
+                decs = np.concatenate([decs, decs])
 
         # ADM the structured array to output.
         qinfo = np.zeros(
@@ -625,11 +631,13 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
 
     # ADM we only looked up pixel-level quantities if zeros wasn't sent.
     if not zeros:
-        # ADM store each quantity of interest in the structured array
-        # ADM remembering that the dictionary keys are lower-case text.
-        cols = qdict.keys()
-        for col in cols:
-            qinfo[col.upper()] = qdict[col]
+        # ADM catch the case where a coadd directory was missing.
+        if len(qdict) > 0:
+            # ADM store each quantity of interest in the structured array
+            # ADM remembering that the dictionary keys are lower-case text.
+            cols = qdict.keys()
+            for col in cols:
+                qinfo[col.upper()] = qdict[col]
 
     # ADM add the RAs/Decs and brick name.
     qinfo["RA"], qinfo["DEC"], qinfo["BRICKNAME"] = ras, decs, brickname

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -837,28 +837,30 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
     :class:`~numpy.ndarray`
         An array of useful information that includes
             - HPXPIXEL: HEALPixel integers at the passed `nside`.
-            - FRACAREA: Fraction of the pixel with at least one observation in any
-                        band according to `randoms`. Made with :func:`pixweight()`.
-            - STARDENS: The stellar density in a pixel from Gaia. Made with
-                        :func:`stellar_density()`.
-            - EBV: The E(B-V) in the pixel from the SFD dust map, derived from the
-                   median of EBV values in the passed random catalog.
-            - PSFDEPTH_G, R, Z: The PSF depth in g, r, z-band in the pixel, derived from
-                                the median of PSFDEPTH values in the passed random catalog.
-            - GALDEPTH_G, R, Z: The galaxy depth in g, r, z-band in the pixel, derived from
-                                the median of GALDEPTH values in the passed random catalog.
-            - PSFDEPTH_W1, W2: (PSF) depth in W1, W2 (AB mag system) in the pixel, derived
-                               from the median of PSFDEPTH values in the passed random catalog..
-            - PSFSIZE_G, R, Z: Weighted average PSF FWHM, in arcsec, in g, r, z in the pixel,
-                               from the median of PSFSIZE values in the passed random catalog.
-            - One column for every bit returned by :func:`desitarget.QA._load_targdens()`.
-              Each column contains the density of targets in pixels at the passed `nside`
+            - FRACAREA: Fraction of pixel with at least one observation
+                        in any band. Made with :func:`pixweight()`.
+            - STARDENS: The stellar density in a pixel from Gaia. Made
+                        with :func:`stellar_density()`.
+            - EBV: E(B-V) in pixel from the SFD dust map, from the
+                   median of EBV values in the passed `randoms`.
+            - PSFDEPTH_G, R, Z: PSF depth in the pixel, from the median
+                                of PSFDEPTH values in `randoms`.
+            - GALDEPTH_G, R, Z: Galaxy depth in the pixel, from the
+                                median of GALDEPTH values in `randoms`.
+            - PSFDEPTH_W1, W2: (AB PSF) depth in the pixel, from the
+                               median of values in the passed `randoms`.
+            - PSFSIZE_G, R, Z: Weighted average PSF FWHM, in arcsec, in
+                               the pixel, from the median of PSFSIZE
+                               values in the passed random catalog.
+            - One column for every bit that is returned by
+              :func:`desitarget.QA._load_targdens()`. Each column
+              contains the target density in the pixel.
     :class:`str`
-        The type of survey to which `targets` corresponds, e.g., 'main', 'sv1', etc.
+        Survey to which `targets` corresponds, e.g., 'main', 'sv1', etc.
 
     Notes
     -----
-        - If `gaialoc` is ``None`` then the environment variable $GAIA_DIR must be set.
+        - If `gaialoc` is ``None`` then $GAIA_DIR must be set.
     """
     # ADM if a file name was passed for the random catalog, read it in
     if isinstance(randoms, str):

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1196,8 +1196,9 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
         log.info('Running on Node {}'.format(os.getenv('SLURMD_NODENAME')))
 
     # ADM recover the pixel-level quantities in the DR bricks.
-    qinfo = select_randoms_bricks(brickdict, bricknames, drdir, numproc=numproc,
-                                  density=density, dustdir=dustdir, aprad=aprad)
+    qinfo = select_randoms_bricks(brickdict, bricknames, numproc=numproc,
+                                  drdir=drdir, density=density, dustdir=dustdir,
+                                  aprad=aprad)
     # ADM remove bricks that overlap between two surveys, if requested.
     if resolverands:
         qinfo = resolve(qinfo)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -995,13 +995,9 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
     :class:`~numpy.ndarray`
         a numpy structured array with the same columns as returned by
         :func:`~desitarget.randoms.get_quantities_in_a_brick`.
-
     """
-    # ADM grab brick information for this data release. Depending on whether this
-    # ADM is pre-or-post-DR8 we need to find the correct directory or directories.
-    drdirs = _pre_or_post_dr8(drdir)
-    brickdict = get_brick_info(drdirs, counts=True)
-    # ADM this is just the UNIQUE brick names across all surveys.
+    # ADM retrieve the table of all bricks as a dictionary.
+    brickdict = get_brick_info(drdirs, allbricks=True)
     bricknames = np.array(list(brickdict.keys()))
 
     # ADM if the pixlist or bundlebricks option was sent, we'll need the HEALPixel

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1017,8 +1017,8 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
     # ADM this is just to count bricks in _update_status.
     nbrick = np.zeros((), dtype='i8')
     t0 = time()
-    # ADM determine how often to write a message.
-    interval = nbricks // 100
+    # ADM write a total of 25 output messages during processing.
+    interval = nbricks // 25
 
     def _update_status(result):
         ''' wrapper function for the critical reduction operation,
@@ -1054,8 +1054,7 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
     return qinfo
 
 
-def supplement_randoms(donebns, density=10000, numproc=32,
-                       dustdir=None, aprad=0.75):
+def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None):
     """Random catalogs of "zeros" for missing bricks.
 
     Parameters
@@ -1063,6 +1062,7 @@ def supplement_randoms(donebns, density=10000, numproc=32,
     donebns : :class:`~numpy.ndarray`
         Names of bricks that have been "completed". Bricks NOT in
         `donebns` will be returned without any pixel-level quantities.
+        Need not be a unique set (bricks can be repeated in `donebns`).
     density : :class:`int`, optional, defaults to 10,000
         Number of random points per sq. deg. A typical brick is ~0.25 x
         0.25 sq. deg. so ~(0.0625*density) points will be returned.
@@ -1077,7 +1077,7 @@ def supplement_randoms(donebns, density=10000, numproc=32,
     Notes
     -----
     - See :func:`~desitarget.randoms.select_randoms` for definitions of
-      `dustdir`, `aprad`.
+      `numproc`, `dustdir`.
     """
     # ADM find the missing bricks.
     brickdict = get_brick_info(None, allbricks=True)
@@ -1087,7 +1087,7 @@ def supplement_randoms(donebns, density=10000, numproc=32,
 
     qzeros = select_randoms_bricks(brickdict, bricknames, numproc=numproc,
                                    zeros=True, cnts=False, density=density,
-                                   dustdir=dustdir, aprad=aprad)
+                                   dustdir=dustdir)
 
     return qzeros
 
@@ -1127,9 +1127,8 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
         a chosen number of nodes). Used in conjunction with `bundlebricks` for the code
         to estimate time to completion when parallelizing across pixels.
     dustdir : :class:`str`, optional, defaults to $DUST_DIR+'maps'
-        The root directory pointing to SFD dust maps. If not
-        sent the code will try to use $DUST_DIR+'maps')
-        before failing.
+        The root directory pointing to SFD dust maps. If None the code
+        will try to use $DUST_DIR+'maps') before failing.
     resolverands : :class:`boolean`, optional, defaults to ``True``
         If ``True``, resolve randoms into northern randoms in northern regions
         and southern randoms in southern regions.

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -809,35 +809,35 @@ def get_targ_dens(targets, Mx, nside=256):
 
 
 def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
-    """A HEALPixel map of useful quantities for analyzing a Legacy Surveys Data Release
+    """HEALPix map of useful quantities for a Legacy Surveys Data Release
 
     Parameters
     ----------
     randoms : :class:`~numpy.ndarray` or `str`
-        A random catalog as made by, e.g., :func:`select_randoms()` or
-        :func:`quantities_at_positions_in_a_brick()`, or the name of such a file.
+        Catalog or file of randoms as made by :func:`select_randoms()` or
+        :func:`quantities_at_positions_in_a_brick()`.
     targets : :class:`~numpy.ndarray` or `str`
-        A corresponding (i.e. same Data Release) target catalog as made by, e.g.,
-        :func:`desitarget.cuts.select_targets()`, or a file name of such targets,
-        or the name of a directory containing HEALPixel-split targets that can
-        be read by :func:`desitarget.io.read_targets_in_box()`.
+        Corresponding (i.e. same Data Release) catalog or file of targets 
+        as made by, e.g., :func:`desitarget.cuts.select_targets()`, or
+        the the name of a directory containing HEALPix-split targets that
+        can be read by :func:`desitarget.io.read_targets_in_box()`.
     rand_density : :class:`int`
-        The number of random points per sq. deg. At which the random catalog was
-        generated (see also :func:`select_randoms()`).
-    nside : :class:`int`, optional, defaults to nside=256 (~0.0525 sq. deg. or "brick-sized")
-        The resolution (HEALPixel nside number) at which to build the map (NESTED scheme).
+        Number of random points per sq. deg. at which the random catalog
+        was generated (see also :func:`select_randoms()`).
+    nside : :class:`int`, optional, defaults to nside=256
+        Resolution (HEALPix nside) at which to build the (NESTED) map.
+        The default corresponds to ~0.0525 sq. deg. (or "brick-sized")
     gaialoc : :class:`str`, optional, defaults to ``None``
-        If a file is passed it is assumed to be a FITS file that already contains the
-        column "STARDENS", which is simply read in. Otherwise, the stellar density is
-        constructed from the files stored in the default location indicated by the
-        $GAIA_DIR environment variable.
+        Name of a FITS file that already contains a column "STARDENS",
+        which is simply read in. If ``None``, the stellar density is
+        constructed from files in $GAIA_DIR.
 
     Returns
     -------
     :class:`~numpy.ndarray`
         An array of useful information that includes
             - HPXPIXEL: HEALPixel integers at the passed `nside`.
-            - FRACAREA: The fraction of the pixel with at least one observation in any
+            - FRACAREA: Fraction of the pixel with at least one observation in any
                         band according to `randoms`. Made with :func:`pixweight()`.
             - STARDENS: The stellar density in a pixel from Gaia. Made with
                         :func:`stellar_density()`.

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -58,6 +58,7 @@ def get_brick_info(drdirs, counts=False, allbricks=False):
         A list of strings, each of which corresponds to a directory pointing
         to a Data Release from the Legacy Surveys. Can be of length one.
         e.g. ['/global/project/projectdirs/cosmo/data/legacysurvey/dr7'].
+        Can be None if `allbricks` is passed.
     counts : :class:`bool`, optional, defaults to ``False``
         If ``True`` also return a count of the number of times each brick
         appears ([RAcen, DECcen, RAmin, RAmax, DECmin, DECmax, CNT]).

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -49,7 +49,7 @@ skydatamodel = np.array([], dtype=[
     ('OBSCONDITIONS', '>i4')])
 
 
-def get_brick_info(drdirs, counts=False):
+def get_brick_info(drdirs, counts=False, allbricks=False):
     """Retrieve brick names and coordinates from Legacy Surveys directories.
 
     Parameters
@@ -61,6 +61,9 @@ def get_brick_info(drdirs, counts=False):
     counts : :class:`bool`, optional, defaults to ``False``
         If ``True`` also return a count of the number of times each brick
         appears ([RAcen, DECcen, RAmin, RAmax, DECmin, DECmax, CNT]).
+    allbricks : :class:`bool`, optional, defaults to ``False``
+        If ``True`` ignore `drdirs` and simply return a dictionary of ALL
+        of the bricks.
 
     Returns
     -------
@@ -74,6 +77,20 @@ def get_brick_info(drdirs, counts=False):
         - Tries a few different ways in case the survey bricks files have
           not ywt been created.
     """
+    # ADM initialize the bricks class, retrieve the brick information look-up
+    # ADM table and turn it into a fast look-up dictionary.
+    from desiutil import brick
+    bricktable = brick.Bricks(bricksize=0.25).to_table()
+    brickdict = {}
+    for b in bricktable:
+        brickdict[b["BRICKNAME"]] = [b["RA"], b["DEC"],
+                                     b["RA1"], b["RA2"],
+                                     b["DEC1"], b["DEC2"]]
+
+    # ADM if requested, return the dictionary of ALL bricks.
+    if allbricks:
+        return brickdict
+
     bricknames = []
     for dd in drdirs:
         # ADM in the simplest case, read in the survey bricks file, which lists
@@ -90,16 +107,6 @@ def get_brick_info(drdirs, counts=False):
 
     # ADM don't count bricks twice, but record number of duplicate bricks.
     bricknames, cnts = np.unique(np.concatenate(bricknames), return_counts=True)
-
-    # ADM initialize the bricks class, retrieve the brick information look-up
-    # ADM table and turn it into a fast look-up dictionary.
-    from desiutil import brick
-    bricktable = brick.Bricks(bricksize=0.25).to_table()
-    brickdict = {}
-    for b in bricktable:
-        brickdict[b["BRICKNAME"]] = [b["RA"], b["DEC"],
-                                     b["RA1"], b["RA2"],
-                                     b["DEC1"], b["DEC2"]]
 
     # ADM only return the subset of the dictionary with bricks in the DR.
     if counts:

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -787,10 +787,10 @@ def select_skies(survey, numproc=16, nskiespersqdeg=None, bands=['g', 'r', 'z'],
         bricknames = bricknames[ii]
         # ADM if there are no bricks to process, then die immediately.
         if len(bricknames) == 0:
-            log.warning('ZERO bricks in passed pixels (nside={}, pixels={}))!!!'
-                        .format(nside, pixlist))
+            log.warning('NO bricks found (nside={}, HEALPixels={}, DRdir={})!'
+                        .format(nside, pixlist, survey.survey_dir))
             return
-        log.info("Processing bricks in (nside={}, pixel numbers={}) HEALPixels"
+        log.info("Processing bricks (nside={}, HEALPixels={})"
                  .format(nside, pixlist))
     nbricks = len(bricknames)
     log.info('Processing {} bricks that have observations from DR at {}...t = {:.1f}s'

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -787,11 +787,11 @@ def select_skies(survey, numproc=16, nskiespersqdeg=None, bands=['g', 'r', 'z'],
         bricknames = bricknames[ii]
         # ADM if there are no bricks to process, then die immediately.
         if len(bricknames) == 0:
-            log.warning('ZERO bricks in passed pixel list!!!')
+            log.warning('ZERO bricks in passed pixels (nside={}, pixels={}))!!!'
+                        .format(nside, pixlist))
             return
         log.info("Processing bricks in (nside={}, pixel numbers={}) HEALPixels"
                  .format(nside, pixlist))
-
     nbricks = len(bricknames)
     log.info('Processing {} bricks that have observations from DR at {}...t = {:.1f}s'
              .format(nbricks, survey.survey_dir, time()-start))
@@ -818,8 +818,10 @@ def select_skies(survey, numproc=16, nskiespersqdeg=None, bands=['g', 'r', 'z'],
         """wrapper function for the critical reduction operation,
         that occurs on the main parallel process"""
         if nbrick % 500 == 0 and nbrick > 0:
-            rate = nbrick / (time() - t0)
-            log.info('{}/{} bricks; {:.1f} bricks/sec'.format(nbrick, nbricks, rate))
+            elapsed = time() - t0
+            rate = nbrick / elapsed
+            log.info('{}/{} bricks; {:.1f} bricks/sec; {:.1f} total mins elapsed'
+                     .format(nbrick, nbricks, rate, elapsed/60.))
 
         nbrick[...] += 1    # this is an in-place modification
         return result
@@ -835,7 +837,7 @@ def select_skies(survey, numproc=16, nskiespersqdeg=None, bands=['g', 'r', 'z'],
             skies.append(_update_status(_get_skies(brickname)))
 
     # ADM some missing blobs may have contaminated the array.
-    skies = [i for i in skies if i is not None]
+    skies = [sk for sk in skies if sk is not None]
     # ADM Concatenate the parallelized results into one rec array of sky information
     skies = np.concatenate(skies)
 

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -378,7 +378,7 @@ def sky_fibers_for_brick(survey, brickname, nskies=144, bands=['g', 'r', 'z'],
     fn = survey.find_file('blobmap', brick=brickname)
     # ADM if the file doesn't exist, warn and return immediately.
     if not os.path.exists(fn):
-        log.warning('blobmap {} does not exist!!!'.format{fn})
+        log.warning('blobmap {} does not exist!!!'.format(fn))
         return None
     blobs = fitsio.read(fn)
     # log.info('Blob maximum value and minimum value in brick {}: {} {}'

--- a/py/desitarget/skyutilities/legacypipe/util.py
+++ b/py/desitarget/skyutilities/legacypipe/util.py
@@ -204,6 +204,7 @@ class LegacySurveyData(object):
             basedir = self.survey_dir
             # ADM if you can't find the file, it's one
             # ADM directory up. Assuming this is dr8+.
+            basedir = basedir.rstrip('/')
             check = os.path.basename(os.path.dirname(basedir))
             if check[:2] == 'dr' and int(check[-1]) >= 8:
                 truebasedir = os.path.dirname(basedir)

--- a/py/desitarget/skyutilities/legacypipe/util.py
+++ b/py/desitarget/skyutilities/legacypipe/util.py
@@ -208,6 +208,8 @@ class LegacySurveyData(object):
             check = os.path.basename(os.path.dirname(basedir))
             if check[:2] == 'dr' and int(check[-1]) >= 8:
                 truebasedir = os.path.dirname(basedir)
+            else:
+                truebasedir = basedir
 
         if brick is not None:
             codir = os.path.join(basedir, 'coadd', brickpre, brick)

--- a/py/desitarget/skyutilities/legacypipe/util.py
+++ b/py/desitarget/skyutilities/legacypipe/util.py
@@ -202,6 +202,11 @@ class LegacySurveyData(object):
             basedir = self.output_dir
         else:
             basedir = self.survey_dir
+            # ADM if you can't find the file, it's one
+            # ADM directory up. Assuming this is dr8+.
+            check = os.path.basename(os.path.dirname(basedir))
+            if check[:2] == 'dr' and int(check[-1]) >= 8:
+                truebasedir = os.path.dirname(basedir)
 
         if brick is not None:
             codir = os.path.join(basedir, 'coadd', brickpre, brick)
@@ -220,20 +225,18 @@ class LegacySurveyData(object):
 
         if filetype == 'bricks':
             fn = 'survey-bricks.fits.gz'
-            if self.version in ['dr1','dr2']:
-                fn = 'decals-bricks.fits'
-            return swap(os.path.join(basedir, fn))
+            return swap(os.path.join(truebasedir, fn))
 
         elif filetype == 'ccds':
             if self.version in ['dr1','dr2']:
                 return swaplist([os.path.join(basedir, 'decals-ccds.fits.gz')])
             else:
                 return swaplist(
-                    glob(os.path.join(basedir, 'survey-ccds-*.fits.gz')))
+                    glob(os.path.join(truebasedir, 'survey-ccds-*.fits.gz')))
 
         elif filetype == 'ccd-kds':
             return swaplist(
-                glob(os.path.join(basedir, 'survey-ccds-*.kd.fits')))
+                glob(os.path.join(truebasedir, 'survey-ccds-*.kd.fits')))
 
         elif filetype == 'tycho2':
             return swap(os.path.join(basedir, 'tycho2.fits.gz'))
@@ -243,7 +246,7 @@ class LegacySurveyData(object):
                 return swaplist(
                     glob(os.path.join(basedir, 'decals-ccds-annotated.fits')))
             return swaplist(
-                glob(os.path.join(basedir, 'ccds-annotated-*.fits.gz')))
+                glob(os.path.join(truebasedir, 'ccds-annotated-*.fits.gz')))
 
         elif filetype == 'tractor':
             return swap(os.path.join(basedir, 'tractor', brickpre,

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -349,16 +349,16 @@ def main_cmx_or_sv(targets, rename=False, scnd=False):
         log.critical(msg)
         raise ValueError(msg)
 
+    if not scnd:
+        outcolnames = outcolnames[:3]
+        masks = masks[:3]
+
     # ADM if requested, rename the columns.
     if rename:
         mapper = {}
         for i, col in enumerate(outcolnames):
             mapper[col] = maincolnames[i]
         return outcolnames, masks, survey, rfn.rename_fields(targets, mapper)
-
-    if not scnd:
-        outcolnames = outcolnames[:3]
-        masks = masks[:3]
 
     return outcolnames, masks, survey
 

--- a/py/desitarget/test/test_skyfibers.py
+++ b/py/desitarget/test/test_skyfibers.py
@@ -19,16 +19,16 @@ class TestSKYFIBERS(unittest.TestCase):
 
     @classmethod
     def setUp(self):
-        # ADM location of input test survey directory structure
+        # ADM location of input test survey directory structure.
         self.sd = resource_filename('desitarget.test', 'dr6')
 
-        # ADM create the survey object
+        # ADM create the survey object.
         self.survey = LegacySurveyData(self.sd)
 
-        # ADM determine which bricks we can access in the test directory
+        # ADM determine which bricks we can access in the test directory.
         brickdirs = glob("{}/coadd/*/*".format(self.survey.survey_dir))
         bricknames = [basename(brickdir) for brickdir in brickdirs]
-        # ADM just test with one brick
+        # ADM just test with one brick.
         self.brickname = bricknames[0]
 
         if self.brickname != '0959p805':
@@ -37,14 +37,14 @@ class TestSKYFIBERS(unittest.TestCase):
             print("images and is relatively small")
             raise ValueError
 
-        # ADM generate a handful (~4) sky locations
+        # ADM generate a handful (~4) sky locations.
         brickarea = 0.25*0.25
         self.nskies = 4
         # ADM as the code ensures a minimum number of skies is
-        # ADM generated, we need to pass 3.9999 not 4
+        # ADM generated, we need to pass 3.9999 not 4.
         self.nskiespersqdeg = int((self.nskies-1e-6)/brickarea)
 
-        # ADM extract flux in 1 and 2" apertures
+        # ADM extract flux in 1 and 2" apertures.
         self.ap_arcsec = [1., 2.]
 
     def test_survey_object(self):
@@ -63,7 +63,7 @@ class TestSKYFIBERS(unittest.TestCase):
         lo = skyfibers.density_of_sky_fibers(1)
 
         # ADM check that margin behaves correctly (with 10x as much margin)
-        # ADM we should always have 10 times as many fibers
+        # ADM we should always have 10 times as many fibers.
         self.assertTrue(modelhi/modello == 10)
         self.assertTrue(hi/lo == 5)
 
@@ -71,29 +71,29 @@ class TestSKYFIBERS(unittest.TestCase):
         """
         Test the production of a few sky locations from a survey object
         """
-        # ADM generate the skies as a structured array
+        # ADM generate the skies as a structured array.
         skies = skyfibers.make_skies_for_a_brick(self.survey, self.brickname,
                                                  nskiespersqdeg=self.nskiespersqdeg,
                                                  apertures_arcsec=self.ap_arcsec)
 
-        # ADM check the brick name information is generated correctly
-        # ADM remember the default for target output strings is bytes
+        # ADM check the brick name information is generated correctly.
+        # ADM remember the default for target output strings is bytes.
         self.assertTrue(np.all(
             skies["BRICKNAME"] == np.array(self.brickname).astype('S'))
         )
 
         # ADM check we've stored the correct information give the numbers of
-        # ADM skies requested and the length of the apertures
+        # ADM skies requested and the length of the apertures.
         self.assertTrue(
             skies["APFLUX_R"].shape == (self.nskies, len(self.ap_arcsec))
         )
 
-        # ADM generate the associated sky table
+        # ADM generate the associated sky table.
         skytable = skyfibers.sky_fibers_for_brick(self.survey, self.brickname,
                                                   nskies=self.nskies,
                                                   apertures_arcsec=self.ap_arcsec)
 
-        # ADM check some of the outputs are the same for the table and FITS
+        # ADM check some of the outputs are the same for the table and FITS.
         self.assertTrue(
             np.all(skies["APFLUX_G"] == skytable.apflux_g)
         )
@@ -105,7 +105,7 @@ class TestSKYFIBERS(unittest.TestCase):
         """
         Test aperture fluxes at sky locations are correct for different bands
         """
-        # ADM generate the skies as a structured array
+        # ADM generate the skies as a structured array.
         skies = skyfibers.make_skies_for_a_brick(self.survey, self.brickname,
                                                  nskiespersqdeg=self.nskiespersqdeg,
                                                  apertures_arcsec=self.ap_arcsec)
@@ -117,14 +117,14 @@ class TestSKYFIBERS(unittest.TestCase):
                                                    bands=["r", "z"])
 
         # ADM ...and just in g-band (which should be THE ONLY GOOD band)!
-        # ADM which is why I set up these tests with brick 0959p805
+        # ADM which is why I set up these tests with brick 0959p805.
         gskies = skyfibers.make_skies_for_a_brick(self.survey, self.brickname,
                                                   nskiespersqdeg=self.nskiespersqdeg,
                                                   apertures_arcsec=self.ap_arcsec,
                                                   bands=["g"])
 
         # ADM the r and z bands for brick 0959p805 are bad, so should be the
-        # ADM same no matter which bands we extract (they should be all zero)
+        # ADM same no matter which bands we extract (they should be all zero).
         self.assertTrue(
             np.all(rzskies["APFLUX_R"] == skies["APFLUX_R"])
         )
@@ -133,7 +133,7 @@ class TestSKYFIBERS(unittest.TestCase):
         )
 
         # ADM but the g band is good, so shouldn't be the same if we extract
-        # ADM it in concert with the other (r,z) bands
+        # ADM it in concert with the other (r,z) bands.
         self.assertFalse(
             np.all(gskies["APFLUX_G"] == skies["APFLUX_G"])
         )
@@ -166,17 +166,17 @@ class TestSKYFIBERS(unittest.TestCase):
         """
         Test the wrapper function for batch selection of skies
         """
-        # ADM generate the skies as a structured array
+        # ADM generate the skies as a structured array.
         skies = skyfibers.make_skies_for_a_brick(self.survey, self.brickname,
                                                  nskiespersqdeg=self.nskiespersqdeg,
                                                  apertures_arcsec=self.ap_arcsec)
 
-        # ADM generate skies using the wrapper function
+        # ADM generate skies using the wrapper function.
         ss = skyfibers.select_skies(self.survey, numproc=1,
                                     nskiespersqdeg=self.nskiespersqdeg,
                                     apertures_arcsec=self.ap_arcsec)
 
-        # ADM check the wrapper generates a single brick correctly
+        # ADM check the wrapper generates a single brick correctly.
         self.assertTrue(np.all(ss == skies))
 
 


### PR DESCRIPTION
Also has some minor updates to catch corner cases when generating DR8 sky locations. Includes:

- Add WISE depth maps to random catalogs and pixweight files.
- Code to generate additional supplemental (i.e. all-sky, outside-of-the-footprint) random catalogs.
- Executable to split a large random catalog into N smaller catalogs.
- Fixes a bug in `desitarget.targets.main_cmx_or_sv()` where the default of *not* returning secondary columns and masks wasn't respected when `rename=True` was sent.
- Better aligns the survey data model with the expected DR8 directory structure, which fixes some directory-not-found and file-not-found bugs when generating sky locations.

The update to `desitarget.targets.main_cmx_or_sv()` should address #511.