### PR TITLE
restore w1/w2 flux argument to iselg_colors

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 0.30.2 (unreleased)
 -------------------
 
+* Near-trivial fix for an unintended change to the isELG API introduced in `PR
+  #513`_ [`PR #514`_]. 
 * Preliminary ELG cuts for DR8 imaging for main and SV [`PR #513`_].
     * Don't deprecate wider SV bits, yet, ELGs may still need them.
 * Further updates to generating randoms for DR8. [`PR #512`_]. Includes:
@@ -43,6 +45,7 @@ desitarget Change Log
 .. _`PR #510`: https://github.com/desihub/desitarget/pull/510
 .. _`PR #512`: https://github.com/desihub/desitarget/pull/512
 .. _`PR #513`: https://github.com/desihub/desitarget/pull/513
+.. _`PR #514`: https://github.com/desihub/desitarget/pull/514
 
 0.30.1 (2019-06-18)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -271,8 +271,8 @@ def isELG(gflux=None, rflux=None, zflux=None, gsnr=None, rsnr=None, zsnr=None,
     elg &= notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
                          primary=primary)
 
-    elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, south=south,
-                        primary=primary)
+    elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=None,
+                        w2flux=None, south=south, primary=primary)
 
     return elg
 
@@ -294,7 +294,8 @@ def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None, primary=None):
     return elg
 
 
-def isELG_colors(gflux=None, rflux=None, zflux=None, south=True, primary=None):
+def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
+                 w2flux=None, south=True, primary=None):
     """Color cuts for ELG target selection classes
     (see, e.g., :func:`desitarget.cuts.set_target_bits` for parameters).
     """

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -256,8 +256,9 @@ def isLRGpass(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     return lrg, lrg1pass, lrg2pass
 
 
-def isELG(gflux=None, rflux=None, zflux=None, gsnr=None, rsnr=None, zsnr=None,
-          maskbits=None, south=True, primary=None):
+def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+          gsnr=None, rsnr=None, zsnr=None, maskbits=None, south=True,
+          primary=None):
     """Definition of ELG target classes. Returns a boolean array.
     (see :func:`~desitarget.cuts.set_target_bits` for parameters).
 
@@ -271,8 +272,8 @@ def isELG(gflux=None, rflux=None, zflux=None, gsnr=None, rsnr=None, zsnr=None,
     elg &= notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
                          primary=primary)
 
-    elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=None,
-                        w2flux=None, south=south, primary=primary)
+    elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
+                        w2flux=w2flux, south=south, primary=primary)
 
     return elg
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -850,8 +850,9 @@ def isBGS_colors(rflux=None, rfiberflux=None, south=True, targtype=None, primary
     return bgs
 
 
-def isELG(gflux=None, rflux=None, zflux=None, gsnr=None, rsnr=None, zsnr=None,
-          maskbits=None, south=True, primary=None):
+def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+          gsnr=None, rsnr=None, zsnr=None, maskbits=None, south=True,
+          primary=None):
     """Definition of ELG target classes. Returns a boolean array.
 
     Parameters
@@ -877,8 +878,8 @@ def isELG(gflux=None, rflux=None, zflux=None, gsnr=None, rsnr=None, zsnr=None,
     elg &= notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
                          primary=primary)
 
-    elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, south=south,
-                        primary=primary)
+    elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
+                        w2flux=w2flux, south=south, primary=primary)
 
     return elg
 
@@ -900,7 +901,8 @@ def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None, primary=None):
     return elg
 
 
-def isELG_colors(gflux=None, rflux=None, zflux=None, south=True, primary=None):
+def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
+                 w2flux=None, south=True, primary=None):
     """Color cuts for ELG target selection classes
     (see, e.g., :func:`desitarget.cuts.set_target_bits` for parameters).
     """


### PR DESCRIPTION
Near-trivial fix for an unintended change to the `isELG` API introduced in #513.