### PR TITLE
Populate the randoms with MASKBITS of BAILOUT when no maskbits file is found

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.30.2 (unreleased)
 -------------------
 
+* MASKBITS of BAILOUT for randoms when no file is found [`PR #515`_].
 * Near-trivial fix for an unintended change to the isELG API introduced in `PR
   #513`_ [`PR #514`_]. 
 * Preliminary ELG cuts for DR8 imaging for main and SV [`PR #513`_].
@@ -46,6 +47,7 @@ desitarget Change Log
 .. _`PR #512`: https://github.com/desihub/desitarget/pull/512
 .. _`PR #513`: https://github.com/desihub/desitarget/pull/513
 .. _`PR #514`: https://github.com/desihub/desitarget/pull/514
+.. _`PR #515`: https://github.com/desihub/desitarget/pull/515
 
 0.30.1 (2019-06-18)
 -------------------

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -386,7 +386,6 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
             if mout == 'maskbits':
                 qdict[mout] |= 2**10
 
-
     # ADM populate the photometric system in the quantity dictionary.
     if instrum is None:
         # ADM don't count bricks where we never read a file header.

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -380,8 +380,12 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
             # ADM add the maskbits to the dictionary.
             qdict[mout] = img.data[y.astype("int"), x.astype("int")]
         else:
-            # ADM if there is no maskbits file, populate with zeros.
+            # ADM if no files are found, populate with zeros.
             qdict[mout] = np.zeros(npts, dtype=mform)
+            # ADM if there was no maskbits file, populate with BAILOUT.
+            if mout == 'maskbits':
+                qdict[mout] |= 2**10
+
 
     # ADM populate the photometric system in the quantity dictionary.
     if instrum is None:


### PR DESCRIPTION
This PR changes the random catalogs so that they default to `MASKBITS` of `2**10` (`BAILOUT`) instead of `MASKBITS` of 0 when no `*-maskbits.fits*` file is found.

This is a very minor change, so I'll merge once tests pass.