### PR TITLE
Add full suite of columns to supplementl skies files

### DIFF
--- a/bin/select_targets
+++ b/bin/select_targets
@@ -122,7 +122,9 @@ else:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
     if ns.bundlefiles is None:
-        io.write_targets(ns.dest, targets, resolve=not(ns.noresolve), indir=ns.sweepdir,
-                         indir2=ns.sweepdir2, survey="main", nsidefile=ns.nside, hpxlist=pixlist,
-                         qso_selection=ns.qsoselection, sandboxcuts=ns.sandbox, nside=nside)
+        # ADM only write out a targeting file if it's non-zero.
+        if len(targets) > 0:
+            io.write_targets(ns.dest, targets, resolve=not(ns.noresolve), indir=ns.sweepdir,
+                             indir2=ns.sweepdir2, survey="main", nsidefile=ns.nside, hpxlist=pixlist,
+                             qso_selection=ns.qsoselection, sandboxcuts=ns.sandbox, nside=nside)
         log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))

--- a/bin/supplement_skies
+++ b/bin/supplement_skies
@@ -5,6 +5,7 @@ from desitarget import io
 
 import numpy as np
 import healpy as hp
+import fitsio
 
 #import warnings
 #warnings.simplefilter('error')
@@ -20,6 +21,8 @@ log = get_logger()
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Generate supplemental sky locations using Gaia-G-band avoidance (for regions beyond the Legacy Surveys)')
+ap.add_argument("source",
+                help="Input sky targets file (e.g. /project/projectdirs/desi/target/catalogs/dr8/0.31.0/skies/skies-dr8-0.31.0.fits). Used purely to set the minimum allowed OBJID.")
 ap.add_argument("dest",
                 help="Output supplemental sky targets file (e.g. /project/projectdirs/desi/target/catalogs/supp-skies-dr4-0.20.0.fits)")
 ap.add_argument("--nskiespersqdeg",
@@ -42,6 +45,9 @@ ap.add_argument("--radius", type=float,
                 default=2.)
 
 ns = ap.parse_args()
+# ADM determine the maximum OBJID in the file that's being supplemented.
+# ADM 1 + this will be the minimum allowed OBJID for supplemental skies.
+minobjid = np.max(fitsio.read(ns.source, columns="BRICK_OBJID"))
 
 # ADM if the GAIA directory was passed, set it...
 gaiadir = ns.gaiadir
@@ -59,7 +65,7 @@ log.info('Generating sky positions at a density of {}'.format(nskiespersqdeg))
 # ADM generate the supplemental sky locations.
 skies = supplement_skies(nskiespersqdeg=nskiespersqdeg, numproc=ns.numproc,
                          gaiadir=gaiadir, radius=ns.radius,
-                         mindec=ns.mindec, mingalb=ns.mingalb)
+                         mindec=ns.mindec, mingalb=ns.mingalb, minobjid=minobjid)
 
 # ADM write to file.
 io.write_skies(ns.dest, skies, supp=True, indir=gaiadir,

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desitarget Change Log
 0.31.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Add full set of columns to supplemental skies file [`PR #518`_]
+* Fix some corner cases when reading HEALPixel-split files [`PR #518`_]
+
+.. _`PR #518`: https://github.com/desihub/desitarget/pull/518
 
 0.31.1 (2019-07-05)
 -------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -382,7 +382,8 @@ def write_secondary(filename, data, primhdr=None, scxdir=None):
     Nothing, but two files are written:
         - The file of secondary targets that do not match a primary
           target is written to `filename`. Such secondary targets
-          are determined from having `RELEASE==0` in the `TARGETID`.
+          are determined from having `RELEASE==0` and `SKY==0`
+          in the `TARGETID`.
         - Each secondary target that, presumably, was initially drawn
           from the "indata" subdirectory of `scxdir` is written to
           the "outdata" subdirectory of `scxdir`.
@@ -505,7 +506,11 @@ def write_skies(filename, data, indir=None, indir2=None, supp=False,
 
     # ADM populate SUBPRIORITY with a reproducible random float.
     if "SUBPRIORITY" in data.dtype.names:
-        np.random.seed(616)
+        # ADM ensure different SUBPRIORITIES for supp/standard files.
+        if supp:
+            np.random.seed(626)
+        else:
+            np.random.seed(616)
         data["SUBPRIORITY"] = np.random.random(nskies)
 
     fitsio.write(filename, data, extname='SKY_TARGETS', header=hdr, clobber=True)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1164,6 +1164,10 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None,
         - If `header` is ``True``, then a second output (the file
           header is returned).
     """
+    # ADM allow an integer instead of a list to be passed.
+    if isinstance(pixlist, int):
+        pixlist = [pixlist]
+
     # ADM we'll need RA/Dec for final cuts, so ensure they're read.
     addedcols = []
     columnscopy = None


### PR DESCRIPTION
The supplemental skies files were missing some columns (`DESI_TARGET`, `TARGETID`, `SUBPRIORITIY`, etc.) that are necessary for fiber assign to run. This PR adds those columns. In addition, it fixes some corner cases when reading and writing HEALPixel-split files.