### PR TITLE
Include further SV-like selections for commissioning

### DIFF
--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -45,7 +45,6 @@ log.info('Working on file {}...t = {:.1f}s'.format(fns[0], time()-start))
 fits.write(data, extname=ns.targtype.upper(), header=hdr, clobber=True)
 
 # ADM add the other files.
-targets = []
 for fn in fns[1:]:
     log.info('Working on file {}...t = {:.1f}s'.format(fn, time()-start))
     data = fitsio.read(fn)

--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -26,25 +26,25 @@ ap.add_argument("targtype", choices=['skies', 'randoms', 'targets'],
 
 ns = ap.parse_args()
 
-#ADM convert passed csv strings to lists
+# ADM convert passed csv strings to lists.
 fns = [ fn for fn in ns.infiles.split(';') ]
 
-#ADM read the header from the first file
+# ADM read the header from the first file.
 fx = fitsio.FITS(fns[0])
 hdr = fx[1].read_header()
 
 log.info('Begin writing {} to {}...t = {:.1f}s'
          .format(ns.targtype, ns.outfile, time()-start))
 
-#ADM open the file for writing
-fits = FITS(ns.outfile,'rw')
+# ADM open the file for writing.
+fits = FITS(ns.outfile, 'rw')
 
-#ADM write the first file with the header
+# ADM write the first file with the header.
 data = fitsio.read(fns[0])
 log.info('Working on file {}...t = {:.1f}s'.format(fns[0], time()-start))
 fits.write(data, extname=ns.targtype.upper(), header=hdr, clobber=True)
 
-#ADM add the other files
+# ADM add the other files.
 targets = []
 for fn in fns[1:]:
     log.info('Working on file {}...t = {:.1f}s'.format(fn, time()-start))

--- a/bin/select_cmx_targets
+++ b/bin/select_cmx_targets
@@ -46,7 +46,7 @@ if len(infiles) == 0:
 fn = infiles
 if ~isinstance(infiles, str):
     fn = infiles[0]
-data = fitsio.read(fn, columns=["RELEASE","PMRA"])
+data = fitsio.read(fn, columns=["RELEASE", "PMRA"])
 if np.any(data["RELEASE"] < 6000):
     log.critical('Commissioning cuts only coded for DR6 or above')
     raise ValueError
@@ -63,7 +63,7 @@ log.info("running on {} processors".format(ns.numproc))
 
 targets = select_targets(infiles, numproc=ns.numproc)
 
-io.write_targets(ns.dest, targets, indir=ns.src, survey="cmx", nside=nside)
+io.write_targets(ns.dest, targets, indir=ns.src, survey="cmx", nside=nside, nchunks=20)
 
 log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.31.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Add ELG/LRG/QSO/STD selections for commissioning [`PR #519`_].
+
+.. _`PR #519`: https://github.com/desihub/desitarget/pull/519
 
 0.31.1 (2019-07-05)
 -------------------

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -457,8 +457,10 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
     """
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
-    lrg = primary.copy()
-    lrg1, lrg2, lrg3, lrg4, lrg5 = np.tile(primary, [5, 1])
+    # ADM take care to explicitly copy these individually to guard
+    # ADM against accidentally changing the type of the bitmasks.
+    lrg, lrg1, lrg2 = primary.copy(), primary.copy(), primary.copy()
+    lrg3, lrg4, lrg5 = primary.copy(), primary.copy(), primary.copy()
 
     # ADM safe as these fluxes are set to > 0 in notinLRG_mask.
     gmag = 22.5 - 2.5 * np.log10(gflux.clip(1e-7))
@@ -566,7 +568,7 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     # ADM we never target sources with dchisq[..., 0] = 0, so force
     # ADM those to have large values of morph2 to avoid divide-by-zero.
     d1, d0 = dchisq[..., 1], dchisq[..., 0]
-    bigmorph = np.zeros_like(d0)+1e9
+    bigmorph = np.array(np.zeros_like(d0) + 1e9)
     dcs = np.divide(d1 - d0, d0, out=bigmorph, where=d0 != 0)
     morph2 = dcs < 0.02
     preSelection &= _psflike(objtype) | morph2

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -21,6 +21,8 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, Row
 
+from pkg_resources import resource_filename
+
 from desitarget import io
 from desitarget.cuts import _psflike, _is_row, _get_colnames
 from desitarget.cuts import _prepare_optical_wise, _prepare_gaia
@@ -58,6 +60,39 @@ def _get_cmxdir(cmxdir=None):
     return cmxdir
 
 
+def _getColors(nbEntries, nfeatures, gflux, rflux, zflux, w1flux, w2flux):
+
+    limitInf = 1.e-04
+    gflux = gflux.clip(limitInf)
+    rflux = rflux.clip(limitInf)
+    zflux = zflux.clip(limitInf)
+    w1flux = w1flux.clip(limitInf)
+    w2flux = w2flux.clip(limitInf)
+
+    g = np.where(gflux > limitInf, 22.5-2.5*np.log10(gflux), 0.)
+    r = np.where(rflux > limitInf, 22.5-2.5*np.log10(rflux), 0.)
+    z = np.where(zflux > limitInf, 22.5-2.5*np.log10(zflux), 0.)
+    W1 = np.where(w1flux > limitInf, 22.5-2.5*np.log10(w1flux), 0.)
+    W2 = np.where(w2flux > limitInf, 22.5-2.5*np.log10(w2flux), 0.)
+
+    photOK = (g > 0.) & (r > 0.) & (z > 0.) & (W1 > 0.) & (W2 > 0.)
+
+    colors = np.zeros((nbEntries, nfeatures))
+    colors[:, 0] = g-r
+    colors[:, 1] = r-z
+    colors[:, 2] = g-z
+    colors[:, 3] = g-W1
+    colors[:, 4] = r-W1
+    colors[:, 5] = z-W1
+    colors[:, 6] = g-W2
+    colors[:, 7] = r-W2
+    colors[:, 8] = z-W2
+    colors[:, 9] = W1-W2
+    colors[:, 10] = r
+
+    return colors, r, photOK
+
+
 def passesSTD_logic(gfracflux=None, rfracflux=None, zfracflux=None,
                     objtype=None, gaia=None, pmra=None, pmdec=None,
                     aen=None, dupsource=None, paramssolved=None,
@@ -92,7 +127,7 @@ def passesSTD_logic(gfracflux=None, rfracflux=None, zfracflux=None,
 
     Notes
     -----
-    - Current version (08/30/18) is version 4 on `the cmx wiki`_.
+    - This version (08/30/18) is version 4 on `the cmx wiki`_.
     - All Gaia quantities are as in `the Gaia data model`_.
     """
     if primary is None:
@@ -180,8 +215,14 @@ def isSV0_STD_bright(gflux=None, rflux=None, zflux=None,
     # ADM a parallax smaller than 1 mas.
     isbright &= parallax < 1.
 
+    # ADM calculate the overall proper motion magnitude.
+    # ADM inexplicably I'm getting a Runtimewarning here for
+    # ADM a few values in the sqrt, so I'm catching it.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        pm = np.sqrt(pmra**2. + pmdec**2.)
+
     # ADM a proper motion larger than 2 mas/yr.
-    pm = np.sqrt(pmra**2. + pmdec**2.)
     isbright &= pm > 2.
 
     return isbright
@@ -206,7 +247,7 @@ def isSV0_BGS(rflux=None, objtype=None, primary=None):
 
     Notes
     -----
-    - Returns the equivalent of ALL BGS classes (for the northern imaging).
+    - Returns the equivalent of ALL BGS classes.
     """
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
@@ -261,7 +302,7 @@ def isSV0_MWS(rflux=None, obs_rflux=None, objtype=None,
 
     Notes
     -----
-    - Returns the equivalent of ALL MWS classes (for the northern imaging).
+    - Returns the equivalent of ALL MWS classes.
     - All Gaia quantities are as in `the Gaia data model`_.
     """
     if primary is None:
@@ -290,6 +331,27 @@ def isSV0_MWS(rflux=None, obs_rflux=None, objtype=None,
     isnear &= parallax > 10.
     # ADM NOTE TO THE MWS GROUP: There is no bright cut on G. IS THAT THE REQUIRED BEHAVIOR?
 
+    # ADM do not target any WDs for which entries are NaN
+    # ADM and turn off the NaNs for those entries.
+    if photbprpexcessfactor is not None:
+        nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
+                np.isnan(parallax) | np.isnan(photbprpexcessfactor))
+    else:
+        nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
+                np.isnan(parallax))
+    w = np.where(nans)[0]
+    if len(w) > 0:
+        parallax, gaiagmag = parallax.copy(), gaiagmag.copy()
+        gaiabmag, gaiarmag = gaiabmag.copy(), gaiarmag.copy()
+        if photbprpexcessfactor is not None:
+            photbprpexcessfactor = photbprpexcessfactor.copy()
+        # ADM safe to make these zero regardless of cuts as...
+            photbprpexcessfactor[w] = 0.
+        parallax[w] = 0.
+        gaiagmag[w], gaiabmag[w], gaiarmag[w] = 0., 0., 0.
+        # ADM ...we'll turn off all bits here.
+        iswd &= ~nans
+
     # ADM apply the selection for MWS-WD targets.
     # ADM must be a Legacy Surveys object that matches a Gaia source.
     iswd &= gaia
@@ -310,8 +372,13 @@ def isSV0_MWS(rflux=None, obs_rflux=None, objtype=None,
     iswd &= Gabs > 5.93 + 5.047*br
     iswd &= Gabs > 6*br*br*br - 21.77*br*br + 27.91*br + 0.897
     iswd &= br < 1.7
+
     # ADM Finite proper motion to reject quasars.
-    pm = np.sqrt(pmra**2. + pmdec**2.)
+    # ADM Inexplicably I'm getting a Runtimewarning here for
+    # ADM a few values in the sqrt, so I'm catching it.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        pm = np.sqrt(pmra**2. + pmdec**2.)
     iswd &= pm > 2.
 
     # ADM As of DR7, photbprpexcessfactor and astrometricsigma5dmax are not in the
@@ -328,6 +395,445 @@ def isSV0_MWS(rflux=None, obs_rflux=None, objtype=None,
 
     # ADM return any object that passes any of the MWS cuts.
     return ismws | isnear | iswd
+
+
+def isSV0_LRG(gflux=None, rflux=None, zflux=None, w1flux=None,
+              rflux_snr=None, zflux_snr=None, w1flux_snr=None,
+              gflux_ivar=None, primary=None):
+    """Target Definition of LRG. Returns a boolean array.
+
+    Parameters
+    ----------
+    - See :func:`~desitarget.cuts.set_target_bits` for parameters.
+
+    Returns
+    -------
+    :class:`array_like`
+        ``True`` if and only if the object is an LRG target.
+
+    Notes
+    -----
+    - This version (03/19/19) is version 56 on `the SV wiki`_.
+    """
+    # ADM LRG SV0 targets.
+    if primary is None:
+        primary = np.ones_like(rflux, dtype='?')
+    lrg = primary.copy()
+
+    lrg &= notinLRG_mask(primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
+                         rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr)
+
+    # ADM pass the lrg that pass cuts as primary, to restrict to the
+    # ADM sources that weren't in a mask/logic cut.
+    lrg_all = isLRG_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
+                           gflux_ivar=gflux_ivar, primary=lrg)
+
+    return lrg_all
+
+
+def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
+                  rflux_snr=None, zflux_snr=None, w1flux_snr=None):
+    """See :func:`~desitarget.sv1.sv1_cuts.isLRG` for details.
+
+    Returns
+    -------
+    :class:`array_like`
+        ``True`` if and only if the object is NOT masked for poor quality.
+    """
+    if primary is None:
+        primary = np.ones_like(rflux, dtype='?')
+    lrg = primary.copy()
+
+    lrg &= (rflux_snr > 0) & (rflux > 0)   # ADM quality in r.
+    lrg &= (zflux_snr > 0) & (zflux > 0)   # ADM quality in z.
+    lrg &= (w1flux_snr > 4) & (w1flux > 0)  # ADM quality in W1.
+
+    return lrg
+
+
+def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
+                 gflux_ivar=None, primary=None):
+    """See :func:`~desitarget.sv1.sv1_cuts.isLRG` for details.
+    """
+    if primary is None:
+        primary = np.ones_like(rflux, dtype='?')
+    lrg = primary.copy()
+    lrg1, lrg2, lrg3, lrg4, lrg5 = np.tile(primary, [5, 1])
+
+    # ADM safe as these fluxes are set to > 0 in notinLRG_mask.
+    gmag = 22.5 - 2.5 * np.log10(gflux.clip(1e-7))
+    rmag = 22.5 - 2.5 * np.log10(rflux.clip(1e-7))
+    zmag = 22.5 - 2.5 * np.log10(zflux.clip(1e-7))
+    w1mag = 22.5 - 2.5 * np.log10(w1flux.clip(1e-7))
+
+    # subsample 1: nominal optical + nominal IR:
+    lrg1 &= zmag - w1mag > 0.8*(rmag-zmag) - 0.735    # non-stellar cut
+    lrg1 &= zmag < 20.365                             # faint limit
+    lrg1 &= rmag - zmag > 0.85                        # broad color box
+    lrg1 &= (rmag - zmag > 1.25) | ((gmag - rmag > 1.655) & (gflux_ivar > 0))  # Low-z cut
+    lrg_opt = rmag - zmag > (zmag - 17.105) / 1.8     # sliding optical cut
+    lrg_ir = rmag - w1mag > (w1mag - 17.723) / 0.385  # sliding IR cut
+    lrg1 &= lrg_opt | lrg_ir
+
+    # subsample 2: optical + IR + low-z extension:
+    lrg2 &= zmag - w1mag > 0.8*(rmag-zmag) - 0.735  # non-stellar cut
+    lrg2 &= zmag < 20.365                           # faint limit
+    lrg2 &= rmag - zmag > 0.85                      # broad color box
+    lrg2 &= (rmag - zmag > 1.25) | ((gmag - rmag > 1.655) & (gflux_ivar > 0))  # Low-z cut
+    lrg_opt = ((rmag - zmag > (zmag - 17.105) / 1.8) |
+               (zmag < 19.655))                             # sliding optical cut with low-z extension
+    lrg_ir = ((rmag - w1mag > (w1mag - 17.723) / 0.385) |
+              ((w1mag < 19.139) & (rmag - w1mag < 1.833)))  # sliding IR cut with low-z extension
+    lrg2 &= lrg_opt | lrg_ir
+
+    # subsample 3: optical + IR + high-z extension:
+    lrg3 &= zmag - w1mag > 0.8*(rmag-zmag) - 0.735  # non-stellar cut
+    lrg3 &= zmag < 20.755                           # extended faint limit
+    lrg3 &= rmag - zmag > 0.85                      # broad color box
+    lrg3 &= (rmag - zmag > 1.25) | ((gmag - rmag > 1.655) & (gflux_ivar > 0))  # Low-z cut
+    lrg_opt = rmag - zmag > (zmag - 17.105) / 1.8     # sliding optical cut
+    lrg_ir = rmag - w1mag > (w1mag - 17.723) / 0.385  # sliding IR cut
+    lrg3 &= lrg_opt | lrg_ir
+
+    # subsample 4: optical + IR + low-z + high-z + relaxed cuts
+    # (relaxed stellar rejection + relaxed sliding cuts + relaxed g-r cut):
+    lrg4 &= zmag - w1mag > 0.8*(rmag-zmag) - 0.935  # relaxed non-stellar cut
+    lrg4 &= zmag < 20.755                           # extended faint limit
+    lrg4 &= rmag - zmag > 0.85                      # broad color box
+    lrg4 &= (rmag - zmag > 1.25) | ((gmag - rmag > 1.455) & (gflux_ivar > 0))  # relaxed low-z cut
+    lrg_opt = ((((zmag - 22.1) / 1.3)**2 + (rmag - zmag + 1.04)**2 > 3.0**2) |
+               (zmag < 19.655))                             # curved sliding optical cut with low-z extension
+    lrg_ir = (((w1mag - 21.)**2 + ((rmag - w1mag - 0.47) / 1.5)**2 > 2.5**2) |
+              ((w1mag < 19.139) & (rmag - w1mag < 1.833)))  # curved sliding IR cut with low-z extension
+    lrg4 &= lrg_opt | lrg_ir
+
+    # subsample 5 (this is a superset of all other subsamples):
+    # optical + IR + low-z + high-z + more relaxed cuts
+    # (relaxed stellar rejection + relaxed sliding cuts + no g-r cut + relaxed broad r-z cut):
+    lrg5 &= zmag - w1mag > 0.8*(rmag-zmag) - 0.935  # relaxed non-stellar cut
+    lrg5 &= zmag < 20.755                           # extended faint limit
+    lrg5 &= rmag - zmag > 0.75                      # relaxed broad color box
+    lrg_opt = ((((zmag - 22.1) / 1.3)**2 + (rmag - zmag + 1.04)**2 > 3.0**2) |
+               (zmag < 19.655))                             # curved sliding optical cut with low-z extension
+    lrg_ir = (((w1mag - 21.)**2 + ((rmag - w1mag - 0.47) / 1.5)**2 > 2.5**2) |
+              ((w1mag < 19.139) & (rmag - w1mag < 1.833)))  # curved sliding IR cut with low-z extension
+    lrg5 &= lrg_opt | lrg_ir
+
+    lrg = lrg1 | lrg2 | lrg3 | lrg4 | lrg5
+
+    return lrg
+
+
+def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+              objtype=None, release=None, dchisq=None, brightstarinblob=None,
+              primary=None):
+    """Early SV QSO target class using random forest. Returns a boolean array.
+
+    Parameters
+    ----------
+    - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
+
+    Returns
+    -------
+    :class:`array_like`
+        ``True`` for objects that pass the quasar color/morphology/logic cuts.
+
+    Notes
+    -----
+    - This version (06/05/19) is version 68 on `the SV wiki`_.
+    """
+    # BRICK_PRIMARY
+    if primary is None:
+        primary = np.ones_like(gflux, dtype=bool)
+
+    # Build variables for random forest.
+    nFeatures = 11  # Number of attributes describing each object to be classified by the rf.
+    nbEntries = rflux.size
+    # ADM shift the northern photometry to the southern system.
+    # ADM we don't need to exactly correspond to SV for SV0.
+    # gflux, rflux, zflux = shift_photo_north(gflux, rflux, zflux)
+
+    # ADM photOK here should ensure (g > 0.) & (r > 0.) & (z > 0.) & (W1 > 0.) & (W2 > 0.)
+    colors, r, photOK = _getColors(nbEntries, nFeatures, gflux, rflux, zflux, w1flux, w2flux)
+    r = np.atleast_1d(r)
+
+    # ADM Preselection to speed up the process
+    rMax = 23.0  # r < 23.0 (different for SV)
+    rMin = 17.5  # r > 17.5
+    preSelection = (r < rMax) & (r > rMin) & photOK & primary
+
+    # ADM relaxed morphology cut for SV.
+    # ADM we never target sources with dchisq[..., 0] = 0, so force
+    # ADM those to have large values of morph2 to avoid divide-by-zero.
+    d1, d0 = dchisq[..., 1], dchisq[..., 0]
+    bigmorph = np.zeros_like(d0)+1e9
+    dcs = np.divide(d1 - d0, d0, out=bigmorph, where=d0 != 0)
+    morph2 = dcs < 0.02
+    preSelection &= _psflike(objtype) | morph2
+
+    # CAC Reject objects flagged inside a blob.
+    preSelection &= ~brightstarinblob
+
+    # "qso" mask initialized to "preSelection" mask
+    qso = np.copy(preSelection)
+
+    if np.any(preSelection):
+
+        from desitarget.myRF import myRF
+
+        # Data reduction to preselected objects
+        colorsReduced = colors[preSelection]
+        r_Reduced = r[preSelection]
+        colorsIndex = np.arange(0, nbEntries, dtype=np.int64)
+        colorsReducedIndex = colorsIndex[preSelection]
+
+        # Path to random forest files
+        pathToRF = resource_filename('desitarget', 'data')
+        # ADM Use RF trained over DR7
+        rf_fileName = pathToRF + '/rf_model_dr7.npz'
+        rf_HighZ_fileName = pathToRF + '/rf_model_dr7_HighZ.npz'
+
+        # rf initialization - colors data duplicated within "myRF"
+        rf = myRF(colorsReduced, pathToRF, numberOfTrees=500, version=2)
+        rf_HighZ = myRF(colorsReduced, pathToRF, numberOfTrees=500, version=2)
+        # rf loading
+        rf.loadForest(rf_fileName)
+        rf_HighZ.loadForest(rf_HighZ_fileName)
+        # Compute rf probabilities
+        tmp_rf_proba = rf.predict_proba()
+        tmp_rf_HighZ_proba = rf_HighZ.predict_proba()
+        # Compute optimized proba cut (all different for SV/main).
+        pcut = np.where(r_Reduced > 20.0,
+                        0.65 - (r_Reduced - 20.0) * 0.075, 0.65)
+        pcut[r_Reduced > 22.0] = 0.50 - 0.25 * (r_Reduced[r_Reduced > 22.0] - 22.0)
+        pcut_HighZ = np.where(r_Reduced > 20.5,
+                              0.5 - (r_Reduced - 20.5) * 0.025, 0.5)
+
+        # Add rf proba test result to "qso" mask
+        qso[colorsReducedIndex] = \
+            (tmp_rf_proba >= pcut) | (tmp_rf_HighZ_proba >= pcut_HighZ)
+
+    # In case of call for a single object passed to the function with scalar arguments
+    # Return "numpy.bool_" instead of "numpy.ndarray"
+    if nbEntries == 1:
+        qso = qso[0]
+
+    return qso
+
+
+def isSV0_ELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+              gsnr=None, rsnr=None, zsnr=None, maskbits=None, primary=None):
+    """Definition of ELG target classes. Returns a boolean array.
+
+    Parameters
+    ----------
+    - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
+
+    Returns
+    -------
+    :class:`array_like`
+        ``True`` if and only if the object is an SV0 ELG target.
+
+    Notes
+    -----
+    - This version (03/19/19) is version 76 on `the SV wiki`_.
+    """
+    if primary is None:
+        primary = np.ones_like(rflux, dtype='?')
+    elg = primary.copy()
+
+    elg &= notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+                         primary=primary)
+
+    elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
+                        w2flux=w2flux, primary=primary)
+
+    return elg
+
+
+def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None, primary=None):
+    """Standard set of masking cuts used by all ELG target selection classes.
+    (see :func:`~desitarget.cuts.set_target_bits` for parameters).
+    """
+    if primary is None:
+        primary = np.ones_like(maskbits, dtype='?')
+    elg = primary.copy()
+
+    # ADM good signal-to-noise in all bands.
+    elg &= (gsnr > 0) & (rsnr > 0) & (zsnr > 0)
+    # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
+    for bit in [1, 5, 6, 7, 11, 12, 13]:
+        elg &= ((maskbits & 2**bit) == 0)
+
+    return elg
+
+
+def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
+                 w2flux=None, primary=None):
+    """Color cuts for ELG target selection classes
+    (see, e.g., :func:`desitarget.cuts.set_target_bits` for parameters).
+    """
+    if primary is None:
+        primary = np.ones_like(rflux, dtype='?')
+    elg = primary.copy()
+
+    # ADM work in magnitudes instead of fluxes. NOTE THIS IS ONLY OK AS
+    # ADM the snr masking in ALL OF g, r AND z ENSURES positive fluxes.
+    g = 22.5 - 2.5*np.log10(gflux.clip(1e-16))
+    r = 22.5 - 2.5*np.log10(rflux.clip(1e-16))
+    z = 22.5 - 2.5*np.log10(zflux.clip(1e-16))
+    # ADM this is a color defined perpendicularly to the negative slope
+    # ADM cut; coii thus follows the OII flux gradient.
+    coii = (g - r) + 1.2*(r - z)
+
+    elg &= g > 20                       # bright cut.
+    elg &= r - z > -1.0                 # blue cut.
+    elg &= g - r < -1.2*(r - z) + 2.5   # OII flux cut.
+
+    elg &= (g - r < 0.2) | (g - r < 1.15*(r - z) - 0.35)  # remove stars and low-z galaxies.
+    elg &= coii < 1.6 - 7.2*(g - 23.6)  # sliding cut.
+
+    return elg
+
+
+def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
+          gfracflux=None, rfracflux=None, zfracflux=None,
+          gfracmasked=None, rfracmasked=None, zfracmasked=None,
+          gnobs=None, rnobs=None, znobs=None,
+          gfluxivar=None, rfluxivar=None, zfluxivar=None, objtype=None,
+          gaia=None, astrometricexcessnoise=None, paramssolved=None,
+          pmra=None, pmdec=None, parallax=None, dupsource=None,
+          gaiagmag=None, gaiabmag=None, gaiarmag=None, bright=False):
+    """Select STD targets using color cuts and photometric quality cuts.
+
+    Parameters
+    ----------
+    bright : :class:`boolean`, defaults to ``False``
+        if ``True`` apply magnitude cuts for "bright" conditions; otherwise,
+        choose "normal" brightness standards. Cut is performed on `gaiagmag`.
+
+    Returns
+    -------
+    :class:`array_like`
+        ``True`` if and only if the object is a STD star.
+
+    Notes
+    -----
+    - This version (11/05/18) is version 24 on `the SV wiki`_.
+    - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
+    """
+    if primary is None:
+        primary = np.ones_like(gflux, dtype='?')
+    std = primary.copy()
+
+    # ADM apply type=PSF cut.
+    std &= _psflike(objtype)
+
+    # ADM apply fracflux, S/N cuts and number of observations cuts.
+    fracflux = [gfracflux, rfracflux, zfracflux]
+    fluxivar = [gfluxivar, rfluxivar, zfluxivar]
+    nobs = [gnobs, rnobs, znobs]
+    fracmasked = [gfracmasked, rfracmasked, zfracmasked]
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')  # fracflux can be Inf/NaN
+        for bandint in (0, 1, 2):  # g, r, z
+            std &= fracflux[bandint] < 0.01
+            std &= fluxivar[bandint] > 0
+            std &= nobs[bandint] > 0
+            std &= fracmasked[bandint] < 0.6
+
+    # ADM apply the Legacy Surveys (optical) magnitude and color cuts.
+    std &= isSTD_colors(primary=primary, zflux=zflux, rflux=rflux, gflux=gflux)
+
+    # ADM apply the Gaia quality cuts.
+    std &= isSTD_gaia(primary=primary, gaia=gaia,
+                      astrometricexcessnoise=astrometricexcessnoise,
+                      pmra=pmra, pmdec=pmdec, parallax=parallax,
+                      dupsource=dupsource, paramssolved=paramssolved,
+                      gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag)
+
+    # ADM brightness cuts in Gaia G-band.
+    if bright:
+        gbright, gfaint = 15., 18.
+    else:
+        gbright, gfaint = 16., 19.
+
+    std &= gaiagmag >= gbright
+    std &= gaiagmag < gfaint
+
+    return std
+
+
+def isSTD_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+                 primary=None):
+    """Select STD stars based on Legacy Surveys color cuts. Returns a boolean array.
+    see :func:`~desitarget.sv1.sv1_cuts.isSTD` for other details.
+    """
+    if primary is None:
+        primary = np.ones_like(gflux, dtype='?')
+    std = primary.copy()
+
+    # Clip to avoid warnings from negative numbers.
+    # ADM we're pretty bright for the STDs, so this should be safe.
+    gflux = gflux.clip(1e-16)
+    rflux = rflux.clip(1e-16)
+    zflux = zflux.clip(1e-16)
+
+    # ADM optical colors for halo TO or bluer.
+    grcolor = 2.5 * np.log10(rflux / gflux)
+    rzcolor = 2.5 * np.log10(zflux / rflux)
+    std &= rzcolor < 0.2
+    std &= grcolor > 0.
+    std &= grcolor < 0.35
+
+    return std
+
+
+def isSTD_gaia(primary=None, gaia=None, astrometricexcessnoise=None,
+               pmra=None, pmdec=None, parallax=None,
+               dupsource=None, paramssolved=None,
+               gaiagmag=None, gaiabmag=None, gaiarmag=None):
+    """Gaia quality cuts used to define STD star targets
+    see :func:`~desitarget.sv1.sv1_cuts.isSTD` for other details.
+    """
+    if primary is None:
+        primary = np.ones_like(gflux, dtype='?')
+    std = primary.copy()
+
+    # ADM Bp and Rp are both measured.
+    std &= ~np.isnan(gaiabmag - gaiarmag)
+
+    # ADM no obvious issues with the astrometry solution.
+    std &= astrometricexcessnoise < 1
+    std &= paramssolved == 31
+
+    # ADM finite proper motions.
+    std &= np.isfinite(pmra)
+    std &= np.isfinite(pmdec)
+
+    # ADM a parallax smaller than 1 mas.
+    std &= parallax < 1.
+
+    # ADM calculate the overall proper motion magnitude
+    # ADM inexplicably I'm getting a Runtimewarning here for
+    # ADM a few values in the sqrt, so I'm catching it.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        pm = np.sqrt(pmra**2. + pmdec**2.)
+
+    # ADM a proper motion larger than 2 mas/yr.
+    std &= pm > 2.
+
+    # ADM fail if dupsource is not Boolean, as was the case for the 7.0 sweeps.
+    # ADM otherwise logic checks on dupsource will be misleading.
+    if not (dupsource.dtype.type == np.bool_):
+        log.error('GAIA_DUPLICATED_SOURCE (dupsource) should be boolean!')
+        raise IOError
+
+    # ADM a unique Gaia source.
+    std &= ~dupsource
+
+    return std
 
 
 def isSTD_dither(obs_gflux=None, obs_rflux=None, obs_zflux=None,
@@ -354,7 +860,7 @@ def isSTD_dither(obs_gflux=None, obs_rflux=None, obs_zflux=None,
 
     Notes
     -----
-    - Current version (08/30/18) is version 4 on `the cmx wiki`_.
+    - This version (08/30/18) is version 4 on `the cmx wiki`_.
     """
     if primary is None:
         primary = np.ones_like(obs_rflux, dtype='?')
@@ -398,7 +904,7 @@ def isSTD_test(obs_gflux=None, obs_rflux=None, obs_zflux=None,
 
     Notes
     -----
-    - Current version (08/30/18) is version 4 on `the cmx wiki`_.
+    - This version (08/30/18) is version 4 on `the cmx wiki`_.
     - See also `the Gaia data model`_.
     """
     if primary is None:
@@ -566,11 +1072,11 @@ def apply_cuts(objects, cmxdir=None):
     )
 
     # ADM determine if an object is a "dither" star.
+    # ADM and priority shift.
     std_dither, shift_dither = isSTD_dither(
         obs_gflux=obs_gflux, obs_rflux=obs_rflux, obs_zflux=obs_zflux,
         isgood=isgood, primary=primary
     )
-    # ADM set up an initial priority shift.
 
     # ADM determine if an object is a bright test star.
     std_test = isSTD_test(
@@ -591,12 +1097,12 @@ def apply_cuts(objects, cmxdir=None):
         gaiagmag=gaiagmag, isgood=isgood, primary=primary
     )
 
-    # ADM determine if an object is SV0_BGS
+    # ADM determine if an object is SV0_BGS.
     sv0_bgs = isSV0_BGS(
         rflux=rflux, objtype=objtype, primary=primary
     )
 
-    # ADM determine if an object is SV0_MWS
+    # ADM determine if an object is SV0_MWS.
     sv0_mws = isSV0_MWS(
         rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
         gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag,
@@ -608,13 +1114,57 @@ def apply_cuts(objects, cmxdir=None):
         galb=galb, gaia=gaia, primary=primary
     )
 
-    # ADM Construct the targetflag bits.
+    # ADM determine if an object is SV0_LRG.
+    sv0_lrg = isSV0_LRG(
+        gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
+        rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr,
+        gflux_ivar=gfluxivar, primary=primary
+    )
+
+    # ADM determine if an object is SV0_ELG.
+    sv0_elg = isSV0_ELG(
+        primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
+        gsnr=gsnr, rsnr=rsnr, zsnr=zsnr, maskbits=maskbits
+    )
+
+    # ADM determine if an object is SV0_QSO.
+    sv0_qso = isSV0_QSO(
+        primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
+        w1flux=w1flux, w2flux=w2flux, objtype=objtype,
+        dchisq=dchisq, brightstarinblob=brightstarinblob
+    )
+
+    # ADM run the STD target types for both faint and bright.
+    # ADM Make sure to pass all of the needed columns! At one point we stopped
+    # ADM passing objtype, which meant no standards were being returned.
+    std_classes = []
+    for bright in [False, True]:
+        std_classes.append(
+            isSTD(
+                primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
+                gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
+                gfracmasked=gfracmasked, rfracmasked=rfracmasked, objtype=objtype,
+                zfracmasked=zfracmasked, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
+                gaia=gaia, astrometricexcessnoise=gaiaaen, paramssolved=gaiaparamssolved,
+                pmra=pmra, pmdec=pmdec, parallax=parallax, dupsource=gaiadupsource,
+                gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag, bright=bright
+            )
+        )
+    std_faint, std_bright = std_classes
+
+    # ADM Construct the target flag bits.
     cmx_target = std_dither * cmx_mask.STD_GAIA
     cmx_target |= std_test * cmx_mask.STD_TEST
     cmx_target |= std_calspec * cmx_mask.STD_CALSPEC
     cmx_target |= sv0_std_bright * cmx_mask.SV0_STD_BRIGHT
     cmx_target |= sv0_bgs * cmx_mask.SV0_BGS
     cmx_target |= sv0_mws * cmx_mask.SV0_MWS
+    cmx_target |= sv0_lrg * cmx_mask.SV0_LRG
+    cmx_target |= sv0_elg * cmx_mask.SV0_ELG
+    cmx_target |= sv0_qso * cmx_mask.SV0_QSO
+    cmx_target |= std_faint * cmx_mask.STD_FAINT
+    cmx_target |= std_bright * cmx_mask.STD_BRIGHT
 
     # ADM update the priority with any shifts.
     # ADM we may need to update this logic if there are other shifts.
@@ -698,10 +1248,11 @@ def select_targets(infiles, numproc=4, cmxdir=None):
     def _update_status(result):
         ''' wrapper function for the critical reduction operation,
             that occurs on the main parallel process '''
-        if nbrick % 50 == 0 and nbrick > 0:
-            rate = nbrick / (time() - t0)
-            log.info('{} files; {:.1f} files/sec'.format(nbrick, rate))
-
+        if nbrick % 20 == 0 and nbrick > 0:
+            elapsed = time() - t0
+            rate = elapsed / nbrick
+            log.info('{} files; {:.1f} secs/file; {:.1f} total mins elapsed'
+                     .format(nbrick, rate, elapsed/60.))
         nbrick[...] += 1    # this is an in-place modification
         return result
 

--- a/py/desitarget/cmx/data/cmx_targetmask.yaml
+++ b/py/desitarget/cmx/data/cmx_targetmask.yaml
@@ -6,9 +6,12 @@ cmx_mask:
     - [STD_TEST,        2, "Very bright stars for early tests", {obsconditions: DARK|GRAY|BRIGHT}]
     - [STD_CALSPEC,     3, "Matches to CALSPEC stars", {obsconditions: DARK|GRAY|BRIGHT}]
 
-    # ADM BGS and MWS bits that should resemble at least the initial SV selections ("SV0"), 
+    # ADM targeting bits that should resemble at least the initial SV selections ("SV0"),
     - [SV0_BGS,         8, "Any SV-like BGS (North) bit is set (from initial SV selection)", {obsconditions: BRIGHT}]
     - [SV0_MWS,         9, "Any SV-like MWS (North) bit is set (from initial SV selection)", {obsconditions: BRIGHT}]
+    - [SV0_LRG,        10, "Any SV-like LRG (North) bit is set (from initial SV selection)", {obsconditions: DARK}]
+    - [SV0_ELG,        11, "Any SV-like ELG (North) bit is set (from initial SV selection)", {obsconditions: DARK|GRAY}]
+    - [SV0_QSO,        12, "Any SV-like QSO (North) bit is set (from initial SV selection)", {obsconditions: DARK}]
 
     #- Calibration targets. Shared between main/cmx/sv programs.
     - [SKY,         32, "Blank sky locations",
@@ -51,6 +54,9 @@ priorities:
         STD_CALSPEC: {UNOBS: 3000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         SV0_BGS: {UNOBS: 2100, MORE_ZWARN: 2100, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         SV0_MWS: {UNOBS: 1500, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        SV0_ELG: {UNOBS: 3000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        SV0_LRG: {UNOBS: 3200, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        SV0_QSO: {UNOBS: 3400, MORE_ZGOOD: 3500, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
         SKY: -1
@@ -66,6 +72,9 @@ numobs:
         STD_CALSPEC: 1
         SV0_BGS: 1
         SV0_MWS: 1
+        SV0_ELG: 1
+        SV0_LRG: 2
+        SV0_QSO: 4
         BAD_SKY: 0
         #- Standards and sky are treated specially; NUMOBS doesn't apply
         SKY: -1

--- a/py/desitarget/cmx/data/cmx_targetmask.yaml
+++ b/py/desitarget/cmx/data/cmx_targetmask.yaml
@@ -6,17 +6,19 @@ cmx_mask:
     - [STD_TEST,        2, "Very bright stars for early tests", {obsconditions: DARK|GRAY|BRIGHT}]
     - [STD_CALSPEC,     3, "Matches to CALSPEC stars", {obsconditions: DARK|GRAY|BRIGHT}]
 
-    # ADM targeting bits that should resemble at least the initial SV selections ("SV0"),
-    - [SV0_BGS,         8, "Any SV-like BGS (North) bit is set (from initial SV selection)", {obsconditions: BRIGHT}]
-    - [SV0_MWS,         9, "Any SV-like MWS (North) bit is set (from initial SV selection)", {obsconditions: BRIGHT}]
-    - [SV0_LRG,        10, "Any SV-like LRG (North) bit is set (from initial SV selection)", {obsconditions: DARK}]
-    - [SV0_ELG,        11, "Any SV-like ELG (North) bit is set (from initial SV selection)", {obsconditions: DARK|GRAY}]
-    - [SV0_QSO,        12, "Any SV-like QSO (North) bit is set (from initial SV selection)", {obsconditions: DARK}]
-
+    # ADM targeting bits that should resemble at least the initial SV selections ("SV0").
+    - [SV0_BGS,         8, "SV-like BGS bit is set (very early SV selection)", {obsconditions: BRIGHT}]
+    - [SV0_MWS,         9, "SV-like MWS bit is set (very early SV selection)", {obsconditions: BRIGHT}]
+    - [SV0_LRG,        10, "SV-like LRG bit is set (very early SV selection)", {obsconditions: DARK}]
+    - [SV0_ELG,        11, "SV-like ELG bit is set (very early SV selection)", {obsconditions: DARK|GRAY}]
+    - [SV0_QSO,        12, "SV-like QSO bit is set (very early SV/RF selection)", {obsconditions: DARK}]
+    
     #- Calibration targets. Shared between main/cmx/sv programs.
     - [SKY,         32, "Blank sky locations",
         {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [BAD_SKY,      36, "Blank sky locations that are imperfect but still useable",
+    - [STD_FAINT,   33, "SV-like standard stars for dark/gray conditions", {obsconditions: DARK|GRAY}]
+    - [STD_BRIGHT,  35, "SV-like standard stars for BRIGHT conditions", {obsconditions: BRIGHT}]
+    - [BAD_SKY,     36, "Blank sky locations that are imperfect but still useable",
         {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
 
 #- Observation State
@@ -59,7 +61,9 @@ priorities:
         SV0_QSO: {UNOBS: 3400, MORE_ZGOOD: 3500, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
-        SKY: -1
+        STD_FAINT:  -1
+        SKY:        -1
+        STD_BRIGHT: -1
 
 # ADM INITIAL number of observations (NUMOBS) for each target bit
 # ADM SAME_AS_XXX means to use the NUMOBS for bitname XXX
@@ -77,4 +81,6 @@ numobs:
         SV0_QSO: 4
         BAD_SKY: 0
         #- Standards and sky are treated specially; NUMOBS doesn't apply
+        STD_FAINT: -1
         SKY: -1
+        STD_BRIGHT: -1

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2082,7 +2082,8 @@ def check_input_files(infiles, numproc=4):
         if nbrick % 25 == 0 and nbrick > 0:
             elapsed = time() - t0
             rate = nbrick / elapsed
-            log.info('{} files; {:.1f} files/sec; {:.1f} total mins elapsed'.format(nbrick, rate, elapsed/60.))
+            log.info('{} files; {:.1f} files/sec; {:.1f} total mins elapsed'
+                     .format(nbrick, rate, elapsed/60.))
         nbrick[...] += 1    # this is an in-place modification
         return result
 
@@ -2319,8 +2320,10 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         ''' wrapper function for the critical reduction operation,
             that occurs on the main parallel process '''
         if nbrick % 50 == 0 and nbrick > 0:
-            rate = nbrick / (time() - t0)
-            log.info('{} files; {:.1f} files/sec'.format(nbrick, rate))
+            elapsed = time() - t0
+            rate = elapsed / nbrick
+            log.info('{} files; {:.1f} secs/file; {:.1f} total mins elapsed'
+                     .format(nbrick, rate, elapsed/60.))
 
         nbrick[...] += 1    # this is an in-place modification
         return result

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -757,18 +757,25 @@ def isMWS_WD(primary=None, gaia=None, galb=None, astrometricexcessnoise=None,
     mws = primary.copy()
 
     # ADM do not target any objects for which entries are NaN
-    # ADM and turn off the NaNs for those entries
-    nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
-            np.isnan(parallax))
+    # ADM and turn off the NaNs for those entries.
+    if photbprpexcessfactor is not None:
+        nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
+                np.isnan(parallax) | np.isnan(photbprpexcessfactor))
+    else:
+        nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
+                np.isnan(parallax))
     w = np.where(nans)[0]
     if len(w) > 0:
         parallax, gaiagmag = parallax.copy(), gaiagmag.copy()
         gaiabmag, gaiarmag = gaiabmag.copy(), gaiarmag.copy()
-        parallax[w] = 0.
+        photbprpexcessfactor = photbprpexcessfactor.copy()
+        # ADM safe to make these zero regardless of cuts as...
+        parallax[w], photbprpexcessfactor[w] = 0., 0.
         gaiagmag[w], gaiabmag[w], gaiarmag[w] = 0., 0., 0.
+        # ADM ...we'll turn off all bits here.
         mws &= ~nans
-        log.info('{}/{} NaNs in file...t = {:.1f}s'
-                 .format(len(w), len(mws), time()-start))
+#        log.info('{}/{} NaNs in file...t = {:.1f}s'
+#                 .format(len(w), len(mws), time()-start))
 
     # ADM apply the selection for all MWS-WD targets
     # ADM must be a Legacy Surveys object that matches a Gaia source

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -768,9 +768,11 @@ def isMWS_WD(primary=None, gaia=None, galb=None, astrometricexcessnoise=None,
     if len(w) > 0:
         parallax, gaiagmag = parallax.copy(), gaiagmag.copy()
         gaiabmag, gaiarmag = gaiabmag.copy(), gaiarmag.copy()
-        photbprpexcessfactor = photbprpexcessfactor.copy()
+        if photbprpexcessfactor is not None:
+            photbprpexcessfactor = photbprpexcessfactor.copy()
         # ADM safe to make these zero regardless of cuts as...
-        parallax[w], photbprpexcessfactor[w] = 0., 0.
+            photbprpexcessfactor[w] = 0.
+        parallax[w] = 0.
         gaiagmag[w], gaiabmag[w], gaiarmag[w] = 0., 0., 0.
         # ADM ...we'll turn off all bits here.
         mws &= ~nans

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -11,12 +11,14 @@ from __future__ import (absolute_import, division)
 #
 import numpy as np
 import fitsio
+from fitsio import FITS
 import os
 import re
 from . import __version__ as desitarget_version
 import numpy.lib.recfunctions as rfn
 import healpy as hp
 from glob import glob, iglob
+from time import time
 
 from desiutil import depend
 from desitarget.geomask import hp_in_box, box_area, is_in_box
@@ -364,8 +366,12 @@ def write_targets(filename, data, indir=None, indir2=None, nchunks=None,
     if nchunks is None:
         fitsio.write(filename, data, extname='TARGETS', header=hdr, clobber=True)
     else:
+        # ADM ensure that files are always overwritten.
+        if os.path.isfile(filename):
+            os.remove(filename)
+        start = time()
         # ADM open a file for writing.
-        outy = fitsio.FITS(filename, 'rw')
+        outy = FITS(filename, 'rw')
         # ADM write the chunks one-by-one.
         chunk = len(data)//nchunks
         for i in range(nchunks):
@@ -382,7 +388,7 @@ def write_targets(filename, data, indir=None, indir2=None, nchunks=None,
         datachunk = data[nchunks*chunk:]
         log.info("Writing final partial chunk from index {} to {}...t = {:.1f}s"
                  .format(nchunks*chunk, len(data)-1, time()-start))
-        outy[-1].append
+        outy[-1].append(datachunk)
         outy.close()
 
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1149,9 +1149,11 @@ def isMWS_WD(primary=None, gaia=None, galb=None, astrometricexcessnoise=None,
     if len(w) > 0:
         parallax, gaiagmag = parallax.copy(), gaiagmag.copy()
         gaiabmag, gaiarmag = gaiabmag.copy(), gaiarmag.copy()
-        photbprpexcessfactor = photbprpexcessfactor.copy()
+        if photbprpexcessfactor is not None:
+            photbprpexcessfactor = photbprpexcessfactor.copy()
         # ADM safe to make these zero regardless of cuts as...
-        parallax[w], photbprpexcessfactor[w] = 0., 0.
+            photbprpexcessfactor[w] = 0.
+        parallax[w] = 0.
         gaiagmag[w], gaiabmag[w], gaiarmag[w] = 0., 0., 0.
         # ADM ...we'll turn off all bits here.
         mws &= ~nans

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1138,18 +1138,25 @@ def isMWS_WD(primary=None, gaia=None, galb=None, astrometricexcessnoise=None,
     mws = primary.copy()
 
     # ADM do not target any objects for which entries are NaN
-    # ADM and turn off the NaNs for those entries
-    nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
-            np.isnan(parallax))
+    # ADM and turn off the NaNs for those entries.
+    if photbprpexcessfactor is not None:
+        nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
+                np.isnan(parallax) | np.isnan(photbprpexcessfactor))
+    else:
+        nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
+                np.isnan(parallax))
     w = np.where(nans)[0]
     if len(w) > 0:
         parallax, gaiagmag = parallax.copy(), gaiagmag.copy()
         gaiabmag, gaiarmag = gaiabmag.copy(), gaiarmag.copy()
-        parallax[w] = 0.
+        photbprpexcessfactor = photbprpexcessfactor.copy()
+        # ADM safe to make these zero regardless of cuts as...
+        parallax[w], photbprpexcessfactor[w] = 0., 0.
         gaiagmag[w], gaiabmag[w], gaiarmag[w] = 0., 0., 0.
+        # ADM ...we'll turn off all bits here.
         mws &= ~nans
-        log.info('{}/{} NaNs in file...t = {:.1f}s'
-                 .format(len(w), len(mws), time()-start))
+#        log.info('{}/{} NaNs in file...t = {:.1f}s'
+#                 .format(len(w), len(mws), time()-start))
 
     # ADM apply the selection for all MWS-WD targets
     # ADM must be a Legacy Surveys object that matches a Gaia source

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1184,9 +1184,9 @@ def isMWS_WD(primary=None, gaia=None, galb=None, astrometricexcessnoise=None,
     mws &= Gabs > 6*br*br*br - 21.77*br*br + 27.91*br + 0.897
     mws &= br < 1.7
 
-    # ADM Finite proper motion to reject quasars
+    # ADM Finite proper motion to reject quasars.
     # ADM Inexplicably I'm getting a Runtimewarning here for
-    # ADM a few values in the sqrt, so I'm catching it
+    # ADM a few values in the sqrt, so I'm catching it.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         pm = np.sqrt(pmra**2. + pmdec**2.)
@@ -1419,7 +1419,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # ADM initially set everything to False for the standards.
     std_faint, std_bright, std_wd = ~primary, ~primary, ~primary
     if "STD" in tcnames:
-        # ADM run the MWS_MAIN target types for both faint and bright.
+        # ADM run the STD target types for both faint and bright.
         # ADM Make sure to pass all of the needed columns! At one point we stopped
         # ADM passing objtype, which meant no standards were being returned.
         std_classes = []


### PR DESCRIPTION
This PR adds the ELG/LRG/QSO/STD early SV ("SV0") selections for commissioning. 

It also includes a more minor update to ensure that (the few) MWS targets that have `NaNs` in columns that were added to the imaging data model as part of DR8 are not targeted.