### PR TITLE
Deprecate BRIGHTSTARINBLOB and use MASKBITS everywhere instead

### DIFF
--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -57,8 +57,18 @@ ap.add_argument("--aprad", type=float,
                 help="Radius of aperture in arcsec in which to generate sky background flux levels (defaults to 0.75; the DESI fiber radius)",
                 default=0.75)
 
-
 ns = ap.parse_args()
+# ADM build the list of command line arguments as
+# ADM bundlefiles potentially needs to know about them.
+extra = " --numproc {}".format(ns.numproc)
+nsdict = vars(ns)
+for nskey in "noresolve", "aprad":
+    if isinstance(nsdict[nskey], bool):
+        if nsdict[nskey]:
+            extra += " --{}".format(nskey)
+    else:
+        extra += " --{} {}".format(nskey, nsdict[nskey])
+
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels
 if pixlist is not None:
@@ -92,7 +102,7 @@ if not 'dr5' in ns.surveydir and not 'dr6' in ns.surveydir:
             hdr[record] = rmhdr['_record_map'][record]
 
 randoms = select_randoms(ns.surveydir, density=ns.density, numproc=ns.numproc,
-                         nside=ns.nside, pixlist=pixlist, aprad=ns.aprad,
+                         nside=ns.nside, pixlist=pixlist, aprad=ns.aprad, extra=extra,
                          bundlebricks=ns.bundlebricks, brickspersec=ns.brickspersec,
                          dustdir=ns.dustdir, resolverands=not(ns.noresolve))
 

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -62,7 +62,8 @@ ap.add_argument('--radecrad',
                 default=None)
 ap.add_argument("--noresolve", action='store_true',
                 help="Do NOT resolve into northern targets in northern regions and southern targets in southern regions")
-
+ap.add_argument("--nomaskbits", action='store_true',
+                help="Do NOT apply information in MASKBITS column to target classes")
 
 ns = ap.parse_args()
 
@@ -121,12 +122,14 @@ targets = select_targets(infiles, numproc=ns.numproc,
                          nside=ns.nside, pixlist=pixlist,
                          bundlefiles=ns.bundlefiles, filespersec=ns.filespersec,
                          radecbox=inlists[0], radecrad=inlists[1],
-                         tcnames=tcnames, survey=survey, resolvetargs=not(ns.noresolve))
+                         tcnames=tcnames, survey=survey,
+                         resolvetargs=not(ns.noresolve), mask=not(ns.nomaskbits))
 if ns.mask:
     targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
 if ns.bundlefiles is None:
     io.write_targets(ns.dest, targets, indir=ns.sweepdir, indir2=ns.sweepdir2,
                      survey=survey, nsidefile=ns.nside, hpxlist=pixlist,
-                     qso_selection=survey, nside=nside, resolve=not(ns.noresolve))
+                     qso_selection=survey, nside=nside,
+                     resolve=not(ns.noresolve), maskbits=not(ns.nomaskbits))
     log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -65,7 +65,15 @@ ap.add_argument("--noresolve", action='store_true',
 ap.add_argument("--nomaskbits", action='store_true',
                 help="Do NOT apply information in MASKBITS column to target classes")
 
+
 ns = ap.parse_args()
+# ADM build the list of command line arguments as
+# ADM bundlefiles potentially needs to know about them.
+extra = " --numproc {}".format(ns.numproc)
+nsdict = vars(ns)
+for nskey in "noresolve", "nomaskbits":
+    if nsdict[nskey]:
+        extra += " --{}".format(nskey)
 
 infiles = io.list_sweepfiles(ns.sweepdir)
 if ns.sweepdir2 is not None:
@@ -119,7 +127,7 @@ for i, inlist in enumerate(inlists):
 tcnames = _parse_tcnames(tcstring=ns.tcnames, add_all=False)
 
 targets = select_targets(infiles, numproc=ns.numproc,
-                         nside=ns.nside, pixlist=pixlist,
+                         nside=ns.nside, pixlist=pixlist, extra=extra,
                          bundlefiles=ns.bundlefiles, filespersec=ns.filespersec,
                          radecbox=inlists[0], radecrad=inlists[1],
                          tcnames=tcnames, survey=survey,

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -77,6 +77,13 @@ ap.add_argument("--nomaskbits", action='store_true',
                 help="Do NOT apply information in MASKBITS column to target classes")
 
 ns = ap.parse_args()
+# ADM build the list of command line arguments as
+# ADM bundlefiles potentially needs to know about them.
+extra = " --numproc {}".format(ns.numproc)
+nsdict = vars(ns)
+for nskey in "noresolve", "nomaskbits":
+    if nsdict[nskey]:
+        extra += " --{}".format(nskey)
 
 infiles = io.list_sweepfiles(ns.sweepdir)
 if ns.sweepdir2 is not None:
@@ -116,7 +123,7 @@ else:
     targets = select_targets(infiles, numproc=ns.numproc,
                              qso_selection=ns.qsoselection, gaiamatch=ns.gaiamatch,
                              sandbox=ns.sandbox, FoMthresh=ns.FoMthresh, Method=ns.Method,
-                             nside=ns.nside, pixlist=pixlist,
+                             nside=ns.nside, pixlist=pixlist, extra=extra,
                              bundlefiles=ns.bundlefiles, filespersec=ns.filespersec,
                              radecbox=inlists[0], radecrad=inlists[1],
                              tcnames=tcnames, survey='main',

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -73,6 +73,8 @@ ap.add_argument('--radecrad',
                 default=None)
 ap.add_argument("--noresolve", action='store_true',
                 help="Do NOT resolve into northern targets in northern regions and southern targets in southern regions")
+ap.add_argument("--nomaskbits", action='store_true',
+                help="Do NOT apply information in MASKBITS column to target classes")
 
 ns = ap.parse_args()
 
@@ -117,14 +119,17 @@ else:
                              nside=ns.nside, pixlist=pixlist,
                              bundlefiles=ns.bundlefiles, filespersec=ns.filespersec,
                              radecbox=inlists[0], radecrad=inlists[1],
-                             tcnames=tcnames, survey='main', resolvetargs=not(ns.noresolve))
+                             tcnames=tcnames, survey='main',
+                             resolvetargs=not(ns.noresolve), mask=not(ns.nomaskbits)
+    )
     if ns.mask:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
     if ns.bundlefiles is None:
         # ADM only write out a targeting file if it's non-zero.
         if len(targets) > 0:
-            io.write_targets(ns.dest, targets, resolve=not(ns.noresolve), indir=ns.sweepdir,
-                             indir2=ns.sweepdir2, survey="main", nsidefile=ns.nside, hpxlist=pixlist,
+            io.write_targets(ns.dest, targets, resolve=not(ns.noresolve), maskbits=not(ns.nomaskbits),
+                             indir=ns.sweepdir, indir2=ns.sweepdir2,
+                             survey="main", nsidefile=ns.nside, hpxlist=pixlist,
                              qso_selection=ns.qsoselection, sandboxcuts=ns.sandbox, nside=nside)
         log.info('{} targets written to {}...t={:.1f}s'.format(len(targets), ns.dest, time()-start))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,12 +5,15 @@ desitarget Change Log
 0.31.2 (unreleased)
 -------------------
 
+* Deprecate ``BRIGHTSTARINBLOB`` use ``MASKBITS`` instead [`PR #521`_].
+* Extra options/care when making/vetting bundling scripts [`PR #521`_].
 * Add ELG/LRG/QSO/STD selections for commissioning [`PR #519`_].
-* Add full set of columns to supplemental skies file [`PR #518`_]
-* Fix some corner cases when reading HEALPixel-split files [`PR #518`_]
+* Add full set of columns to supplemental skies file [`PR #518`_].
+* Fix some corner cases when reading HEALPixel-split files [`PR #518`_].
 
 .. _`PR #518`: https://github.com/desihub/desitarget/pull/518
 .. _`PR #519`: https://github.com/desihub/desitarget/pull/519
+.. _`PR #521`: https://github.com/desihub/desitarget/pull/521
 
 0.31.1 (2019-07-05)
 -------------------
@@ -22,7 +25,7 @@ desitarget Change Log
 0.31.0 (2019-06-30)
 -------------------
 
-* MASKBITS of BAILOUT for randoms when no file is found [`PR #515`_].
+* ``MASKBITS`` of ``BAILOUT`` for randoms when no file is found [`PR #515`_].
 * Near-trivial fix for an unintended change to the isELG API introduced in `PR
   #513`_ [`PR #514`_]. 
 * Preliminary ELG cuts for DR8 imaging for main and SV [`PR #513`_].

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,8 +5,9 @@ desitarget Change Log
 0.31.2 (unreleased)
 -------------------
 
-* Deprecate ``BRIGHTSTARINBLOB`` use ``MASKBITS`` instead [`PR #521`_].
-* Extra options/care when making/vetting bundling scripts [`PR #521`_].
+* Use ``MASKBITS`` instead of ``BRIGHTSTARINBLOB`` [`PR #521`_]. Also:
+    * Extra options and checks when making and vetting bundling scripts.
+    * Option to turn off commissioning QSO cuts to speed unit tests.
 * Add ELG/LRG/QSO/STD selection cuts for commissioning [`PR #519`_].
 * Add full set of columns to supplemental skies file [`PR #518`_].
 * Fix some corner cases when reading HEALPixel-split files [`PR #518`_].

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,7 +7,7 @@ desitarget Change Log
 
 * Deprecate ``BRIGHTSTARINBLOB`` use ``MASKBITS`` instead [`PR #521`_].
 * Extra options/care when making/vetting bundling scripts [`PR #521`_].
-* Add ELG/LRG/QSO/STD selections for commissioning [`PR #519`_].
+* Add ELG/LRG/QSO/STD selection cuts for commissioning [`PR #519`_].
 * Add full set of columns to supplemental skies file [`PR #518`_].
 * Fix some corner cases when reading HEALPixel-split files [`PR #518`_].
 

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1026,8 +1026,7 @@ def apply_cuts(objects, cmxdir=None):
         gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,                         \
         gfracmasked, rfracmasked, zfracmasked,                                        \
         gfracin, rfracin, zfracin, gallmask, rallmask, zallmask,                      \
-        gsnr, rsnr, zsnr, w1snr, w2snr,                                               \
-        dchisq, deltaChi2, brightstarinblob, maskbits =                               \
+        gsnr, rsnr, zsnr, w1snr, w2snr, dchisq, deltaChi2, maskbits =                 \
         _prepare_optical_wise(objects, colnames=colnames)
 
     # ADM in addition, cmx needs ra and dec.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2125,7 +2125,7 @@ Method_sandbox_options = ['XD', 'RF_photo', 'RF_spectro']
 def select_targets(infiles, numproc=4, qso_selection='randomforest',
                    gaiamatch=False, sandbox=False, FoMthresh=None, Method=None,
                    nside=None, pixlist=None, bundlefiles=None, filespersec=0.12,
-                   radecbox=None, radecrad=None, mask=True,
+                   extra=None, radecbox=None, radecrad=None, mask=True,
                    tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD"],
                    survey='main', resolvetargs=True):
     """Process input files in parallel to select targets.
@@ -2162,10 +2162,13 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         files per node. So, for instance, if `bundlefiles` is 100 then commands would be
         returned with the correct `pixlist` values set to pass to the code to pack at
         about 100 files per node across all of the passed `infiles`.
-    filespersec : :class:`float`, optional, defaults to 1
+    filespersec : :class:`float`, optional, defaults to 0.12
         The rough number of files processed per second by the code (parallelized across
         a chosen number of nodes). Used in conjunction with `bundlefiles` for the code
         to estimate time to completion when parallelizing across pixels.
+    extra : :class:`str`, optional
+        Extra command line flags to be passed to the executable lines in
+        the output slurm script. Used in conjunction with `bundlefiles`.
     radecbox : :class:`list`, defaults to `None`
         4-entry list of coordinates [ramin, ramax, decmin, decmax] forming the edges
         of a box in RA/Dec (degrees). Only targets in this box region will be processed.
@@ -2269,7 +2272,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         surveydirs = list(set([os.path.dirname(fn) for fn in infiles]))
         bundle_bricks(pixnum, bundlefiles, nside,
                       brickspersec=filespersec, gather=False,
-                      prefix=prefix, surveydirs=surveydirs)
+                      prefix=prefix, surveydirs=surveydirs, extra=extra)
         return
 
     # ADM restrict to only input files in a set of HEALPixels, if requested.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1156,7 +1156,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
         for bit in [1, 10, 12, 13]:
             preSelection &= ((maskbits & 2**bit) == 0)
 
-    # "qso" mask initialized to "preSelection" mask
+    # "qso" mask initialized to "preSelection" mask.
     qso = np.copy(preSelection)
 
     if np.any(preSelection):

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -753,6 +753,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
         s2 = "-s2 {}".format(surveydir2)
 
     outfiles = []
+    from desitarget.io import _check_hpx_length
     for bin in bins:
         num = np.array(bin)[:, 0]
         pix = np.array(bin)[:, 1]
@@ -760,6 +761,8 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
         if len(wpix) > 0:
             goodpix = pix[wpix]
             goodpix.sort()
+            # ADM check that we won't overwhelm the pixel scheme.
+            _check_hpx_length(goodpix)
             strgoodpix = ",".join([str(pix) for pix in goodpix])
             # ADM the replace is to handle inputs that look like "sv1_targets".
             outfile = "$CSCRATCH/{}-dr{}-hp-{}.fits".format(prefix.replace("_", "-"), dr, strgoodpix)

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -605,7 +605,7 @@ def circle_boundaries(RAcens, DECcens, r, nloc):
 
 
 def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
-                  gather=True, surveydirs=None):
+                  gather=True, surveydirs=None, extra=None):
     """Determine the optimal packing for bricks collected by HEALpixel integer.
 
     Parameters
@@ -634,6 +634,9 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
         list is interpreted as the main directory. IF the list is of length two
         then the second directory is supplied as "-s2" in the output script.
         (e.g. ["/global/project/projectdirs/cosmo/data/legacysurvey/dr6"]).
+    extra : :class:`str`, optional
+        Extra command line flags to be passed to the executable lines in
+        the output slurm script.
 
     Returns
     -------
@@ -703,7 +706,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             # ADM add the total across all of the pixels
             outnote.append('Total: {}'.format(np.sum(goodnum)))
             # ADM a crude estimate of how long the script will take to run
-            # ADM brickspersec is bricks/sec. Extra delta is minutes to write to disk
+            # ADM brickspersec is bricks/sec. Extra delta is minutes to write to disk.
             delta = 3./60.
             eta = delta + np.sum(goodnum)/brickspersec/3600
             outnote.append('Estimated time to run in hours (for 32 processors per node): {:.2f}h'
@@ -767,7 +770,9 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             # ADM the replace is to handle inputs that look like "sv1_targets".
             outfile = "$CSCRATCH/{}-dr{}-hp-{}.fits".format(prefix.replace("_", "-"), dr, strgoodpix)
             outfiles.append(outfile)
-            print("srun -N 1 select_{} {} {} {} --numproc 32 --nside {} --healpixels {} &"
+            if extra is not None:
+                strgoodpix += extra
+            print("srun -N 1 select_{} {} {} {} --nside {} --healpixels {} &"
                   .format(prefix2, surveydir, outfile, s2, nside, strgoodpix))
     print("wait")
     print("")

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -270,7 +270,8 @@ def release_to_photsys(release):
 
 def write_targets(filename, data, indir=None, indir2=None, nchunks=None,
                   qso_selection=None, sandboxcuts=False, nside=None,
-                  survey="?", nsidefile=None, hpxlist=None, resolve=True):
+                  survey="?", nsidefile=None, hpxlist=None,
+                  resolve=True, maskbits=True):
     """Write a target catalogue.
 
     Parameters
@@ -300,8 +301,8 @@ def write_targets(filename, data, indir=None, indir2=None, nchunks=None,
         Passed to indicate in the output file header that the targets
         have been limited to only this list of HEALPixels. Used in
         conjunction with `nsidefile`.
-    resolve : :class:`bool`, optional, defaults to ``True``
-        Written to the output file header as `RESOLVE`.
+    resolve, maskbits : :class:`bool`, optional, default to ``True``
+        Written to the output file header as `RESOLVE`, `MASKBITS`.
     """
     # FIXME: assert data and tsbits schema
 
@@ -349,6 +350,8 @@ def write_targets(filename, data, indir=None, indir2=None, nchunks=None,
     hdr["SURVEY"] = survey
     # ADM add whether or not the targets were resolved to the header.
     hdr["RESOLVE"] = resolve
+    # ADM add whether or not MASKBITS was applied to the header.
+    hdr["MASKBITS"] = maskbits
 
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1448,7 +1448,7 @@ def _check_hpx_length(hpxlist, length=68, warning=False):
     """Check a list expressed as a csv string won't exceed a length."""
     pixstring = ",".join([str(i) for i in hpxlist])
     if len(pixstring) > length:
-        msg = 'Pixel string is too long ({}). Can only store {}'   \
+        msg = "Pixel string {} is too long. Maximum is length-{} strings."  \
             .format(pixstring, length)
         if warning:
             log.warning(msg)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -363,6 +363,8 @@ def write_targets(filename, data, indir=None, indir2=None, nchunks=None,
             raise ValueError(msg)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
+        # ADM warn if we've stored a pixel string that is too long.
+        _check_hpx_length(hpxlist, warning=True)
         hdr['FILEHPX'] = hpxlist
 
     # ADM write in a series of chunks to save memory.
@@ -1134,6 +1136,8 @@ def check_hp_target_dir(hpdirname):
         # ADM if this is a one-pixel file, convert to a list.
         if isinstance(pixels, int):
             pixels = [pixels]
+        # ADM check we haven't stored a pixel string that is too long.
+        _check_hpx_length(pixels)
         # ADM create a look-up dictionary of file-for-each-pixel.
         for pix in pixels:
             pixdict[pix] = fn
@@ -1438,3 +1442,16 @@ def target_columns_from_header(hpdirname):
     targcols = allcols[['_TARGET' in col for col in allcols]]
 
     return list(targcols)
+
+
+def _check_hpx_length(hpxlist, length=68, warning=False):
+    """Check a list expressed as a csv string won't exceed a length."""
+    pixstring = ",".join([str(i) for i in hpxlist])
+    if len(pixstring) > length:
+        msg = 'Pixel string is too long ({}). Can only store {}'   \
+            .format(pixstring, length)
+        if warning:
+            log.warning(msg)
+        else:
+            log.critical(msg)
+            raise ValueError(msg)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1118,7 +1118,7 @@ def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None):
 
 
 def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
-                   bundlebricks=None, brickspersec=2.5,
+                   bundlebricks=None, brickspersec=2.5, extra=None,
                    dustdir=None, resolverands=True, aprad=0.75):
     """NOBS, DEPTHs (per-band), MASKs for random points in a Legacy Surveys DR.
 
@@ -1151,6 +1151,9 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
         The rough number of bricks processed per second by the code (parallelized across
         a chosen number of nodes). Used in conjunction with `bundlebricks` for the code
         to estimate time to completion when parallelizing across pixels.
+    extra : :class:`str`, optional
+        Extra command line flags to be passed to the executable lines in
+        the output slurm script. Used in conjunction with `bundlefiles`.
     dustdir : :class:`str`, optional, defaults to $DUST_DIR+'maps'
         The root directory pointing to SFD dust maps. If None the code
         will try to use $DUST_DIR+'maps') before failing.
@@ -1187,7 +1190,7 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
         allpixnum = np.concatenate([np.zeros(cnt, dtype=int)+pix
                                     for cnt, pix in zip(cnts.astype(int), pixnum)])
         bundle_bricks(allpixnum, bundlebricks, nside, brickspersec=brickspersec,
-                      prefix='randoms', surveydirs=[drdir])
+                      prefix='randoms', surveydirs=[drdir], extra=extra)
         return
 
     # ADM restrict to only bricks in a set of HEALPixels, if requested.

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -378,8 +378,8 @@ def isSTD_gaia(primary=None, gaia=None, astrometricexcessnoise=None,
 
 def isQSO_cuts(gflux=None, rflux=None, zflux=None,
                w1flux=None, w2flux=None, w1snr=None, w2snr=None,
-               dchisq=None, brightstarinblob=None,
-               objtype=None, primary=None, south=True):
+               dchisq=None, maskbits=None, objtype=None,
+               primary=None, south=True):
     """Definition of QSO target classes from color cuts. Returns a boolean array.
 
     Parameters
@@ -405,8 +405,11 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None,
         primary = np.ones_like(rflux, dtype='?')
     qso = primary.copy()
 
-    # ADM Reject objects flagged inside a bright star blob.
-    qso &= ~brightstarinblob
+    # ADM Reject objects in masks.
+    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
+    if maskbits is not None:
+        for bit in [1, 10, 12, 13]:
+            qso &= ((maskbits & 2**bit) == 0)
 
     # ADM relaxed morphology cut for SV.
     # ADM we never target sources with dchisq[..., 0] = 0, so force
@@ -518,7 +521,7 @@ def isQSO_color_high_z(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
 
 
 def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-                       objtype=None, release=None, dchisq=None, brightstarinblob=None,
+                       objtype=None, release=None, dchisq=None, maskbits=None,
                        primary=None, south=True):
     """Definition of QSO target class using random forest. Returns a boolean array.
 
@@ -570,8 +573,11 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
         morph2 = dcs < 0.02
     preSelection &= _psflike(objtype) | morph2
 
-    # CAC Reject objects flagged inside a blob.
-    preSelection &= ~brightstarinblob
+    # ADM Reject objects in masks.
+    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
+    if maskbits is not None:
+        for bit in [1, 10, 12, 13]:
+            preSelection &= ((maskbits & 2**bit) == 0)
 
     # "qso" mask initialized to "preSelection" mask
     qso = np.copy(preSelection)
@@ -628,7 +634,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
 
 
 def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-                      objtype=None, release=None, dchisq=None, brightstarinblob=None,
+                      objtype=None, release=None, dchisq=None, maskbits=None,
                       primary=None, south=True):
     """Definition of QSO target for highz (z>2.0) faint QSOs. Returns a boolean array.
 
@@ -682,8 +688,11 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
     # Standard morphology cut.
     preSelection &= _psflike(objtype)
 
-    #  Reject objects flagged inside a blob.
-    preSelection &= ~brightstarinblob
+    # ADM Reject objects in masks.
+    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
+    if maskbits is not None:
+        for bit in [1, 10, 12, 13]:
+            preSelection &= ((maskbits & 2**bit) == 0)
 
     # "qso" mask initialized to "preSelection" mask.
     qso = np.copy(preSelection)
@@ -734,7 +743,7 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
 def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, rfiberflux=None,
           gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
           gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
-          gfluxivar=None, rfluxivar=None, zfluxivar=None, brightstarinblob=None, Grr=None,
+          gfluxivar=None, rfluxivar=None, zfluxivar=None, maskbits=None, Grr=None,
           w1snr=None, gaiagmag=None, objtype=None, primary=None, south=True, targtype=None):
     """Definition of BGS target classes. Returns a boolean array.
 
@@ -772,7 +781,7 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, rfiberfl
                          gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
                          gfracin=gfracin, rfracin=rfracin, zfracin=zfracin, w1snr=w1snr,
                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
-                         gaiagmag=gaiagmag, brightstarinblob=brightstarinblob, objtype=objtype, targtype=targtype)
+                         gaiagmag=gaiagmag, maskbits=maskbits, objtype=objtype, targtype=targtype)
 
     bgs &= isBGS_colors(rflux=rflux, rfiberflux=rfiberflux, south=south, targtype=targtype, primary=primary)
 
@@ -784,7 +793,7 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
                   gfracflux=None, rfracflux=None, zfracflux=None,
                   gfracin=None, rfracin=None, zfracin=None, w1snr=None,
                   gfluxivar=None, rfluxivar=None, zfluxivar=None, Grr=None,
-                  gaiagmag=None, brightstarinblob=None, objtype=None, targtype=None):
+                  gaiagmag=None, maskbits=None, objtype=None, targtype=None):
     """Standard set of masking cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS_faint` for parameters).
     """
@@ -801,7 +810,7 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
     bgs_qcs &= (gfracflux < 5.0) & (rfracflux < 5.0) & (zfracflux < 5.0)
     bgs_qcs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
     bgs_qcs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
-    bgs_qcs &= ~brightstarinblob
+    bgs_qcs &= (maskbits & 2**1) == 0
     # color box
     bgs_qcs &= rflux > gflux * 10**(-1.0/2.5)
     bgs_qcs &= rflux < gflux * 10**(4.0/2.5)
@@ -1217,7 +1226,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     gaia, pmra, pmdec, parallax, parallaxovererror, parallaxerr,
                     gaiagmag, gaiabmag, gaiarmag, gaiaaen, gaiadupsource,
                     gaiaparamssolved, gaiabprpfactor, gaiasigma5dmax, galb,
-                    tcnames, qso_optical_cuts, qso_selection, brightstarinblob,
+                    tcnames, qso_optical_cuts, qso_selection,
                     maskbits, Grr, primary, resolvetargs=True):
     """Perform target selection on parameters, return target mask arrays.
 
@@ -1291,7 +1300,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 isQSO_cuts(
                     primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                     w1flux=w1flux, w2flux=w2flux,
-                    dchisq=dchisq, brightstarinblob=brightstarinblob,
+                    dchisq=dchisq, maskbits=maskbits,
                     objtype=objtype, w1snr=w1snr, w2snr=w2snr,
                     south=south
                 )
@@ -1306,7 +1315,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     isQSO_randomforest(
                         primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                         w1flux=w1flux, w2flux=w2flux,
-                        dchisq=dchisq, brightstarinblob=brightstarinblob,
+                        dchisq=dchisq, maskbits=maskbits,
                         objtype=objtype, south=south
                     )
                 )
@@ -1314,7 +1323,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     isQSO_highz_faint(
                         primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                         w1flux=w1flux, w2flux=w2flux,
-                        dchisq=dchisq, brightstarinblob=brightstarinblob,
+                        dchisq=dchisq, maskbits=maskbits,
                         objtype=objtype, south=south
                     )
                 )
@@ -1366,7 +1375,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                         gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
                         gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
                         gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                        brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag,
+                        maskbits=maskbits, Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag,
                         objtype=objtype, primary=primary, south=south, targtype=targtype
                     )
                 )

--- a/py/desitarget/test/test_cmx.py
+++ b/py/desitarget/test/test_cmx.py
@@ -29,21 +29,23 @@ class TestCMX(unittest.TestCase):
     def test_cuts_basic(self):
         """Test cuts work with either data or filenames
         """
-        # ADM test for tractor files
+        # ADM test for tractor files.
+        # ADM No QSO cuts for speed. This doesn't affect coverage.
         cmx, pshift = cuts.apply_cuts(self.tractorfiles[0],
-                                      cmxdir=self.cmxdir)
+                                      cmxdir=self.cmxdir, noqso=True)
         data = io.read_tractor(self.tractorfiles[0])
         cmx2, pshift2 = cuts.apply_cuts(data,
-                                        cmxdir=self.cmxdir)
+                                        cmxdir=self.cmxdir, noqso=True)
         self.assertTrue(np.all(cmx == cmx2))
         self.assertTrue(np.all(pshift == pshift2))
 
-        # ADM test for sweeps files
+        # ADM test for sweeps files.
+        # ADM No QSO cuts for speed. This doesn't affect coverage.
         cmx, pshift = cuts.apply_cuts(self.sweepfiles[0],
-                                      cmxdir=self.cmxdir)
+                                      cmxdir=self.cmxdir, noqso=True)
         data = io.read_tractor(self.sweepfiles[0])
         cmx2, pshift2 = cuts.apply_cuts(data,
-                                        cmxdir=self.cmxdir)
+                                        cmxdir=self.cmxdir, noqso=True)
         self.assertTrue(np.all(cmx == cmx2))
         self.assertTrue(np.all(pshift == pshift2))
 
@@ -85,12 +87,13 @@ class TestCMX(unittest.TestCase):
         """Test select targets works with either data or filenames
         """
         for filelist in [self.tractorfiles, self.sweepfiles]:
+            # ADM No QSO cuts for speed. This doesn't affect coverage.
             targets = cuts.select_targets(filelist, numproc=1,
-                                          cmxdir=self.cmxdir)
+                                          cmxdir=self.cmxdir, noqso=True)
             t1 = cuts.select_targets(filelist[0:1], numproc=1,
-                                     cmxdir=self.cmxdir)
+                                     cmxdir=self.cmxdir, noqso=True)
             t2 = cuts.select_targets(filelist[0], numproc=1,
-                                     cmxdir=self.cmxdir)
+                                     cmxdir=self.cmxdir, noqso=True)
             for col in t1.dtype.names:
                 try:
                     notNaN = ~np.isnan(t1[col])
@@ -110,8 +113,9 @@ class TestCMX(unittest.TestCase):
         """
         for nproc in [1, 2]:
             for filelist in [self.tractorfiles, self.sweepfiles]:
+                # ADM No QSO cuts for speed. Doesn't affect coverage.
                 targets = cuts.select_targets(filelist, numproc=nproc,
-                                              cmxdir=self.cmxdir)
+                                              cmxdir=self.cmxdir, noqso=True)
                 self.assertTrue('CMX_TARGET' in targets.dtype.names)
                 self.assertEqual(len(targets), np.count_nonzero(targets['CMX_TARGET']))
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -107,7 +107,6 @@ class TestCuts(unittest.TestCase):
         gfracin = targets['FRACIN_G']
         rfracin = targets['FRACIN_R']
         zfracin = targets['FRACIN_Z']
-        brightstarinblob = (targets['MASKBITS'] & 2**1) != 0
         maskbits = targets['MASKBITS']
 
         gaiagmag = targets['GAIA_PHOT_G_MEAN_MAG']
@@ -153,7 +152,7 @@ class TestCuts(unittest.TestCase):
                                gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
                                gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
                                gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                               brightstarinblob=brightstarinblob, Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag,
+                               maskbits=maskbits, Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag,
                                primary=primary, targtype=targtype)
                 )
             self.assertTrue(np.all(bgs[0] == bgs[1]))
@@ -163,11 +162,11 @@ class TestCuts(unittest.TestCase):
         # - Test that objtype and primary are optional
         psftype = targets['TYPE']
         qso1 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
-                               deltaChi2=deltaChi2, brightstarinblob=brightstarinblob,
+                               deltaChi2=deltaChi2, maskbits=maskbits,
                                w1snr=w1snr, w2snr=w2snr, objtype=psftype, primary=primary,
                                release=release)
         qso2 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
-                               deltaChi2=deltaChi2, brightstarinblob=brightstarinblob,
+                               deltaChi2=deltaChi2, maskbits=maskbits,
                                w1snr=w1snr, w2snr=w2snr, objtype=None, primary=None,
                                release=release)
         self.assertTrue(np.all(qso1 == qso2))


### PR DESCRIPTION
This PR deprecates `BRIGHTSTARINBLOB`. Logic cuts on `MASKBITS` are used throughout the code instead.

This PR also includes extra options when generating parallelization/bundling scripts, and extra error checking on I/O for files that are partitioned by HEALPixel