### PR TITLE
Add new redshift 5 quasar selection for SV

### DIFF
--- a/bin/select_secondary
+++ b/bin/select_secondary
@@ -23,7 +23,7 @@ ap.add_argument("priminfodir",
 ap.add_argument("dest",
                 help="Output secondary-only targets file (e.g. '/project/projectdirs/desi/target/catalogs/secondary-dr6-0.20.0.fits' at NERSC)")
 ap.add_argument("-s", "--separation", type=float, default=1.,
-                help='Angular separation at which to match primary and secondary targets. Defaults to [1] arcsec.')
+                help='Angular separation at which to match secondary targets to themselves. Defaults to [1] arcsec.')
 ap.add_argument("--scnddir",
                 help="Base directory of secondary target files (e.g. '/project/projectdirs/desi/target/secondary' at NERSC). "+
                 "Defaults to SCND_DIR environment variable.")

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -119,7 +119,16 @@ else:
     skies = np.concatenate(skies[ii])
 
     # ADM resolve any duplicates between imaging data releases. 
-    skies = resolve(skies)
+    resolved = resolve(skies)
+    # ADM recover any unique bricks that were on the other side of the
+    # ADM resolve, in case of missing N/S bricks available in the S/N.
+    missedbrx = list(set(skies["BRICKNAME"]) - set(resolved["BRICKNAME"]))
+    if len(missedbrx) > 0:
+        backin = np.any([skies["BRICKNAME"]==brx for brx in missedbrx], axis=0)
+        skies = np.concatenate([resolved, skies[backin]])
+        log.info('Added some post-resolve bricks back in: {}'.format(missedbrx))
+    else:
+        skies = resolved
 
     # ADM this correctly records the apertures in the output file header
     # ADM as well as adding HEALPixel information.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,11 @@ desitarget Change Log
 0.32.1 (unreleased)
 -------------------
 
+* Add new redshift 5 (``QSO_Z5``) SV QSO selection [`PR #539`_]. Also:
+    * Remove all Tycho and LSLGA sources from the GFA catalog.
+    * Minor improvements to documentation for secondary targets.
+    * Use N/S bricks for skies when S/N bricks aren't available.
+* Tune, high-z, faint (``QSO_HZ_F``) SV QSO selection [`PR #538`_]
 * Update LRG selections for DR8 [`PR #532`_]. Includes:
     * New LRG selection for SV with fewer bits.
     * New ``LOWZ_FILLER`` class for SV.
@@ -28,6 +33,8 @@ desitarget Change Log
 .. _`PR #527`: https://github.com/desihub/desitarget/pull/527
 .. _`PR #531`: https://github.com/desihub/desitarget/pull/531
 .. _`PR #532`: https://github.com/desihub/desitarget/pull/532
+.. _`PR #538`: https://github.com/desihub/desitarget/pull/538
+.. _`PR #539`: https://github.com/desihub/desitarget/pull/539
 
 0.32.0 (2019-08-07)
 -------------------

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -146,6 +146,11 @@ def gaia_gfas_from_sweep(filename, maglim=18.):
     ii = gfas['GAIA_PHOT_G_MEAN_MAG'] < maglim
     gfas = gfas[ii]
 
+    # ADM remove any sources based on Tycho or LSLGA.
+    ii = ((gfas["REF_CAT"] == b'L2') | (gfas["REF_CAT"] == 'L2') |
+          (gfas["REF_CAT"] == b'T2') | (gfas["REF_CAT"] == 'T2'))
+    gfas = gfas[~ii]
+
     return gfas
 
 

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -145,7 +145,7 @@ def _get_scxdir(scxdir=None):
 
     # ADM fail if the scx directory is not set or passed.
     if scxdir is None or not os.path.exists(scxdir):
-        log.info('pass scxdir or set $SCND_DIR...')
+        log.info('pass scxdir (or --scnddir or --nosecondary) or set $SCND_DIR')
         msg = 'Secondary target files not found in {}'.format(scxdir)
         log.critical(msg)
         raise ValueError(msg)

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -23,47 +23,49 @@ sv1_desi_mask:
     - [QSO_COLOR_8PASS,   14, "High-z (Lyman-Alpha) QSO using color cuts",    {obsconditions: DARK}]
     - [QSO_RF_8PASS,      15, "High-z (Lyman-Alpha) QSO using random forest", {obsconditions: DARK}]
     - [QSO_HZ_F,          16, "QSO at high-redshift and faint",               {obsconditions: DARK}]
+    - [QSO_Z5,            17, "z~5 QSO",                                      {obsconditions: DARK}]
 
     #- North vs. South selections for different sub-classes
-    - [LRG_INIT_4PASS_NORTH,   17, "Bright LRG using initial optical and IR cuts tuned for Bok/Mosaic", {obsconditions: DARK}]
-    - [LRG_SUPER_4PASS_NORTH,  18, "Bright LRG that is a superset of other cuts tuned for Bok/Mosaic",  {obsconditions: DARK}]
-    - [LRG_INIT_8PASS_NORTH,   19, "Faint LRG using initial optical and IR cuts tuned for Bok/Mosaic",  {obsconditions: DARK}]
-    - [LRG_SUPER_8PASS_NORTH,  20, "Faint LRG that is a superset of other cuts tuned for Bok/Mosaic",   {obsconditions: DARK}]
-    - [LOWZ_FILLER_NORTH,      21, "LRG-like low-z filler sample tuned for Bok/Mosaic",                 {obsconditions: DARK}]
+    - [LRG_INIT_4PASS_NORTH,   18, "Bright LRG using initial optical and IR cuts tuned for Bok/Mosaic", {obsconditions: DARK}]
+    - [LRG_SUPER_4PASS_NORTH,  19, "Bright LRG that is a superset of other cuts tuned for Bok/Mosaic",  {obsconditions: DARK}]
+    - [LRG_INIT_8PASS_NORTH,   20, "Faint LRG using initial optical and IR cuts tuned for Bok/Mosaic",  {obsconditions: DARK}]
+    - [LRG_SUPER_8PASS_NORTH,  21, "Faint LRG that is a superset of other cuts tuned for Bok/Mosaic",   {obsconditions: DARK}]
+    - [LOWZ_FILLER_NORTH,      22, "LRG-like low-z filler sample tuned for Bok/Mosaic",                 {obsconditions: DARK}]
 
-    - [LRG_INIT_4PASS_SOUTH,   22, "Bright LRG using initial optical and IR cuts tuned for DECam", {obsconditions: DARK}]
-    - [LRG_SUPER_4PASS_SOUTH,  23, "Bright LRG that is a superset of other cuts tuned for DECam",  {obsconditions: DARK}]
-    - [LRG_INIT_8PASS_SOUTH,   24, "Faint LRG using initial optical and IR cuts tuned for DECam",  {obsconditions: DARK}]
-    - [LRG_SUPER_8PASS_SOUTH,  25, "Faint LRG that is a superset of other cuts tuned for DECam",   {obsconditions: DARK}]
-    - [LOWZ_FILLER_SOUTH,      26, "LRG-like low-z filler sample tuned for DECam",                 {obsconditions: DARK}]
+    - [LRG_INIT_4PASS_SOUTH,   23, "Bright LRG using initial optical and IR cuts tuned for DECam", {obsconditions: DARK}]
+    - [LRG_SUPER_4PASS_SOUTH,  24, "Bright LRG that is a superset of other cuts tuned for DECam",  {obsconditions: DARK}]
+    - [LRG_INIT_8PASS_SOUTH,   25, "Faint LRG using initial optical and IR cuts tuned for DECam",  {obsconditions: DARK}]
+    - [LRG_SUPER_8PASS_SOUTH,  26, "Faint LRG that is a superset of other cuts tuned for DECam",   {obsconditions: DARK}]
+    - [LOWZ_FILLER_SOUTH,      27, "LRG-like low-z filler sample tuned for DECam",                 {obsconditions: DARK}]
 
-    - [ELG_FDR_NORTH,         27, "ELG using FDR cuts tuned for Bok/Mosaic",             {obsconditions: DARK|GRAY}]
-    - [ELG_FDR_FAINT_NORTH,   28, "ELG using fainter FDR cuts tuned for Bok/Mosaic",     {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_BLUE_NORTH,     29, "ELG blue extension in rz color tuned for Bok/Mosaic", {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_RED_NORTH,      30, "ELG red extension in rz color tuned for Bok/Mosaic",  {obsconditions: DARK|GRAY}]
-
-    - [ELG_FDR_SOUTH,         31, "ELG using FDR cuts tuned for DECam",                  {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_NORTH,         28, "ELG using FDR cuts tuned for Bok/Mosaic",             {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_FAINT_NORTH,   29, "ELG using fainter FDR cuts tuned for Bok/Mosaic",     {obsconditions: DARK|GRAY}]
+    - [ELG_RZ_BLUE_NORTH,     30, "ELG blue extension in rz color tuned for Bok/Mosaic", {obsconditions: DARK|GRAY}]
+    - [ELG_RZ_RED_NORTH,      31, "ELG red extension in rz color tuned for Bok/Mosaic",  {obsconditions: DARK|GRAY}]
 
     #- ADM leave 32-37 reserved for calibration targets (to mirror the main survey)
 
-    - [ELG_FDR_FAINT_SOUTH,   38, "ELG using fainter FDR tuned for DECam",               {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_BLUE_SOUTH,     39, "ELG blue extension in rz color tuned for DECam",      {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_RED_SOUTH,      40, "ELG red extension in rz color tuned for DECam",       {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_SOUTH,         38, "ELG using FDR cuts tuned for DECam",                  {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_FAINT_SOUTH,   39, "ELG using fainter FDR tuned for DECam",               {obsconditions: DARK|GRAY}]
+    - [ELG_RZ_BLUE_SOUTH,     40, "ELG blue extension in rz color tuned for DECam",      {obsconditions: DARK|GRAY}]
+    - [ELG_RZ_RED_SOUTH,      41, "ELG red extension in rz color tuned for DECam",       {obsconditions: DARK|GRAY}]
 
-    - [QSO_COLOR_4PASS_NORTH, 41, "Low-z (tracer) QSO using color cuts tuned for Bok/Mosaic",          {obsconditions: DARK}]
-    - [QSO_RF_4PASS_NORTH,    42, "Low-z (tracer) QSO using random forest tuned for Bok/Mosaic",       {obsconditions: DARK}]
-    - [QSO_COLOR_8PASS_NORTH, 43, "High-z (Lyman-Alpha) QSO using color cuts tuned for Bok/Mosaic",    {obsconditions: DARK}]
-    - [QSO_RF_8PASS_NORTH,    44, "High-z (Lyman-Alpha) QSO using random forest tuned for Bok/Mosaic", {obsconditions: DARK}]
-    - [QSO_HZ_F_NORTH,        45, "QSO at high-redshift and faint tuned for Bok/Mosaic",               {obsconditions: DARK}]
+    - [QSO_COLOR_4PASS_NORTH, 42, "Low-z (tracer) QSO using color cuts tuned for Bok/Mosaic",          {obsconditions: DARK}]
+    - [QSO_RF_4PASS_NORTH,    43, "Low-z (tracer) QSO using random forest tuned for Bok/Mosaic",       {obsconditions: DARK}]
+    - [QSO_COLOR_8PASS_NORTH, 44, "High-z (Lyman-Alpha) QSO using color cuts tuned for Bok/Mosaic",    {obsconditions: DARK}]
+    - [QSO_RF_8PASS_NORTH,    45, "High-z (Lyman-Alpha) QSO using random forest tuned for Bok/Mosaic", {obsconditions: DARK}]
+    - [QSO_HZ_F_NORTH,        46, "QSO at high-redshift and faint tuned for Bok/Mosaic",               {obsconditions: DARK}]
+    - [QSO_Z5_NORTH,          47, "z~5 QSO tuned for Bok/Mosaic",                                      {obsconditions: DARK}]
 
-    - [QSO_COLOR_4PASS_SOUTH, 46, "Low-z (tracer) QSO using color cuts tuned for DECam",               {obsconditions: DARK}]
-    - [QSO_RF_4PASS_SOUTH,    47, "Low-z (tracer) QSO using random forest tuned for DECam",            {obsconditions: DARK}]
-    - [QSO_COLOR_8PASS_SOUTH, 48, "High-z (Lyman-Alpha) QSO using color cuts tuned for DECam",         {obsconditions: DARK}]
+    - [QSO_COLOR_4PASS_SOUTH, 48, "Low-z (tracer) QSO using color cuts tuned for DECam",               {obsconditions: DARK}]
 
     #- ADM retain bits 49-52 for masking/convenience (to mirror the main survey)
 
-    - [QSO_RF_8PASS_SOUTH,    53, "High-z (Lyman-Alpha) QSO using random forest tuned for DECam",      {obsconditions: DARK}]
-    - [QSO_HZ_F_SOUTH,        54, "QSO at high-redshift and faint tuned for DECam",                    {obsconditions: DARK}]
+    - [QSO_RF_4PASS_SOUTH,    53, "Low-z (tracer) QSO using random forest tuned for DECam",            {obsconditions: DARK}]
+    - [QSO_COLOR_8PASS_SOUTH, 54, "High-z (Lyman-Alpha) QSO using color cuts tuned for DECam",         {obsconditions: DARK}]
+    - [QSO_RF_8PASS_SOUTH,    55, "High-z (Lyman-Alpha) QSO using random forest tuned for DECam",      {obsconditions: DARK}]
+    - [QSO_HZ_F_SOUTH,        56, "QSO at high-redshift and faint tuned for DECam",                    {obsconditions: DARK}]
+    - [QSO_Z5_SOUTH,          57, "z~5 QSO tuned for DECam",                                           {obsconditions: DARK}]
 
     #- Calibration targets
     - [SKY,         32, "Blank sky locations",
@@ -74,7 +76,7 @@ sv1_desi_mask:
         {obsconditions: BRIGHT}]
     - [BAD_SKY,     36, "Blank sky locations that are imperfect but still useable",
         {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [SUPP_SKY,      37, "SKY is based on Gaia-avoidance (SKY will be set, too)",
+    - [SUPP_SKY,    37, "SKY is based on Gaia-avoidance (SKY will be set, too)",
         {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
 
     #- Reserved convenience bits that can, e.g., be set downstream of desitarget
@@ -207,6 +209,7 @@ priorities:
         QSO_COLOR_8PASS: SAME_AS_QSO
         QSO_RF_8PASS:    SAME_AS_QSO
         QSO_HZ_F:        SAME_AS_QSO
+        QSO_Z5:          SAME_AS_QSO
         # ADM don't prioritize a N/S target if it doesn't have other bits set
         LRG_INIT_4PASS_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
         LRG_SUPER_4PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
@@ -231,11 +234,13 @@ priorities:
         QSO_COLOR_8PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_RF_8PASS_NORTH:    SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_HZ_F_NORTH:        SAME_AS_LRG_INIT_4PASS_NORTH
+        QSO_Z5_NORTH:          SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_COLOR_4PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_RF_4PASS_SOUTH:    SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_COLOR_8PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_RF_8PASS_SOUTH:    SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_HZ_F_SOUTH:        SAME_AS_LRG_INIT_4PASS_NORTH
+        QSO_Z5_SOUTH:          SAME_AS_LRG_INIT_4PASS_NORTH
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FAINT:  -1
@@ -326,6 +331,7 @@ numobs:
         QSO_COLOR_8PASS: 8
         QSO_RF_8PASS:    8
         QSO_HZ_F:        SAME_AS_QSO
+        QSO_Z5_F:        SAME_AS_QSO
         # ADM don't observe a N/S target if it doesn't have other bits set
         LRG_INIT_4PASS_NORTH:  0
         LRG_SUPER_4PASS_NORTH: 0
@@ -350,11 +356,13 @@ numobs:
         QSO_COLOR_8PASS_NORTH: 0
         QSO_RF_8PASS_NORTH:    0
         QSO_HZ_F_NORTH:        0
+        QSO_Z5_NORTH:          0
         QSO_COLOR_4PASS_SOUTH: 0
         QSO_RF_4PASS_SOUTH:    0
         QSO_COLOR_8PASS_SOUTH: 0
         QSO_RF_8PASS_SOUTH:    0
         QSO_HZ_F_SOUTH:        0
+        QSO_Z5_SOUTH:          0
         BAD_SKY: 0
         #- Standards and sky are treated specially; NUMOBS doesn't apply
         STD_FAINT:  -1

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -331,7 +331,7 @@ numobs:
         QSO_COLOR_8PASS: 8
         QSO_RF_8PASS:    8
         QSO_HZ_F:        SAME_AS_QSO
-        QSO_Z5_F:        SAME_AS_QSO
+        QSO_Z5:          SAME_AS_QSO
         # ADM don't observe a N/S target if it doesn't have other bits set
         LRG_INIT_4PASS_NORTH:  0
         LRG_SUPER_4PASS_NORTH: 0

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -766,6 +766,123 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
     return qso
 
 
+def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
+                 gsnr=None, rsnr=None, zsnr=None,
+                 w1flux=None, w2flux=None, w1snr=None, w2snr=None,
+                 dchisq=None, maskbits=None, objtype=None, primary=None,
+                 south=True):
+    """Definition of z~5 QSO target classes from color cuts. Returns a boolean array.
+
+    Parameters
+    ----------
+    south : :class:`boolean`, defaults to ``True``
+        Use cuts appropriate to the Northern imaging surveys (BASS/MzLS) if ``south=False``,
+        otherwise use cuts appropriate to the Southern imaging survey (DECaLS).
+
+    Returns
+    -------
+    :class:`array_like`
+        ``True`` for objects that pass the quasar color/morphology/logic cuts.
+
+    Notes
+    -----
+    - Current version (09/05/19) is version 93 on `the SV wiki`_.
+    - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
+    """
+    if not south:
+        gflux, rflux, zflux = shift_photo_north(gflux, rflux, zflux)
+
+    if primary is None:
+        primary = np.ones_like(rflux, dtype='?')
+    qso = primary.copy()
+
+    # ADM Reject objects in masks.
+    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
+    if maskbits is not None:
+        #for bit in [1, 10, 12, 13]:
+        for bit in [10, 12, 13]:
+            qso &= ((maskbits & 2**bit) == 0)
+
+    # ADM relaxed morphology cut for SV.
+    # ADM we never target sources with dchisq[..., 0] = 0, so force
+    # ADM those to have large values of morph2 to avoid divide-by-zero.
+    d1, d0 = dchisq[..., 1], dchisq[..., 0]
+    bigmorph = np.zeros_like(d0)+1e9
+    dcs = np.divide(d1 - d0, d0, out=bigmorph, where=d0 != 0)
+    if south:
+        morph2 = dcs < 0.01
+    else:
+        morph2 = dcs < 0.005
+    qso &= _psflike(objtype) | morph2
+
+    # ADM SV cuts are different for WISE SNR.
+    if south:
+        qso &= w1snr > 3
+        qso &= w2snr > 2
+    else:
+        qso &= w1snr > 3
+        qso &= w2snr > 2
+
+    # ADM perform the color cuts to finish the selection.
+    qso &= isQSOz5_colors(gflux=gflux, rflux=rflux, zflux=zflux,
+                          gsnr=gsnr, rsnr=gsnr, zsnr=gsnr,
+                          w1flux=w1flux, w2flux=w2flux,
+                          primary=primary, south=south)
+
+    return qso
+
+
+def isQSOz5_colors(gflux=None, rflux=None, zflux=None,
+                   gsnr=None, rsnr=None, zsnr=None,
+                   w1flux=None, w2flux=None, primary=None, south=True):
+    """Color cut to select z~5 quasar targets.
+    (See :func:`~desitarget.sv1.sv1_cuts.isQSOz5_cuts`).
+    """
+    if primary is None:
+        primary = np.ones_like(rflux, dtype='?')
+    qso = primary.copy()
+
+    # flux limit, z < 21.4 or z_fiber < 21.67.
+    qso &= zflux > 10**((22.5-21.4)/2.5)
+
+    # gr cut, SNg < 3 | g > 24.5 | g-r > 1.8.
+    SNRg = gsnr < 3
+    gcut = gflux < 10**((22.5-24.5)/2.5)
+    grcut = rflux > 10**(1.8/2.5) * gflux
+    qso &= SNRg | gcut | grcut
+
+    # zw1w2 cuts: SNz > 5
+    # & w1-w2 > 0.5 & z- w1 < 4.5 & z-w1 > 2.0  (W1, W2 in Vega).
+    qso &= zsnr > 5
+    qso &= w2flux > 10**(-0.14/2.5) * w1flux # w1-w2 > -0.14 in AB magnitude
+    qso &= ((w1flux < 10**((4.5-2.699)/2.5) * zflux) &
+            (w1flux > 10**((2.0-2.699)/2.5) * zflux))
+
+    # rzW1 cuts: (SNr < 3 |
+    # (r-z < 3.2*(z-w1) - 6.5 & r-z > 1.0 & r-z < 3.9) | r-z > 4.4).
+    SNRr = rsnr < 3
+       # using same cuts for 'north' and 'south', at least initially.
+    if south:
+        rzw1cut = (
+            (np.log10(zflux/rflux) <
+            3.2*np.log10(w1flux/zflux) - (6.5-3.2*2.699)/2.5)
+            & (zflux > 10**(1.0/2.5) * rflux) & (zflux < 10**(3.9/2.5) * rflux)
+        )
+        rzcut = zflux > 10**(4.4/2.5) * rflux  # for z~6 quasar
+
+    else:
+        rzw1cut = (
+            (np.log10(zflux/rflux) <
+            3.2*np.log10(w1flux/zflux) - (6.5-3.2*2.699)/2.5)
+            & (zflux > 10**(1.0/2.5) * rflux) & (zflux < 10**(3.9/2.5) * rflux)
+        )
+        rzcut = zflux > 10**(4.4/2.5) * rflux
+
+    qso &= SNRr | rzw1cut | rzcut
+
+    return qso
+
+
 def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, rfiberflux=None,
           gnobs=None, rnobs=None, znobs=None, gfracmasked=None, rfracmasked=None, zfracmasked=None,
           gfracflux=None, rfracflux=None, zfracflux=None, gfracin=None, rfracin=None, zfracin=None,
@@ -1373,9 +1490,18 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     w1flux=w1flux, w2flux=w2flux, south=south
                 )
             )
+            qso_store.append(
+                isQSOz5_cuts(
+                    primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
+                    gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+                    w1flux=w1flux, w2flux=w2flux, w1snr=w1snr, w2snr=w2snr,
+                    dchisq=dchisq, maskbits=maskbits, objtype=objtype,
+                    south=south
+                )
+            )
             qso_classes[int(south)] = qso_store
-    qsocolor_north, qsorf_north, qsohizf_north, qsocolor_high_z_north = qso_classes[0]
-    qsocolor_south, qsorf_south, qsohizf_south, qsocolor_high_z_south = qso_classes[1]
+    qsocolor_north, qsorf_north, qsohizf_north, qsocolor_high_z_north, qsoz5_north = qso_classes[0]
+    qsocolor_south, qsorf_south, qsohizf_south, qsocolor_high_z_south, qsoz5_south = qso_classes[1]
 
     # ADM combine quasar target bits for a quasar target based on any imaging.
     qsocolor_highz_north = (qsocolor_north & qsocolor_high_z_north)
@@ -1383,14 +1509,14 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     qsocolor_lowz_north = (qsocolor_north & ~qsocolor_high_z_north)
     qsorf_lowz_north = (qsorf_north & ~qsocolor_high_z_north)
     qso_north = (qsocolor_lowz_north | qsorf_lowz_north | qsocolor_highz_north
-                 | qsorf_highz_north | qsohizf_north)
+                 | qsorf_highz_north | qsohizf_north | qsoz5_north)
 
     qsocolor_highz_south = (qsocolor_south & qsocolor_high_z_south)
     qsorf_highz_south = (qsorf_south & qsocolor_high_z_south)
     qsocolor_lowz_south = (qsocolor_south & ~qsocolor_high_z_south)
     qsorf_lowz_south = (qsorf_south & ~qsocolor_high_z_south)
     qso_south = (qsocolor_lowz_south | qsorf_lowz_south | qsocolor_highz_south
-                 | qsorf_highz_south | qsohizf_south)
+                 | qsorf_highz_south | qsohizf_south | qsoz5_south)
 
     qso = (qso_north & photsys_north) | (qso_south & photsys_south)
     qsocolor_highz = (qsocolor_highz_north & photsys_north) | (qsocolor_highz_south & photsys_south)
@@ -1398,6 +1524,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     qsocolor_lowz = (qsocolor_lowz_north & photsys_north) | (qsocolor_lowz_south & photsys_south)
     qsorf_lowz = (qsorf_lowz_north & photsys_north) | (qsorf_lowz_south & photsys_south)
     qsohizf = (qsohizf_north & photsys_north) | (qsohizf_south & photsys_south)
+    qsoz5 = (qsoz5_north & photsys_north) | (qsoz5_south & photsys_south)
 
     # ADM initially set everything to arrays of False for the BGS selection
     # ADM the zeroth element stores the northern targets bits (south=False).
@@ -1512,6 +1639,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= qsocolor_highz_south * desi_mask.QSO_COLOR_8PASS_SOUTH
     desi_target |= qsorf_highz_south * desi_mask.QSO_RF_8PASS_SOUTH
     desi_target |= qsohizf_south * desi_mask.QSO_HZ_F_SOUTH
+    desi_target |= qsoz5_south * desi_mask.QSO_Z5_SOUTH
 
     # ADM add the per-bit information in the north for LRGs...
     desi_target |= lrginit_n_4 * desi_mask.LRG_INIT_4PASS_NORTH
@@ -1525,6 +1653,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= qsocolor_highz_north * desi_mask.QSO_COLOR_8PASS_NORTH
     desi_target |= qsorf_highz_north * desi_mask.QSO_RF_8PASS_NORTH
     desi_target |= qsohizf_north * desi_mask.QSO_HZ_F_NORTH
+    desi_target |= qsoz5_north * desi_mask.QSO_Z5_NORTH
 
     # ADM combined per-bit information for the LRGs...
     desi_target |= lrginit_4 * desi_mask.LRG_INIT_4PASS
@@ -1538,6 +1667,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= qsocolor_highz * desi_mask.QSO_COLOR_8PASS
     desi_target |= qsorf_highz * desi_mask.QSO_RF_8PASS
     desi_target |= qsohizf * desi_mask.QSO_HZ_F
+    desi_target |= qsoz5 * desi_mask.QSO_Z5
 
     # ADM Standards.
     desi_target |= std_faint * desi_mask.STD_FAINT

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -799,7 +799,7 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
     # ADM Reject objects in masks.
     # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
     if maskbits is not None:
-        #for bit in [1, 10, 12, 13]:
+        # for bit in [1, 10, 12, 13]:
         for bit in [10, 12, 13]:
             qso &= ((maskbits & 2**bit) == 0)
 
@@ -854,18 +854,18 @@ def isQSOz5_colors(gflux=None, rflux=None, zflux=None,
     # zw1w2 cuts: SNz > 5
     # & w1-w2 > 0.5 & z- w1 < 4.5 & z-w1 > 2.0  (W1, W2 in Vega).
     qso &= zsnr > 5
-    qso &= w2flux > 10**(-0.14/2.5) * w1flux # w1-w2 > -0.14 in AB magnitude
+    qso &= w2flux > 10**(-0.14/2.5) * w1flux  # w1-w2 > -0.14 in AB magnitude
     qso &= ((w1flux < 10**((4.5-2.699)/2.5) * zflux) &
             (w1flux > 10**((2.0-2.699)/2.5) * zflux))
 
     # rzW1 cuts: (SNr < 3 |
     # (r-z < 3.2*(z-w1) - 6.5 & r-z > 1.0 & r-z < 3.9) | r-z > 4.4).
     SNRr = rsnr < 3
-       # using same cuts for 'north' and 'south', at least initially.
+    # using same cuts for 'north' and 'south', at least initially.
     if south:
         rzw1cut = (
             (np.log10(zflux/rflux) <
-            3.2*np.log10(w1flux/zflux) - (6.5-3.2*2.699)/2.5)
+             3.2*np.log10(w1flux/zflux) - (6.5-3.2*2.699)/2.5)
             & (zflux > 10**(1.0/2.5) * rflux) & (zflux < 10**(3.9/2.5) * rflux)
         )
         rzcut = zflux > 10**(4.4/2.5) * rflux  # for z~6 quasar
@@ -873,7 +873,7 @@ def isQSOz5_colors(gflux=None, rflux=None, zflux=None,
     else:
         rzw1cut = (
             (np.log10(zflux/rflux) <
-            3.2*np.log10(w1flux/zflux) - (6.5-3.2*2.699)/2.5)
+             3.2*np.log10(w1flux/zflux) - (6.5-3.2*2.699)/2.5)
             & (zflux > 10**(1.0/2.5) * rflux) & (zflux < 10**(3.9/2.5) * rflux)
         )
         rzcut = zflux > 10**(4.4/2.5) * rflux


### PR DESCRIPTION
This PR adds a new redshift 5 (`QSO_Z5`) SV QSO selection. It also includes code to:
- Remove all Tycho and LSLGA sources from the GFA catalog.
- Slightly improve documentation for secondary targets.
- Use N/S bricks for assigning pixel-level sky locations when S/N bricks aren't available.
