### PR TITLE
Fixes missing discard of duplicate secondary targets

### DIFF
--- a/bin/select_secondary
+++ b/bin/select_secondary
@@ -27,10 +27,9 @@ ap.add_argument("-s", "--separation", type=float, default=1.,
 ap.add_argument("--scnddir",
                 help="Base directory of secondary target files (e.g. '/project/projectdirs/desi/target/secondary' at NERSC). "+
                 "Defaults to SCND_DIR environment variable.")
-ap.add_argument("--darkbright",
+ap.add_argument("--writeall",
                 action='store_true',
-                help=" If sent, then split `NUMOBS_INIT` and `PRIORITY_INIT` into `NUMOBS_INIT_DARK`, `NUMOBS_INIT_BRIGHT`, `PRIORITY_INIT_DARK`"+
-                "and `PRIORITY_INIT_BRIGHT` and calculate values appropriate to 'BRIGHT' and 'DARK|GRAY' observing conditions.")
+                help="Default behavior is to split targets by bright/dark-time surveys. Set this to ALSO write a file of ALL targets")
 ns = ap.parse_args()
 
 # ADM Sanity check that priminfodir exists.
@@ -50,7 +49,7 @@ scxdir = _get_scxdir(ns.scnddir)
 if surv != 'main':
     scxdir = os.path.join(scxdir, surv)
 
-scx = select_secondary(ns.priminfodir, sep=ns.separation, scxdir=scxdir, darkbright=ns.darkbright)
+scx = select_secondary(ns.priminfodir, sep=ns.separation, scxdir=scxdir, darkbright=(not ns.writeall))
 
 # ADM add the primary directory and matching radius to the header
 # ADM from the first primary file.
@@ -61,6 +60,8 @@ hdr['SEP'] = float(ns.separation)
 # ADM and dark-time targets written separately.
 obscons = ["BRIGHT", "DARK"]
 
+if ns.writeall:
+    obscons.append(None)
 for obscon in obscons:
     # ADM the dict() here is to make hdr immutable.
     ntargs, outfile = io.write_secondary(ns.dest, scx, primhdr=dict(hdr),

--- a/bin/select_secondary
+++ b/bin/select_secondary
@@ -27,7 +27,10 @@ ap.add_argument("-s", "--separation", type=float, default=1.,
 ap.add_argument("--scnddir",
                 help="Base directory of secondary target files (e.g. '/project/projectdirs/desi/target/secondary' at NERSC). "+
                 "Defaults to SCND_DIR environment variable.")
-
+ap.add_argument("--darkbright",
+                action='store_true',
+                help=" If sent, then split `NUMOBS_INIT` and `PRIORITY_INIT` into `NUMOBS_INIT_DARK`, `NUMOBS_INIT_BRIGHT`, `PRIORITY_INIT_DARK`"+
+                "and `PRIORITY_INIT_BRIGHT` and calculate values appropriate to 'BRIGHT' and 'DARK|GRAY' observing conditions.")
 ns = ap.parse_args()
 
 # ADM Sanity check that priminfodir exists.
@@ -47,7 +50,7 @@ scxdir = _get_scxdir(ns.scnddir)
 if surv != 'main':
     scxdir = os.path.join(scxdir, surv)
 
-scx = select_secondary(ns.priminfodir, sep=ns.separation, scxdir=scxdir, darkbright=True)
+scx = select_secondary(ns.priminfodir, sep=ns.separation, scxdir=scxdir, darkbright=ns.darkbright)
 
 # ADM add the primary directory and matching radius to the header
 # ADM from the first primary file.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,12 @@ desitarget Change Log
 0.32.1 (unreleased)
 -------------------
 
+*  Further updates to changes in `PR #531`, [`PR #544`_]. Includes:
+    * A `--writeall` option to `select_secondary` writes a unified target
+      file without the BRIGHT/DARK split, as for `select_targets` 
+    * Removes duplicate secondaries that arise from multiple matches to 
+      one primary and secondary targets appearing in more than one input
+      file. The duplciate with highest `PRIORTIY_INIT` is retained.
 * Add new redshift 5 (``QSO_Z5``) SV QSO selection [`PR #539`_]. Also:
     * Remove all Tycho and LSLGA sources from the GFA catalog.
     * Minor improvements to documentation for secondary targets.
@@ -19,7 +25,7 @@ desitarget Change Log
     * New and simplified LRG selection for the Main Survey.
     * Deprecate Main Survey 1PASS/2PASS LRGs, all LRGs now have one pass.
     * Deprecate some very old code in :mod:`desitarget.targets`.
-* Finalize secondaries, add BRIGHT/DARK split [`PR #531`_]. Includes:
+* Finalize secondaries, add BRIGHT/DARK split [`PR #531` ]. Includes:
     * Updated data model for secondaries.
     * New secondary output columns (``OBSCONDITIONS``, proper motions).
     * Add a cached file of primary TARGETIDs to prevent duplicates.
@@ -38,6 +44,7 @@ desitarget Change Log
 .. _`PR #537`: https://github.com/desihub/desitarget/pull/537
 .. _`PR #538`: https://github.com/desihub/desitarget/pull/538
 .. _`PR #539`: https://github.com/desihub/desitarget/pull/539
+.. _`PR #544`: https://github.com/desihub/desitarget/pull/544
 
 0.32.0 (2019-08-07)
 -------------------

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -93,6 +93,7 @@ suppdatamodel = np.array([], dtype=[
     ('SCND_TARGET_INIT', '>i8'), ('SCND_ORDER', '>i4')
 ])
 
+
 def duplicates(seq):
     """Locations of duplicates in an array or list.
 
@@ -345,10 +346,10 @@ def add_primary_info(scxtargs, priminfodir):
         primtargs = np.concatenate([primtargs, prim])
 
     # ADM make a unique look-up for the target sets.
-    scxbitnum  = np.log2(scxtargs["SCND_TARGET"]).astype('int')
+    scxbitnum = np.log2(scxtargs["SCND_TARGET"]).astype('int')
     primbitnum = np.log2(primtargs["SCND_TARGET"]).astype('int')
 
-    scxids  = 1000 * scxtargs["SCND_ORDER"] + scxbitnum
+    scxids = 1000 * scxtargs["SCND_ORDER"] + scxbitnum
     primids = 1000 * primtargs["SCND_ORDER"] + primbitnum
 
     # ADM if a secondary matched TWO (or more) primaries,
@@ -356,17 +357,17 @@ def add_primary_info(scxtargs, priminfodir):
     alldups = []
     # for _, dups in duplicates(primids):
     for _, dups in duplicates(primtargs['TARGETID']):
-        am   = np.argmax(primtargs[dups]["PRIORITY_INIT"])
+        am = np.argmax(primtargs[dups]["PRIORITY_INIT"])
         dups = np.delete(dups, am)
         alldups.append(dups)
-    alldups   = np.hstack(alldups)
+    alldups = np.hstack(alldups)
     primtargs = np.delete(primtargs, alldups)
-    primids   = np.delete(primids,   alldups)
+    primids = np.delete(primids, alldups)
 
     # ADM we already know that all primaries match a secondary, so,
     # ADM for speed, we can reduce to the matching set.
     sprimids = set(primids)
-    scxii    = [scxid in sprimids for scxid in scxids]
+    scxii = [scxid in sprimids for scxid in scxids]
     assert len(sprimids) == len(primids)
     assert set(scxids[scxii]) == sprimids
 
@@ -603,7 +604,8 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
 
     # ADM assign the unique TARGETIDs to the secondary objects.
     scxtargs["TARGETID"][nomatch] = targetid[nomatch]
-    log.debug("Assigned {} targetids to unmatched secondaries".format(len(targetid[nomatch])))
+    log.debug("Assigned {} targetids to unmatched \
+               secondaries".format(len(targetid[nomatch])))
 
     # ADM match secondaries to themselves, to ensure duplicates
     # ADM share a TARGETID. Don't match special (OVERRIDE) targets
@@ -645,10 +647,11 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     # APC Remove duplicate targetids from secondary-only targets
     alldups = []
     for _, dups in duplicates(scxtargs['TARGETID']):
-        dups = np.delete(dups, 0) # Retain the first
+        dups = np.delete(dups, 0)  # Retain the first match
         alldups.append(dups)
-    alldups   = np.hstack(alldups)
-    log.debug("Flagging {} duplicate secondary targetids with PRIORITY_INIT=-1".format(len(alldups)))
+    alldups = np.hstack(alldups)
+    log.debug("Flagging {} duplicate secondary targetids with \
+               PRIORITY_INIT=-1".format(len(alldups)))
 
     # ADM and remove the INIT fields in prep for a dark/bright split.
     scxtargs = rfn.drop_fields(scxtargs, ["PRIORITY_INIT", "NUMOBS_INIT"])
@@ -687,6 +690,7 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     done["OBSCONDITIONS"] = set_obsconditions(done, scnd=True)
 
     return done
+
 
 def select_secondary(priminfodir, sep=1., scxdir=None, darkbright=False):
     """Process secondary targets and update relevant bits.

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -647,8 +647,11 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     # APC Remove duplicate targetids from secondary-only targets
     alldups = []
     for _, dups in duplicates(scxtargs['TARGETID']):
-        # Retain the duplicate with highest priority
-        dups = np.delete(dups, np.argmax(scxtargs['PRIORITY_INIT'][dups]))
+        # Retain the duplicate with highest priority, breaking ties
+        # on lowest index in list of targets (see docstring)
+        max_priority = (scxtargs['PRIORITY_INIT'][dups]).max()
+        i_retain = np.min(np.flatnonzero(scxtargs['PRIORITY_INIT'][dups] == max_priority))
+        dups = np.delete(dups, i_retain)
         alldups.append(dups)
     alldups = np.hstack(alldups)
     log.debug("Flagging {} duplicate secondary targetids with \

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -361,6 +361,7 @@ def add_primary_info(scxtargs, priminfodir):
         dups = np.delete(dups, am)
         alldups.append(dups)
     alldups = np.hstack(alldups)
+    log.debug("Discarding {} primary duplicates".format(len(alldups)))
     primtargs = np.delete(primtargs, alldups)
     primids = np.delete(primids, alldups)
 

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -93,7 +93,6 @@ suppdatamodel = np.array([], dtype=[
     ('SCND_TARGET_INIT', '>i8'), ('SCND_ORDER', '>i4')
 ])
 
-
 def duplicates(seq):
     """Locations of duplicates in an array or list.
 
@@ -346,26 +345,28 @@ def add_primary_info(scxtargs, priminfodir):
         primtargs = np.concatenate([primtargs, prim])
 
     # ADM make a unique look-up for the target sets.
-    scxbitnum = np.log2(scxtargs["SCND_TARGET"]).astype('int')
+    scxbitnum  = np.log2(scxtargs["SCND_TARGET"]).astype('int')
     primbitnum = np.log2(primtargs["SCND_TARGET"]).astype('int')
 
-    scxids = 1000 * scxtargs["SCND_ORDER"] + scxbitnum
+    scxids  = 1000 * scxtargs["SCND_ORDER"] + scxbitnum
     primids = 1000 * primtargs["SCND_ORDER"] + primbitnum
 
     # ADM if a secondary matched TWO (or more) primaries,
     # ADM only retain the highest-priority primary.
     alldups = []
-    for _, dups in duplicates(primids):
-        am = np.argmax(primtargs[dups]["PRIORITY_INIT"])
+    # for _, dups in duplicates(primids):
+    for _, dups in duplicates(primtargs['TARGETID']):
+        am   = np.argmax(primtargs[dups]["PRIORITY_INIT"])
         dups = np.delete(dups, am)
         alldups.append(dups)
+    alldups   = np.hstack(alldups)
     primtargs = np.delete(primtargs, alldups)
-    primids = np.delete(primids, alldups)
+    primids   = np.delete(primids,   alldups)
 
     # ADM we already know that all primaries match a secondary, so,
     # ADM for speed, we can reduce to the matching set.
     sprimids = set(primids)
-    scxii = [scxid in sprimids for scxid in scxids]
+    scxii    = [scxid in sprimids for scxid in scxids]
     assert len(sprimids) == len(primids)
     assert set(scxids[scxii]) == sprimids
 
@@ -380,6 +381,9 @@ def add_primary_info(scxtargs, priminfodir):
     # ADM with the primary TARGETIDs.
     scxtargs["TARGETID"][scxii] = primtargs["TARGETID"][primii]
 
+    # APC Secondary targets that don't match to a primary.
+    # APC all still have TARGETID = -1 at this point. They
+    # APC get removed in finalize_secondary().
     log.info("Done matching primaries in {} to secondaries...t={:.1f}s"
              .format(priminfodir, time()-start))
 
@@ -599,6 +603,7 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
 
     # ADM assign the unique TARGETIDs to the secondary objects.
     scxtargs["TARGETID"][nomatch] = targetid[nomatch]
+    log.debug("Assigned {} targetids to unmatched secondaries".format(len(targetid[nomatch])))
 
     # ADM match secondaries to themselves, to ensure duplicates
     # ADM share a TARGETID. Don't match special (OVERRIDE) targets
@@ -636,6 +641,18 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     scxtargs = rfn.rename_fields(
         scxtargs, {'SCND_TARGET': prepend+'SCND_TARGET'}
     )
+
+    # APC Remove duplicate targetids from secondary-only targets
+    # APC nb. consistent with effect but not procedure in the
+    # APC docstring
+    alldups = []
+    for _, dups in duplicates(scxtargs['TARGETID']):
+        dups = np.delete(dups, 0) # Retain the first
+        alldups.append(dups)
+    alldups   = np.hstack(alldups)
+    log.debug("Removing {} duplicate targetids".format(len(alldups)))
+    scxtargs = np.delete(scxtargs,alldups)
+
     # ADM and remove the INIT fields in prep for a dark/bright split.
     scxtargs = rfn.drop_fields(scxtargs, ["PRIORITY_INIT", "NUMOBS_INIT"])
 
@@ -670,7 +687,6 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     done["OBSCONDITIONS"] = set_obsconditions(done, scnd=True)
 
     return done
-
 
 def select_secondary(priminfodir, sep=1., scxdir=None, darkbright=False):
     """Process secondary targets and update relevant bits.

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -648,10 +648,8 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     alldups = []
     for _, dups in duplicates(scxtargs['TARGETID']):
         # Retain the duplicate with highest priority, breaking ties
-        # on lowest index in list of targets (see docstring)
-        max_priority = (scxtargs['PRIORITY_INIT'][dups]).max()
-        i_retain = np.min(np.flatnonzero(scxtargs['PRIORITY_INIT'][dups] == max_priority))
-        dups = np.delete(dups, i_retain)
+        # on lowest index in list of duplicates
+        dups = np.delete(dups, np.argmax(scxtargs['PRIORITY_INIT'][dups]))
         alldups.append(dups)
     alldups = np.hstack(alldups)
     log.debug("Flagging {} duplicate secondary targetids with PRIORITY_INIT=-1".format(len(alldups)))

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -647,7 +647,8 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     # APC Remove duplicate targetids from secondary-only targets
     alldups = []
     for _, dups in duplicates(scxtargs['TARGETID']):
-        dups = np.delete(dups, 0)  # Retain the first match
+        # Retain the duplicate with highest priority
+        dups = np.delete(dups, np.argmax(scxtargs['PRIORITY_INIT'][dups]))
         alldups.append(dups)
     alldups = np.hstack(alldups)
     log.debug("Flagging {} duplicate secondary targetids with \

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -604,8 +604,7 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
 
     # ADM assign the unique TARGETIDs to the secondary objects.
     scxtargs["TARGETID"][nomatch] = targetid[nomatch]
-    log.debug("Assigned {} targetids to unmatched \
-               secondaries".format(len(targetid[nomatch])))
+    log.debug("Assigned {} targetids to unmatched secondaries".format(len(targetid[nomatch])))
 
     # ADM match secondaries to themselves, to ensure duplicates
     # ADM share a TARGETID. Don't match special (OVERRIDE) targets
@@ -654,8 +653,7 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
         dups = np.delete(dups, i_retain)
         alldups.append(dups)
     alldups = np.hstack(alldups)
-    log.debug("Flagging {} duplicate secondary targetids with \
-               PRIORITY_INIT=-1".format(len(alldups)))
+    log.debug("Flagging {} duplicate secondary targetids with PRIORITY_INIT=-1".format(len(alldups)))
 
     # ADM and remove the INIT fields in prep for a dark/bright split.
     scxtargs = rfn.drop_fields(scxtargs, ["PRIORITY_INIT", "NUMOBS_INIT"])

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -643,15 +643,12 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     )
 
     # APC Remove duplicate targetids from secondary-only targets
-    # APC nb. consistent with effect but not procedure in the
-    # APC docstring
     alldups = []
     for _, dups in duplicates(scxtargs['TARGETID']):
         dups = np.delete(dups, 0) # Retain the first
         alldups.append(dups)
     alldups   = np.hstack(alldups)
-    log.debug("Removing {} duplicate targetids".format(len(alldups)))
-    scxtargs = np.delete(scxtargs,alldups)
+    log.debug("Flagging {} duplicate secondary targetids with PRIORITY_INIT=-1".format(len(alldups)))
 
     # ADM and remove the INIT fields in prep for a dark/bright split.
     scxtargs = rfn.drop_fields(scxtargs, ["PRIORITY_INIT", "NUMOBS_INIT"])
@@ -682,6 +679,9 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     for edr, oc in zip(ender, obscon):
         pc, nc = "PRIORITY_INIT"+edr, "NUMOBS_INIT"+edr
         done[pc], done[nc] = initial_priority_numobs(done, obscon=oc, scnd=True)
+
+        # APC Flagged duplicates are removed in io.write_secondary
+        done[pc][alldups] = -1
 
     # ADM set the OBSCONDITIONS.
     done["OBSCONDITIONS"] = set_obsconditions(done, scnd=True)


### PR DESCRIPTION
@geordie666 , I think this fixes the issue I raised by email: multiple rows in the output of `select_secondary` for (a) secondary targets that appear in more than one input catalog or (b) primary targets matched to more than one secondary.

Case (a) is fixed here:
https://github.com/desihub/desitarget/blob/203e392cf427c57391f1b6eabaec5808a7684bc3/py/desitarget/secondary.py#L648-L654

Case (b) is fixed here:
https://github.com/desihub/desitarget/blob/203e392cf427c57391f1b6eabaec5808a7684bc3/py/desitarget/secondary.py#L358

which was previously
https://github.com/desihub/desitarget/blob/203e392cf427c57391f1b6eabaec5808a7684bc3/py/desitarget/secondary.py#L357

**Question**
https://github.com/desihub/desitarget/blob/203e392cf427c57391f1b6eabaec5808a7684bc3/py/desitarget/secondary.py#L547-L554
I didn't see the `PRIORITY_INIT=-1` filtering implemented anywhere and it's not how I've handled case (a) in this PR. Wondering if I missed something about the intention here?