### PR TITLE
fixed overlap in faint_ext bit

### DIFF
--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -998,6 +998,7 @@ def isBGS_colors(rflux=None, rfiberflux=None, south=True, targtype=None, primary
     elif targtype == 'faint_ext':
         bgs &= rflux > 10**((22.5-20.5)/2.5)
         bgs &= rflux <= 10**((22.5-20.1)/2.5)
+        bgs &= ~np.logical_and(rflux <= 10**((22.5-20.1)/2.5), rfiberflux > 10**((22.5-21.0511)/2.5))
     elif targtype == 'fibmag':
         bgs &= rflux <= 10**((22.5-20.1)/2.5)
         bgs &= rfiberflux > 10**((22.5-21.0511)/2.5)


### PR DESCRIPTION
There is a huge overlap between the faint_ext bit and the fibermag bit in BGS SV. This fixed that overlap by excluding the overleaped objects in the faint_ext.