### PR TITLE
Updates for ELG selections for SV

### DIFF
--- a/bin/select_skies
+++ b/bin/select_skies
@@ -33,7 +33,7 @@ ap.add_argument('-s2', "--surveydir2",
                 help='Additional Legacy Surveys directory (useful for combining, e.g., DR8 into one file of sky locations)',
                 default=None)
 ap.add_argument("--nskiespersqdeg", type=float,
-                help="Number of sky locations to generate per sq. deg. (don't pass to read the default from desimodel.io with a 4x margin)",
+                help="Number of sky locations to generate per sq. deg. (don't pass to read the default from desimodel.io with a 16x margin)",
                 default=None)
 ap.add_argument("--bands", 
                 help='Bands in this Legacy Survey Data Release to consider when deriving sky location and aperture fluxes (e.g, "g,r")',
@@ -84,7 +84,7 @@ if pixlist is not None:
 # ADM if needed, determine the minimum density of sky fibers to generate.
 nskiespersqdeg = ns.nskiespersqdeg
 if nskiespersqdeg is None:
-    nskiespersqdeg = density_of_sky_fibers(margin=4)
+    nskiespersqdeg = density_of_sky_fibers(margin=16)
 # ADM and log how many sky positions per brick we expect to be generated.
 area = 0.25*0.25
 nskiesfloat = area*nskiespersqdeg

--- a/bin/supplement_skies
+++ b/bin/supplement_skies
@@ -27,7 +27,7 @@ ap = ArgumentParser(description='Generate supplemental sky locations using Gaia-
 ap.add_argument("dest",
                 help="Output supplemental sky targets file (e.g. /project/projectdirs/desi/target/catalogs/supp-skies-dr4-0.20.0.fits)")
 ap.add_argument("--nskiespersqdeg", type=float,
-                help="Number of sky locations to generate per sq. deg. (don't pass to read the default from desimodel.io with a 4x margin)",
+                help="Number of sky locations to generate per sq. deg. (don't pass to read the default from desimodel.io with a 16x margin)",
                 default=None)
 ap.add_argument("--numproc", type=int,
                 help="number of concurrent processes to use (defaults to [{}])".format(nproc),
@@ -76,7 +76,7 @@ if gaiadir is None:
 # ADM if needed, determine the minimum density of sky fibers to generate.
 nskiespersqdeg = ns.nskiespersqdeg
 if nskiespersqdeg is None:
-    nskiespersqdeg = density_of_sky_fibers(margin=4)
+    nskiespersqdeg = density_of_sky_fibers(margin=16)
 log.info('Generating sky positions at a density of {}'.format(nskiespersqdeg))
 
 # ADM build the list of command line arguments as

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,13 +5,22 @@ desitarget Change Log
 0.33.2 (unreleased)
 -------------------
 
-* New ``FIBERFLUX_R`` bright-end cut on ``BGS_FAINT_EXT`` [`PR #552`_].
+* Update the ELG selections for SV [`PR #553`_]. Includes:
+    * Four new bit names:
+        * ``ELG_SV_GTOT``, ``ELG_SV_GFIB``.
+	* ``ELG_FDR_GTOT``, ``ELG_FDR_GFIB``.
+    * Associated new ELG selections with north/south differences.
+    * Propagate ``FIBERFLUX_G`` from the sweeps for SV ELG cuts.
+    * Increase the default sky densities by a factor of 4x.
+    * Relax CMX ``BACKUP_FAINT`` limit to G < 21 to test fiber assign.
+* Bright-end ``FIBERFLUX_R`` cut on ``BGS_FAINT_EXT`` in SV [`PR #552`_].
 * Update LRG selections for SV [`PR #550`_]. Includes:
     * The zfibermag faint limit is changed from 21.6 to 21.9.
     * IR-selected objects with r-W1>3.1 not subjected to the sliding cut.
 
 .. _`PR #550`: https://github.com/desihub/desitarget/pull/550
 .. _`PR #552`: https://github.com/desihub/desitarget/pull/552
+.. _`PR #553`: https://github.com/desihub/desitarget/pull/553
 
 0.33.1 (2019-10-13)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,13 @@ desitarget Change Log
 0.33.2 (unreleased)
 -------------------
 
+* New ``FIBERFLUX_R`` bright-end cut on ``BGS_FAINT_EXT`` [`PR #552`_].
 * Update LRG selections for SV [`PR #550`_]. Includes:
-    * The zfibermag faint limit is changed from 21.6 to 21.9
-    * For the IR selection, objects with r-W1>3.1 are not subjected to the sliding cut
+    * The zfibermag faint limit is changed from 21.6 to 21.9.
+    * IR-selected objects with r-W1>3.1 not subjected to the sliding cut.
 
 .. _`PR #550`: https://github.com/desihub/desitarget/pull/550
+.. _`PR #552`: https://github.com/desihub/desitarget/pull/552
 
 0.33.1 (2019-10-13)
 -------------------

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1163,8 +1163,8 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     colnames = _get_colnames(objects)
 
     photsys_north, photsys_south, obs_rflux, gflux, rflux, zflux,                     \
-        w1flux, w2flux, rfiberflux, zfiberflux, objtype, release,                     \
-        gfluxivar, rfluxivar, zfluxivar,                                              \
+        w1flux, w2flux, gfiberflux, rfiberflux, zfiberflux,                           \
+        objtype, release, gfluxivar, rfluxivar, zfluxivar,                            \
         gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,                         \
         gfracmasked, rfracmasked, zfracmasked,                                        \
         gfracin, rfracin, zfracin, gallmask, rallmask, zallmask,                      \

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -944,9 +944,9 @@ def isBACKUP(ra=None, dec=None, gaiagmag=None, primary=None):
     isbackupbright &= gaiagmag >= 13
     isbackupbright &= gaiagmag < 16
 
-    # ADM faint targets are 16 < G < 18.
+    # ADM faint targets are 16 < G < 21.
     isbackupfaint &= gaiagmag >= 16
-    isbackupfaint &= gaiagmag < 18
+    isbackupfaint &= gaiagmag < 21
     # ADM and are "far from" the Galaxy.
     isbackupfaint &= ~in_gal
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1350,6 +1350,7 @@ def _prepare_optical_wise(objects, mask=True):
     zflux = flux['ZFLUX']
     w1flux = flux['W1FLUX']
     w2flux = flux['W2FLUX']
+    gfiberflux = flux['GFIBERFLUX']
     rfiberflux = flux['RFIBERFLUX']
     zfiberflux = flux['ZFIBERFLUX']
     objtype = objects['TYPE']
@@ -1402,8 +1403,8 @@ def _prepare_optical_wise(objects, mask=True):
         deltaChi2[w] = -1e6
 
     return (photsys_north, photsys_south, obs_rflux, gflux, rflux, zflux,
-            w1flux, w2flux, rfiberflux, zfiberflux, objtype, release,
-            gfluxivar, rfluxivar, zfluxivar,
+            w1flux, w2flux, gfiberflux, rfiberflux, zfiberflux,
+            objtype, release, gfluxivar, rfluxivar, zfluxivar,
             gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,
             gfracmasked, rfracmasked, zfracmasked,
             gfracin, rfracin, zfracin, gallmask, rallmask, zallmask,
@@ -1951,8 +1952,8 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
 
     # ADM process the Legacy Surveys columns for Target Selection.
     photsys_north, photsys_south, obs_rflux, gflux, rflux, zflux,                     \
-        w1flux, w2flux, rfiberflux, zfiberflux, objtype, release,                     \
-        gfluxivar, rfluxivar, zfluxivar,                                              \
+        w1flux, w2flux, gfiberflux, rfiberflux, zfiberflux,                           \
+        objtype, release, gfluxivar, rfluxivar, zfluxivar,                            \
         gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,                         \
         gfracmasked, rfracmasked, zfracmasked,                                        \
         gfracin, rfracin, zfracin, gallmask, rallmask, zallmask,                      \

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -236,8 +236,8 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
 
 
 def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-          gsnr=None, rsnr=None, zsnr=None, maskbits=None, south=True,
-          primary=None):
+          gsnr=None, rsnr=None, zsnr=None, gnobs=None, rnobs=None, znobs=None,
+          maskbits=None, south=True, primary=None):
     """Definition of ELG target classes. Returns a boolean array.
     (see :func:`~desitarget.cuts.set_target_bits` for parameters).
 
@@ -249,7 +249,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     elg = primary.copy()
 
     elg &= notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
-                         primary=primary)
+                         gnobs=gnobs, rnobs=rnobs, znobs=znobs, primary=primary)
 
     elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
                         w2flux=w2flux, south=south, primary=primary)
@@ -257,7 +257,8 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     return elg
 
 
-def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None, primary=None):
+def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None,
+                  gnobs=None, rnobs=None, znobs=None, primary=None):
     """Standard set of masking cuts used by all ELG target selection classes.
     (see :func:`~desitarget.cuts.set_target_bits` for parameters).
     """
@@ -267,6 +268,10 @@ def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None, primary=None):
 
     # ADM good signal-to-noise in all bands.
     elg &= (gsnr > 0) & (rsnr > 0) & (zsnr > 0)
+
+    # ADM observed in every band.
+    elg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
+
     # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
     for bit in [1, 5, 6, 7, 11, 12, 13]:
         elg &= ((maskbits & 2**bit) == 0)
@@ -1662,7 +1667,9 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         for south in south_cuts:
             elg_classes[int(south)] = isELG(
                 primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
-                gsnr=gsnr, rsnr=rsnr, zsnr=zsnr, maskbits=maskbits, south=south
+                gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+                gnobs=gnobs, rnobs=rnobs, znobs=znobs, maskbits=maskbits,
+                south=south
             )
     elg_north, elg_south = elg_classes
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1531,7 +1531,7 @@ def unextinct_fluxes(objects):
 
 def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     gflux, rflux, zflux, w1flux, w2flux,
-                    rfiberflux, zfiberflux,
+                    gfiberflux, rfiberflux, zfiberflux,
                     objtype, release, gfluxivar, rfluxivar, zfluxivar,
                     gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,
                     gfracmasked, rfracmasked, zfracmasked,
@@ -1554,11 +1554,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     gflux, rflux, zflux, w1flux, w2flux : :class:`~numpy.ndarray`
         The flux in nano-maggies of g, r, z, W1 and W2 bands.
         Corrected for Galactic extinction.
-    rfiberflux : :class:`~numpy.ndarray`
-        Predicted fiber flux in 1 arcsecond seeing in r-band.
-        Corrected for Galactic extinction.
-    zfiberflux : :class:`~numpy.ndarray`
-        Predicted fiber flux in 1 arcsecond seeing in z-band.
+    gfiberflux, rfiberflux, zfiberflux : :class:`~numpy.ndarray`
+        Predicted fiber flux in 1 arcsecond seeing in g/r/z-band.
         Corrected for Galactic extinction.
     objtype, release : :class:`~numpy.ndarray`
         `The Legacy Surveys`_ imaging ``TYPE`` and ``RELEASE`` columns.
@@ -1987,7 +1984,7 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
     desi_target, bgs_target, mws_target = targcuts.set_target_bits(
         photsys_north, photsys_south, obs_rflux,
         gflux, rflux, zflux, w1flux, w2flux,
-        rfiberflux, zfiberflux,
+        gfiberflux, rfiberflux, zfiberflux,
         objtype, release, gfluxivar, rfluxivar, zfluxivar,
         gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,
         gfracmasked, rfracmasked, zfracmasked,

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1519,6 +1519,7 @@ def unextinct_fluxes(objects):
     result['ZFLUX'] = objects['FLUX_Z'] / objects['MW_TRANSMISSION_Z']
     result['W1FLUX'] = objects['FLUX_W1'] / objects['MW_TRANSMISSION_W1']
     result['W2FLUX'] = objects['FLUX_W2'] / objects['MW_TRANSMISSION_W2']
+    result['GFIBERFLUX'] = objects['FIBERFLUX_G'] / objects['MW_TRANSMISSION_G']
     result['RFIBERFLUX'] = objects['FIBERFLUX_R'] / objects['MW_TRANSMISSION_R']
     result['ZFIBERFLUX'] = objects['FIBERFLUX_Z'] / objects['MW_TRANSMISSION_Z']
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1508,7 +1508,7 @@ def unextinct_fluxes(objects):
     """
     dtype = [('GFLUX', 'f4'), ('RFLUX', 'f4'), ('ZFLUX', 'f4'),
              ('W1FLUX', 'f4'), ('W2FLUX', 'f4'),
-             ('RFIBERFLUX', 'f4'), ('ZFIBERFLUX', 'f4')]
+             ('GFIBERFLUX', 'f4'), ('RFIBERFLUX', 'f4'), ('ZFIBERFLUX', 'f4')]
     if _is_row(objects):
         result = np.zeros(1, dtype=dtype)[0]
     else:

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -242,7 +242,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     (see :func:`~desitarget.cuts.set_target_bits` for parameters).
 
     Notes:
-    - Current version (06/25/19) is version 180 on `the wiki`_.
+    - Current version (10/16/19) is version 202 on `the wiki`_.
     """
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -12,10 +12,10 @@ sv1_desi_mask:
     - [LOWZ_FILLER,     7, "LRG-like low-z filler sample (will NOT also have LRG set)",  {obsconditions: DARK}]
 
     #- ADM ELG sub-classes
-    - [ELG_FDR,        8, "ELG using FDR cuts",             {obsconditions: DARK|GRAY}]
-    - [ELG_FDR_FAINT,  9, "ELG using fainter FDR cuts",     {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_BLUE,   10, "ELG blue extension in rz color", {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_RED,    11, "ELG red extension in rz color",  {obsconditions: DARK|GRAY}]
+    - [ELG_SV_GTOT,        8, "ELG from relaxed version of FDR cuts and g-limit",        {obsconditions: DARK|GRAY}]
+    - [ELG_SV_GFIB,        9, "ELG from relaxed version of FDR cuts and g-fiber-limit",  {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_GTOT,      10, "ELG from FDR cuts with g-mag-limit",                      {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_GFIB,      11, "ELG from FDR cuts with g-fiber-mag-limit",                {obsconditions: DARK|GRAY}]
 
     #- ADM QSO sub-classes
     - [QSO_COLOR_4PASS,   12, "Low-z (tracer) QSO using color cuts",          {obsconditions: DARK}]
@@ -38,17 +38,17 @@ sv1_desi_mask:
     - [LRG_SUPER_8PASS_SOUTH,  26, "Faint LRG that is a superset of other cuts tuned for DECam",   {obsconditions: DARK}]
     - [LOWZ_FILLER_SOUTH,      27, "LRG-like low-z filler sample tuned for DECam",                 {obsconditions: DARK}]
 
-    - [ELG_FDR_NORTH,         28, "ELG using FDR cuts tuned for Bok/Mosaic",             {obsconditions: DARK|GRAY}]
-    - [ELG_FDR_FAINT_NORTH,   29, "ELG using fainter FDR cuts tuned for Bok/Mosaic",     {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_BLUE_NORTH,     30, "ELG blue extension in rz color tuned for Bok/Mosaic", {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_RED_NORTH,      31, "ELG red extension in rz color tuned for Bok/Mosaic",  {obsconditions: DARK|GRAY}]
+    - [ELG_SV_GTOT_NORTH,      28, "ELG from relaxed version of FDR cuts and g-limit for Bok/Mosaic",        {obsconditions: DARK|GRAY}]
+    - [ELG_SV_GFIB_NORTH,      29, "ELG from relaxed version of FDR cuts and g-fiber-limit for Bok/Mosaic",  {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_GTOT_NORTH,     30, "ELG from FDR cuts with g-mag-limit for Bok/Mosaic",                      {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_GFIB_NORTH,     31, "ELG from FDR cuts with g-fiber-mag-limit for Bok/Mosaic",                {obsconditions: DARK|GRAY}]
 
     #- ADM leave 32-37 reserved for calibration targets (to mirror the main survey)
 
-    - [ELG_FDR_SOUTH,         38, "ELG using FDR cuts tuned for DECam",                  {obsconditions: DARK|GRAY}]
-    - [ELG_FDR_FAINT_SOUTH,   39, "ELG using fainter FDR tuned for DECam",               {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_BLUE_SOUTH,     40, "ELG blue extension in rz color tuned for DECam",      {obsconditions: DARK|GRAY}]
-    - [ELG_RZ_RED_SOUTH,      41, "ELG red extension in rz color tuned for DECam",       {obsconditions: DARK|GRAY}]
+    - [ELG_SV_GTOT_SOUTH,      38, "ELG from relaxed version of FDR cuts and g-limit for DECam",        {obsconditions: DARK|GRAY}]
+    - [ELG_SV_GFIB_SOUTH,      39, "ELG from relaxed version of FDR cuts and g-fiber-limit for DECam",  {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_GTOT_SOUTH,     40, "ELG from FDR cuts with g-mag-limit for DECam",                      {obsconditions: DARK|GRAY}]
+    - [ELG_FDR_GFIB_SOUTH,     41, "ELG from FDR cuts with g-fiber-mag-limit for DECam",                {obsconditions: DARK|GRAY}]
 
     - [QSO_COLOR_4PASS_NORTH, 42, "Low-z (tracer) QSO using color cuts tuned for Bok/Mosaic",          {obsconditions: DARK}]
     - [QSO_RF_4PASS_NORTH,    43, "Low-z (tracer) QSO using random forest tuned for Bok/Mosaic",       {obsconditions: DARK}]
@@ -200,10 +200,10 @@ priorities:
         LRG_INIT_8PASS: SAME_AS_LRG
         LRG_SUPER_8PASS: SAME_AS_LRG
         LOWZ_FILLER: {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        ELG_FDR:       SAME_AS_ELG
-        ELG_FDR_FAINT: SAME_AS_ELG
-        ELG_RZ_BLUE:   SAME_AS_ELG
-        ELG_RZ_RED:    SAME_AS_ELG
+        ELG_SV_GTOT: SAME_AS_ELG
+        ELG_SV_GFIB: SAME_AS_ELG
+        ELG_FDR_GTOT: SAME_AS_ELG
+        ELG_FDR_GFIB: SAME_AS_ELG
         QSO_COLOR_4PASS: SAME_AS_QSO
         QSO_RF_4PASS:    SAME_AS_QSO
         QSO_COLOR_8PASS: SAME_AS_QSO
@@ -221,14 +221,14 @@ priorities:
         LRG_INIT_8PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
         LRG_SUPER_8PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
         LOWZ_FILLER_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_FDR_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_FDR_FAINT_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_RZ_BLUE_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_RZ_RED_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_FDR_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_FDR_FAINT_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_RZ_BLUE_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_RZ_RED_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
+        ELG_SV_GTOT_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
+        ELG_SV_GFIB_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
+        ELG_FDR_GTOT_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
+        ELG_FDR_GFIB_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
+        ELG_SV_GTOT_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
+        ELG_SV_GFIB_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
+        ELG_FDR_GTOT_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
+        ELG_FDR_GFIB_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_COLOR_4PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_RF_4PASS_NORTH:    SAME_AS_LRG_INIT_4PASS_NORTH
         QSO_COLOR_8PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
@@ -322,10 +322,10 @@ numobs:
         LRG_INIT_8PASS: 8
         LRG_SUPER_8PASS: 8
         LOWZ_FILLER: 1
-        ELG_FDR:       SAME_AS_ELG
-        ELG_FDR_FAINT: SAME_AS_ELG
-        ELG_RZ_BLUE:   SAME_AS_ELG
-        ELG_RZ_RED:    SAME_AS_ELG
+        ELG_SV_GTOT: SAME_AS_ELG
+        ELG_SV_GFIB: SAME_AS_ELG
+        ELG_FDR_GTOT: SAME_AS_ELG
+        ELG_FDR_GFIB: SAME_AS_ELG
         QSO_COLOR_4PASS: 4
         QSO_RF_4PASS:    4
         QSO_COLOR_8PASS: 8
@@ -343,14 +343,14 @@ numobs:
         LRG_INIT_8PASS_SOUTH:  0
         LRG_SUPER_8PASS_SOUTH: 0
         LOWZ_FILLER_SOUTH: 0
-        ELG_FDR_NORTH:       0
-        ELG_FDR_FAINT_NORTH: 0
-        ELG_RZ_BLUE_NORTH:   0
-        ELG_RZ_RED_NORTH:    0
-        ELG_FDR_SOUTH:       0
-        ELG_FDR_FAINT_SOUTH: 0
-        ELG_RZ_BLUE_SOUTH:   0
-        ELG_RZ_RED_SOUTH:    0
+        ELG_SV_GTOT_NORTH: 0
+        ELG_SV_GFIB_NORTH: 0
+        ELG_FDR_GTOT_NORTH: 0
+        ELG_FDR_GFIB_NORTH: 0
+        ELG_SV_GTOT_SOUTH: 0
+        ELG_SV_GFIB_SOUTH: 0
+        ELG_FDR_GTOT_SOUTH: 0
+        ELG_FDR_GFIB_SOUTH: 0
         QSO_COLOR_4PASS_NORTH: 0
         QSO_RF_4PASS_NORTH:    0
         QSO_COLOR_8PASS_NORTH: 0

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1113,7 +1113,7 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     # ADM create the FDR classes.
     fdr &= (rz > 0.3)                 # rz cut.
     fdr &= (rz < 1.6)                 # rz cut.
-    fdr &= gr < -1.20*rz + 1.6        # OII cut. 
+    fdr &= gr < -1.20*rz + 1.6        # OII cut.
     fdr &= gr < 1.15*rz + lowzcut_zp  # star/lowz cut.
 
     # ADM gfib/g split for FDR-like classes.

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1059,8 +1059,8 @@ def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None, primary=None):
     return elg
 
 
-def isELG_colors(gflux=None, rflux=None, zflux=None, gfiberflux=None,
-                 primary=None, south=True):
+def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+                 gfiberflux=None, primary=None, south=True):
     """Color cuts for ELG target selection classes
     (see, e.g., :func:`desitarget.cuts.set_target_bits` for parameters).
     """
@@ -1398,7 +1398,7 @@ def isMWS_WD(primary=None, gaia=None, galb=None, astrometricexcessnoise=None,
 
 def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     gflux, rflux, zflux, w1flux, w2flux,
-                    rfiberflux, zfiberflux,
+                    gfiberflux, rfiberflux, zfiberflux,
                     objtype, release, gfluxivar, rfluxivar, zfluxivar,
                     gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,
                     gfracmasked, rfracmasked, zfracmasked,

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -56,7 +56,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     Notes
     -----
-    - Current version (09/09/19) is version 92 on `the SV wiki`_.
+    - Current version (10/14/19) is version 104 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # ADM LRG SV targets.
@@ -419,7 +419,7 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None,
 
     Notes
     -----
-    - Current version (06/05/19) is version 68 on `the SV wiki`_.
+    - Current version (09/25/19) is version 100 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if not south:
@@ -562,7 +562,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
 
     Notes
     -----
-    - Current version (06/05/19) is version 68 on `the SV wiki`_.
+    - Current version (09/25/19) is version 100 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # BRICK_PRIMARY
@@ -675,7 +675,7 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
 
     Notes
     -----
-    - Current version (04/05/19) is version 64 on `the SV wiki`_.
+    - Current version (09/25/19) is version 100 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # BRICK_PRIMARY
@@ -784,7 +784,7 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
 
     Notes
     -----
-    - Current version (09/05/19) is version 93 on `the SV wiki`_.
+    - Current version (09/25/19) is version 101 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if not south:
@@ -912,7 +912,7 @@ def isBGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, rfiberfl
 
     Notes
     -----
-    - Current version (02/06/19) is version 36 on `the SV wiki`_.
+    - Current version (10/14/19) is version 105 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     _check_BGS_targtype_sv(targtype)
@@ -1024,7 +1024,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (03/19/19) is version 76 on `the SV wiki`_.
+    - Current version (10/14/19) is version 107 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if primary is None:

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1079,12 +1079,17 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, gfiberflux=None,
         lowzcut_zp = -0.35
 
     # ADM work in magnitudes not fluxes. THIS IS ONLY OK AS the snr cuts
-    # ADM in notinELG_mask ENSURES positive fluxes in all of g, r and z.
+    # ADM in notinELG_mask ENSURE positive fluxes in all of g, r and z.
     g = 22.5 - 2.5*np.log10(gflux.clip(1e-16))
     r = 22.5 - 2.5*np.log10(rflux.clip(1e-16))
     z = 22.5 - 2.5*np.log10(zflux.clip(1e-16))
 
+    # ADM gfiberflux can be zero but is never negative. So this is safe.
     gfib = 22.5 - 2.5*np.log10(gfiberflux.clip(1e-16))
+
+    # ADM these are safe as the snr cuts in notinELG_mask ENSURE positive
+    # ADM fluxes in all of g, r and z...so things near colors of zero but
+    # ADM that actually have negative fluxes will never be targeted.
     rz = r - z
     gr = g - r
 
@@ -1101,8 +1106,7 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, gfiberflux=None,
 
     # ADM gfib/g split for SV-like classes.
     svgtot, svgfib = sv.copy(), sv.copy()
-    # ADM coii?
-    coii = -1.2*rz + 2.5
+    coii = gr + 1.2*rz  # color defined perpendicularly to the -ve slope cut.
     svgtot &= coii < 1.6 - 7.2*(g-gtotfaint_fdr)     # sliding cut.
     svgfib &= coii < 1.6 - 7.2*(gfib-gfibfaint_fdr)  # sliding cut.
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1037,7 +1037,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
         gfiberflux=gfiberflux, south=south, primary=elg
     )
-    
+
     return svgtot, svgfib, fdrgtot, fdrgfib
 
 
@@ -1077,7 +1077,7 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, gfiberflux=None,
         gtotfaint_fdr = 23.6
         gfibfaint_fdr = 24.2
         lowzcut_zp = -0.35
-        
+
     # ADM work in magnitudes not fluxes. THIS IS ONLY OK AS the snr cuts
     # ADM in notinELG_mask ENSURES positive fluxes in all of g, r and z.
     g = 22.5 - 2.5*np.log10(gflux.clip(1e-16))
@@ -1087,10 +1087,10 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, gfiberflux=None,
     gfib = 22.5 - 2.5*np.log10(gfiberflux.clip(1e-16))
     rz = r - z
     gr = g - r
-    
+
     # ADM all classes have g > 20.
     elg &= g >= 20
-    
+
     # ADM parent classes for SV (relaxed) and FDR cuts.
     sv, fdr = elg.copy(), elg.copy()
 
@@ -1116,7 +1116,7 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, gfiberflux=None,
     fdrgtot, fdrgfib = fdr.copy(), fdr.copy()
     fdrgtot &= g < gtotfaint_fdr      # faint cut.
     fdrgfib &= gfib < gfibfaint_fdr   # faint cut.
-    
+
     return svgtot, svgfib, fdrgtot, fdrgfib
 
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1007,6 +1007,7 @@ def isBGS_colors(rflux=None, rfiberflux=None, south=True, targtype=None, primary
 
 def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
           gsnr=None, rsnr=None, zsnr=None, gfiberflux=None,
+          gnobs=None, rnobs=None, znobs=None,
           maskbits=None, south=True, primary=None):
     """Definition of ELG target classes. Returns a boolean array.
 
@@ -1031,7 +1032,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     elg = primary.copy()
 
     elg &= notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
-                         primary=primary)
+                         gnobs=gnobs, rnobs=rnobs, znobs=znobs, primary=primary)
 
     svgtot, svgfib, fdrgtot, fdrgfib = isELG_colors(
         gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
@@ -1041,7 +1042,8 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     return svgtot, svgfib, fdrgtot, fdrgfib
 
 
-def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None, primary=None):
+def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None,
+                  gnobs=None, rnobs=None, znobs=None, primary=None):
     """Standard set of masking cuts used by all ELG target selection classes.
     (see :func:`~desitarget.cuts.set_target_bits` for parameters).
     """
@@ -1051,6 +1053,9 @@ def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None, primary=None):
 
     # ADM good signal-to-noise in all bands.
     elg &= (gsnr > 0) & (rsnr > 0) & (zsnr > 0)
+
+    # ADM observed in every band.
+    elg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
     for bit in [1, 5, 6, 7, 11, 12, 13]:
@@ -1478,7 +1483,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
             elg_classes[int(south)] = isELG(
                 primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
                 gsnr=gsnr, rsnr=rsnr, zsnr=zsnr, gfiberflux=gfiberflux,
-                maskbits=maskbits, south=south
+                gnobs=gnobs, rnobs=rnobs, znobs=znobs, maskbits=maskbits,
+                south=south
             )
 
     elgsvgtot_n, elgsvgfib_n, elgfdrgtot_n, elgfdrgfib_n = elg_classes[0]

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -133,9 +133,11 @@ class TestCuts(unittest.TestCase):
 
         elg1 = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux,
                           gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+                          gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                           maskbits=maskbits, primary=primary)
         elg2 = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux,
                           gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+                          gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                           maskbits=maskbits, primary=None)
         self.assertTrue(np.all(elg1 == elg2))
 


### PR DESCRIPTION
Includes, related to ELG selections for SV:
- Four new bit names: `ELG_SV_GTOT`, `ELG_SV_GFIB`, `ELG_FDR_GTOT`, `ELG_FDR_GFIB` that replace the old ELG selections.
- A new set of cuts for each of these new selections, which include north/south differences.
- The `FIBERFLUX_G` column is now propagated from the sweeps to facilitate SV ELG cuts.

Also includes some minor updates for commissioning work:
- Increase the default sky densities by a factor of 4x.
- Relax the limit of the `BACKUP_FAINT` CMX targets to G < 21.