### PR TITLE
Add FIBERFLUX_IVAR_G/R/Z to mock skies when merging

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.33.2 (unreleased)
 -------------------
 
+* Add FIBERFLUX_IVAR_G/R/Z to mock skies when merging [`PR #556`_].
 * Fix minor bugs in `select_mock_targets` [`PR #555`_].
 * Update the ELG selections for SV [`PR #553`_]. Includes:
     * Four new bit names:
@@ -23,6 +24,7 @@ desitarget Change Log
 .. _`PR #552`: https://github.com/desihub/desitarget/pull/552
 .. _`PR #553`: https://github.com/desihub/desitarget/pull/553
 .. _`PR #555`: https://github.com/desihub/desitarget/pull/555
+.. _`PR #556`: https://github.com/desihub/desitarget/pull/556
 
 0.33.1 (2019-10-13)
 -------------------

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -1254,7 +1254,12 @@ def join_targets_truth(mockdir, outdir=None, overwrite=False, comm=None):
     if todo['sky']:
         _merge_file_tables(mockdir+'/*/*/sky-*.fits', 'SKY_TARGETS',
                            outfile=outdir+'/sky.fits', comm=comm,
-                           overwrite=overwrite)
+                           overwrite=overwrite,
+                           addcols=dict(
+                               FIBERFLUX_IVAR_G=300.0,
+                               FIBERFLUX_IVAR_R=900.0,
+                               FIBERFLUX_IVAR_Z=130.0)
+                           )
                            #addcols=dict(OBSCONDITIONS=obsmask.mask('DARK|GRAY|BRIGHT')))
         
     for obscon in ('bright', 'dark'):


### PR DESCRIPTION
This PR adds dummy FIBERFLUX_IVAR_G/R/Z columns to the merged mock skies file as a workaround to some downstream data model issues that we're sorting out (desihub/fiberassign#231).

Pragmatic hack: I added it while merging because I didn't want to have to re-run select_mock_targets from scratch just to get this columns for 19.9 testing.  We could upgrade it to the individual skies files if we decide we really do need this column.