### PR TITLE
Strict NoneType checking for fiberfluxes

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,14 @@ desitarget Change Log
 0.34.1 (unreleased)
 -------------------
 
+* Strict ``NoneType`` checking and testing for fiberfluxes [`PR #563`_]:
+    * Useful to ensure ongoing compatibility with the mocks.
+* Bitmasks (1,12,13), rfiberflux cut for BGS Main Survey [`PR #562`_].
 * Implement a variety of fixes to `select_mock_targets` [`PR #561`_].
-* Add bitmasks (1,12,13) and rfiberflux cut for BGS Main Survey selection [`PR #562`_].
 
 .. _`PR #561`: https://github.com/desihub/desitarget/pull/561
 .. _`PR #562`: https://github.com/desihub/desitarget/pull/562
+.. _`PR #562`: https://github.com/desihub/desitarget/pull/563
 
 0.34.0 (2019-11-03)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -12,7 +12,7 @@ desitarget Change Log
 
 .. _`PR #561`: https://github.com/desihub/desitarget/pull/561
 .. _`PR #562`: https://github.com/desihub/desitarget/pull/562
-.. _`PR #562`: https://github.com/desihub/desitarget/pull/563
+.. _`PR #563`: https://github.com/desihub/desitarget/pull/563
 
 0.34.0 (2019-11-03)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1023,12 +1023,12 @@ def notinBGS_mask(gnobs=None, rnobs=None, znobs=None, primary=None,
     bgs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
     bgs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
 
-    #geometrical cuts (i.e., bright sources)
+    # geometrical cuts (i.e., bright sources)
     for bit in [1, 12, 13]:
         bgs &= ((maskbits & 2**bit) == 0)
 
-    #Allmask?
-    #for bit in [5, 6, 7]:
+    # Allmask?
+    # for bit in [5, 6, 7]:
     #    bgs &= ((maskbits & 2**bit) == 0)
 
     if targtype == 'bright':
@@ -1048,12 +1048,12 @@ def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=Non
     """Standard set of color-based cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
+    _check_BGS_targtype(targtype)
+
     # ADM to maintain backwards-compatibility with mocks.
     if rfiberflux is None:
         log.warning('Setting rfiberflux to rflux!!!')
         rfiberflux = rflux.copy()
-
-    _check_BGS_targtype(targtype)
 
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
@@ -1079,13 +1079,14 @@ def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=Non
         bgs &= rflux < gflux * 10**(4.0/2.5)
         bgs &= zflux > rflux * 10**(-1.0/2.5)
         bgs &= zflux < rflux * 10**(4.0/2.5)
-        
+
     g = 22.5 - 2.5*np.log10(gflux.clip(1e-16))
     r = 22.5 - 2.5*np.log10(rflux.clip(1e-16))
     z = 22.5 - 2.5*np.log10(zflux.clip(1e-16))
     rfib = 22.5 - 2.5*np.log10(rfiberflux.clip(1e-16))
 
-    #Fibre Magnitude Cut (FMC) -- This is a low surface brightness cut with the aim of increase the redshift success rate.
+    # Fibre Magnitude Cut (FMC) -- This is a low surface brightness cut
+    # with the aim of increase the redshift success rate.
     fmc |= ((rfib < (2.9 + 1.2) + r) & (r < 17.1))
     fmc |= ((rfib < 21.2) & (r < 18.3) & (r > 17.1))
     fmc |= ((rfib < 2.9 + r) & (r > 18.3))
@@ -1817,7 +1818,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
             for targtype in ["bright", "faint", "wise"]:
                 bgs_store.append(
                     isBGS(
-                        rfiberflux=rfiberflux, gflux=gflux, rflux=rflux, zflux=zflux, 
+                        rfiberflux=rfiberflux, gflux=gflux, rflux=rflux, zflux=zflux,
                         w1flux=w1flux, w2flux=w2flux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                         gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
                         gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -252,6 +252,11 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
         primary = np.ones_like(rflux, dtype='?')
     lrg = primary.copy()
 
+    # ADM to maintain backwards-compatibility with mocks.
+    if zfiberflux is None:
+        log.warning('Setting zfiberflux to zflux!!!')
+        zfiberflux = zflux.copy()
+
     lrg &= (rflux_snr > 0) & (rflux > 0)   # ADM quality in r.
     lrg &= (zflux_snr > 0) & (zflux > 0) & (zfiberflux > 0)   # ADM quality in z.
     lrg &= (w1flux_snr > 4) & (w1flux > 0)  # ADM quality in W1.
@@ -1043,6 +1048,11 @@ def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=Non
     """Standard set of color-based cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
+    # ADM to maintain backwards-compatibility with mocks.
+    if rfiberflux is None:
+        log.warning('Setting rfiberflux to rflux!!!')
+        rfiberflux = rflux.copy()
+
     _check_BGS_targtype(targtype)
 
     if primary is None:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -531,7 +531,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
 
     # Optionally write out mock catalog data.
     if mockdata is not None:
-        #truthfile = filename.replace('targets-', 'truth-')
+        # truthfile = filename.replace('targets-', 'truth-')
         truthdata, trueflux, objtruth = mockdata['truth'], mockdata['trueflux'], mockdata['objtruth']
 
         hdr['SEED'] = (mockdata['seed'], 'initial random seed')
@@ -1574,6 +1574,7 @@ def _get_targ_dir():
         raise ValueError(msg)
 
     return targdir
+
 
 def find_target_files(targdir, dr=None, flavor="targets", survey="main",
                       obscon=None, hp=None, nside=None, resolve=True,

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -154,6 +154,11 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
         primary = np.ones_like(rflux, dtype='?')
     lrg = primary.copy()
 
+    # ADM to maintain backwards-compatibility with mocks.
+    if zfiberflux is None:
+        log.warning('Setting zfiberflux to zflux!!!')
+        zfiberflux = zflux.copy()
+
     lrg &= (rflux_snr > 0) & (rflux > 0)   # ADM quality in r.
     lrg &= (zflux_snr > 0) & (zflux > 0) & (zfiberflux > 0)   # ADM quality in z.
     lrg &= (w1flux_snr > 4) & (w1flux > 0)  # ADM quality in W1.
@@ -169,6 +174,11 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
         primary = np.ones_like(rflux, dtype='?')
     lrg = primary.copy()
     lrginit, lrgsuper = np.tile(primary, [2, 1])
+
+    # ADM to maintain backwards-compatibility with mocks.
+    if zfiberflux is None:
+        log.warning('Setting zfiberflux to zflux!!!')
+        zfiberflux = zflux.copy()
 
     gmag = 22.5 - 2.5 * np.log10(gflux.clip(1e-7))
     # ADM safe as these fluxes are set to > 0 in notinLRG_mask.
@@ -293,6 +303,11 @@ def isfiller(gflux=None, rflux=None, zflux=None, w1flux=None,
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
     filler = primary.copy()
+
+    # ADM to maintain backwards-compatibility with mocks.
+    if rfiberflux is None:
+        log.warning('Setting rfiberflux to rflux!!!')
+        rfiberflux = rflux.copy()
 
     filler &= (gflux_snr > 0) & (gflux > 0)    # ADM quality in g.
     filler &= (rflux_snr > 0) & (rflux > 0) & (rfiberflux > 0)   # ADM quality in r.
@@ -1051,10 +1066,14 @@ def isBGS_colors(rflux=None, rfiberflux=None, south=True, targtype=None, primary
     """Standard set of masking cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
-
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
     bgs = primary.copy()
+
+    # ADM to maintain backwards-compatibility with mocks.
+    if rfiberflux is None:
+        log.warning('Setting rfiberflux to rflux!!!')
+        rfiberflux = rflux.copy()
 
     if targtype == 'lowq':
         bgs &= rflux > 10**((22.5-20.1)/2.5)
@@ -1143,6 +1162,11 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
     elg = primary.copy()
+
+    # ADM to maintain backwards-compatibility with mocks.
+    if gfiberflux is None:
+        log.warning('Setting gfiberflux to gflux!!!')
+        gfiberflux = gflux.copy()
 
     # ADM some cuts specific to north or south
     if south:

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -139,18 +139,25 @@ class TestCuts(unittest.TestCase):
         else:
             primary = np.ones_like(gflux, dtype='?')
 
-        lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
-                          zfiberflux=zfiberflux, rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
-        lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
-                          zfiberflux=zfiberflux, rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
-        self.assertTrue(np.all(lrg1 == lrg2))
-        # ADM also check that the color selections alone work. This tripped us up once
-        # ADM with the mocks part of the code calling a non-existent LRG colors function.
-        lrg1 = cuts.isLRG_colors(primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
-                                 zfiberflux=zfiberflux, w1flux=w1flux, w2flux=w2flux)
-        lrg2 = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux, zflux=zflux,
-                                 zfiberflux=zfiberflux, w1flux=w1flux, w2flux=w2flux)
-        self.assertTrue(np.all(lrg1 == lrg2))
+        # ADM check for both defined fiberflux and fiberflux of None.
+        for ff in zfiberflux, None:
+            lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
+                              zflux=zflux, w1flux=w1flux, zfiberflux=ff,
+                              rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
+            lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux, zflux=zflux,
+                              w1flux=w1flux, zfiberflux=ff,
+                              rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
+            self.assertTrue(np.all(lrg1 == lrg2))
+
+            # ADM also check that the color selections alone work. This tripped us up once
+            # ADM with the mocks part of the code calling a non-existent LRG colors function.
+            lrg1 = cuts.isLRG_colors(primary=primary, gflux=gflux, rflux=rflux,
+                                     zflux=zflux, zfiberflux=ff,
+                                     w1flux=w1flux, w2flux=w2flux)
+            lrg2 = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux,
+                                     zflux=zflux, zfiberflux=ff,
+                                     w1flux=w1flux, w2flux=w2flux)
+            self.assertTrue(np.all(lrg1 == lrg2))
 
         elg1 = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux,
                           gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
@@ -166,20 +173,26 @@ class TestCuts(unittest.TestCase):
         elg2 = cuts.isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, primary=None)
         self.assertTrue(np.all(elg1 == elg2))
 
-        for targtype in ["bright", "faint", "wise"]:
-            bgs = []
-            for primary in [primary, None]:
-                bgs.append(
-                    cuts.isBGS(rfiberflux=rfiberflux, gflux=gflux, rflux=rflux, zflux=zflux, 
-                               w1flux=w1flux, w2flux=w2flux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                               gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                               gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
-                               gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
-                               gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
-                               maskbits=maskbits, Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag,
-                               primary=primary, targtype=targtype)
-                )
-            self.assertTrue(np.all(bgs[0] == bgs[1]))
+        # ADM check for both defined fiberflux and fiberflux of None.
+        for ff in rfiberflux, None:
+            for targtype in ["bright", "faint", "wise"]:
+                bgs = []
+                for prim in [primary, None]:
+                    bgs.append(
+                        cuts.isBGS(
+                            rfiberflux=ff, gflux=gflux, rflux=rflux,
+                            zflux=zflux, w1flux=w1flux, w2flux=w2flux,
+                            gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                            gfracmasked=gfracmasked, rfracmasked=rfracmasked,
+                            zfracmasked=zfracmasked, gfracflux=gfracflux,
+                            rfracflux=rfracflux, zfracflux=zfracflux,
+                            gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
+                            gfluxivar=gfluxivar, rfluxivar=rfluxivar,
+                            zfluxivar=zfluxivar, maskbits=maskbits,
+                            Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag,
+                            primary=prim, targtype=targtype)
+                    )
+                self.assertTrue(np.all(bgs[0] == bgs[1]))
 
         # ADM need to include RELEASE for quasar cuts, at least.
         release = targets['RELEASE']


### PR DESCRIPTION
This PR checks for `NoneType` fiberfluxes and substitutes `FLUX_X` when `FIBERFLUX_X` is not available. The goal is to make it easier for the mocks to directly use `desitarget` cuts without having to create mock fiberfluxes. 

Also included are new unit tests to explicitly pass `fiberflux=None` to the relevant `desitarget.cuts()` functions, to try to ensure continued compatibility with the mocks.