### PR TITLE
Some further clean-up of glitches and minor bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,16 +106,16 @@ matrix:
         # Coverage test.  Note that installing the coverage software can
         # change the set of packages installed by conda, so we do
         # separate 'test' and 'test --coverage'.
-        - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test --coverage'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+        # - os: linux
+        #  env: PYTHON_VERSION=3.5 SETUP_CMD='test --coverage'
+        #       CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+        #       PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         # Standard tests.
-       # - os: linux
-       #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'
-       #        CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-       #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+        # - os: linux
+        #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'
+        #        CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+        #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         # Redundant with the coverage test
         # - os: linux

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -158,9 +158,16 @@ if ns.bundlefiles is None:
         if not os.path.exists(scndoutdn):
             log.info("making directory...{}".format(scndoutdn))
             os.makedirs(scndoutdn)
-        scndoutfn = "{}.fits".format(os.path.splitext(os.path.basename(ns.dest))[0])
+        if pixlist is not None:
+            scndoutfn = io.find_target_files(ns.dest, dr=drint, flavor="targets",
+                                             survey=survey, hp=pixlist)
+        else:
+            scndoutfn = io.find_target_files(ns.dest, dr=drint, flavor="targets",
+                                             survey=survey, hp="X")
         # ADM construct the output directory for primary match info.
+        scndoutfn = os.path.basename(scndoutfn)
         scndout = os.path.join(scndoutdn, scndoutfn)
+        log.info("writing files of primary matches to...{}".format(scndout))
         targets = match_secondary(targets, scxdir, scndout, sep=1.,
                                   pix=pixlist, nside=ns.nside)
 

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -159,9 +159,16 @@ if ns.bundlefiles is None:
         if not os.path.exists(scndoutdn):
             log.info("making directory...{}".format(scndoutdn))
             os.makedirs(scndoutdn)
-        scndoutfn = "{}.fits".format(os.path.splitext(os.path.basename(ns.dest))[0])
+        if pixlist is not None:
+            scndoutfn = io.find_target_files(ns.dest, dr=drint, flavor="targets",
+                                             survey="main", hp=pixlist)
+        else:
+            scndoutfn = io.find_target_files(ns.dest, dr=drint, flavor="targets",
+                                             survey="main", hp="X")
         # ADM construct the output directory for primary match info.
+        scndoutfn = os.path.basename(scndoutfn)
         scndout = os.path.join(scndoutdn, scndoutfn)
+        log.info("writing files of primary matches to...{}".format(scndout))
         targets = match_secondary(targets, scxdir, scndout, sep=1.,
                                   pix=pixlist, nside=ns.nside)
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -44,7 +44,7 @@ desitarget Change Log
 .. _`PR #563`: https://github.com/desihub/desitarget/pull/563
 .. _`PR #564`: https://github.com/desihub/desitarget/pull/564
 .. _`PR #569`: https://github.com/desihub/desitarget/pull/569
-.. _`PR #569`: https://github.com/desihub/desitarget/pull/570
+.. _`PR #570`: https://github.com/desihub/desitarget/pull/570
 
 0.34.0 (2019-11-03)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,14 @@ desitarget Change Log
 0.34.1 (unreleased)
 -------------------
 
+* More clean-up of glitches and minor bugs [`PR #570`_]. Includes:
+    * Remove Python 3.5 unit tests.
+    * Catch AssertionError if NoneType input directory when writing.
+    * Assert the data model when reading secondary target files.
+    * Use io.find_target_files() to name priminfo file for secondaries.
+    * Allow N < 16 nodes when bundling files for slurm.
+    * Use the DR14Q file for SV, not the DR16Q file.
+* Fix bug where wrong SNRs were passed to z~5 QSO selection [`PR #569`_].
 * General clean-up of glitches and minor bugs [`PR #564`_]. Includes:
     * Don't include BACKUP targets in the pixweight files.
     * Correctly write all all-sky pixels outside of the Legacy Surveys.
@@ -35,6 +43,8 @@ desitarget Change Log
 .. _`PR #562`: https://github.com/desihub/desitarget/pull/562
 .. _`PR #563`: https://github.com/desihub/desitarget/pull/563
 .. _`PR #564`: https://github.com/desihub/desitarget/pull/564
+.. _`PR #569`: https://github.com/desihub/desitarget/pull/569
+.. _`PR #569`: https://github.com/desihub/desitarget/pull/570
 
 0.34.0 (2019-11-03)
 -------------------

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -727,7 +727,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
         bins = [[[i, j]] for i, j in
                 zip(np.ones(nbins, dtype='int'), np.arange(nbins))]
         maxeta = 1
-        nnodes = 16
+        nnodes = min(16, len(bins))
         if prefix == 'supp-skies':
             nnodes = 4
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -435,7 +435,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
         try:
             drint = int(indir.split("dr")[1][0])
             drstring = 'dr'+str(drint)
-        except (ValueError, IndexError):
+        except (ValueError, IndexError, AssertionError):
             drstring = "X"
 
     # ADM catch cases where we're writing-to-file and there's no hpxlist.
@@ -892,7 +892,7 @@ def write_gfas(targdir, data, indir=None, indir2=None, nside=None,
     try:
         drint = int(indir.split("dr")[1][0])
         drstring = 'dr'+str(drint)
-    except (ValueError, IndexError):
+    except (ValueError, IndexError, AssertionError):
         drint = None
         drstring = "X"
 
@@ -1015,7 +1015,7 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
             drint = int(indir.split("dr")[1][0])
             drstring = 'dr'+str(drint)
             depend.setdep(hdr, 'photcat', drstring)
-        except (ValueError, IndexError):
+        except (ValueError, IndexError, AssertionError):
             drint = None
 
     # ADM add HEALPix column, if requested by input.

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -292,6 +292,11 @@ def read_files(scxdir, scnd_mask):
         # ADM ensure this is a properly constructed numpy array.
         scxin = np.atleast_1d(scxin)
 
+        # ADM assert the data model.
+        msg = "Data model doesn't match {} in {}".format(indatamodel.dtype, fn)
+        for col in indatamodel.dtype.names:
+            assert scxin[col].dtype == indatamodel[col].dtype, msg
+
         # ADM the default is 2015.5 for the REF_EPOCH.
         ii = scxin["REF_EPOCH"] == 0
         scxin["REF_EPOCH"][ii] = 2015.5

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -146,8 +146,8 @@ sv1_mws_mask:
 sv1_scnd_mask:
     - [VETO,        0, "Never observe, even if a primary target bit is set",
        {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18, filename: 'veto'}]
-    - [DR16Q,       1, "Known quasars from the SDSS DR16Q catalog",
-       {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18, filename: 'dr16q'}]
+    - [DR14Q,       1, "Known quasars from the SDSS DR14Q catalog",
+       {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18, filename: 'dr14q'}]
     - [MWS_WD_SV,                10, "Milky Way Survey White Dwarf (SV cuts)",  
         {obsconditions: BRIGHT|GRAY|DARK, filename: 'MWS_WD_SV'}]
     - [MWS_SPECIAL_DRACO_SV,     11, "Likely Draco members (SV cuts)",
@@ -338,7 +338,7 @@ priorities:
     # ADM secondary target priorities. Probably all have very low UNOBS
     sv1_scnd_mask:
         VETO:                         {UNOBS:  0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
-        DR16Q:                        {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        DR14Q:                        {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         MWS_WD_SV:                    {UNOBS: 2296, DONE:  600, OBS: 1, DONOTOBSERVE: 0}
         MWS_WD_SV_VERYBRIGHT:         SAME_AS_MWS_WD_SV
         MWS_CALIB_APOGEE:             {UNOBS: 2995, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
@@ -480,7 +480,7 @@ numobs:
     # ADM initial number of observations for secondary targets
     sv1_scnd_mask:
         VETO: 1
-        DR16Q: 1
+        DR14Q: 1
         MWS_WD_SV:                       100
         MWS_WD_SV_VERYBRIGHT:            SAME_AS_MWS_WD_SV
         MWS_CALIB_APOGEE:                100


### PR DESCRIPTION
Includes:
- Deprecate the Python 3.5 unit tests.
- Catch the `AssertionError` if a `NoneType` input directory is passed in `desitarget.io` when writing files (this should address #568).
- Assert the data model when reading secondary target files.
- Use `io.find_target_files()` to name the priminfo file (the file of primary matches) for secondaries.
- Allow N < 16 nodes when bundling files for slurm.
- Use the DR14Q file for SV, not the DR16Q file. By agreement with SDSS-IV/eBOSS we can only use DR16Q once the DR16Q fits file is made public.
