### PR TITLE
Preparation for DR9, particularly the DR9c imaging files.

### DIFF
--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -56,13 +56,16 @@ ap.add_argument("--noresolve", action='store_true',
 ap.add_argument("--aprad", type=float,
                 help="Radius of aperture in arcsec in which to generate sky background flux levels (defaults to 0.75; the DESI fiber radius)",
                 default=0.75)
+ap.add_argument("--seed", type=int,
+                help="Random seed passed to desitarget.randoms.select_randoms()",
+                default=1)
 
 ns = ap.parse_args()
 # ADM build the list of command line arguments as
 # ADM bundlefiles potentially needs to know about them.
 extra = " --numproc {}".format(ns.numproc)
 nsdict = vars(ns)
-for nskey in "noresolve", "aprad", "density":
+for nskey in "noresolve", "aprad", "density", "seed":
     if isinstance(nsdict[nskey], bool):
         if nsdict[nskey]:
             extra += " --{}".format(nskey)
@@ -104,12 +107,16 @@ if not 'dr5' in ns.surveydir and not 'dr6' in ns.surveydir:
 randoms = select_randoms(ns.surveydir, density=ns.density, numproc=ns.numproc,
                          nside=ns.nside, pixlist=pixlist, aprad=ns.aprad, extra=extra,
                          bundlebricks=ns.bundlebricks, brickspersec=ns.brickspersec,
-                         dustdir=ns.dustdir, resolverands=not(ns.noresolve))
+                         dustdir=ns.dustdir, resolverands=not(ns.noresolve), seed=ns.seed)
 
 if ns.bundlebricks is None:
+    # ADM extra header keywords for the output fits file.
+    extra = {k: v for k, v in zip(["density", "aprad", "seed"],
+                                  [ns.density, ns.aprad, ns.seed])}
+
+
     nrands, outfile = io.write_randoms(
-        ns.dest, randoms, indir=ns.surveydir, aprad=ns.aprad, hdr=hdr,
-        nside=nside, density=ns.density, resolve=not(ns.noresolve),
-        nsidefile=ns.nside, hpxlist=pixlist)
+        ns.dest, randoms, indir=ns.surveydir, hdr=hdr, nside=nside, extra=extra,
+        resolve=not(ns.noresolve), nsidefile=ns.nside, hpxlist=pixlist)
     log.info('wrote file of {} randoms to {}...t = {:.1f}s'
              .format(nrands, outfile, time()-start))

--- a/bin/select_secondary
+++ b/bin/select_secondary
@@ -5,7 +5,6 @@ import fitsio
 import numpy as np
 import argparse
 from desitarget.secondary import select_secondary, _get_scxdir
-from desitarget.targets import main_cmx_or_sv
 from desitarget import io
 import os
 from glob import glob
@@ -21,7 +20,7 @@ ap.add_argument("priminfodir",
                 help="Location of the directory that has previously matched primary and secondary targets to recover the unique primary TARGETIDs " +
                 "(as made by, e.g., select_targets without the --nosecondary option set).")
 ap.add_argument("dest",
-                help="Output secondary-only targets file (e.g. '/project/projectdirs/desi/target/catalogs/secondary-dr6-0.20.0.fits' at NERSC)")
+                help="Output secondary-only targets directory (the file names are built on-the-fly from other inputs")
 ap.add_argument("-s", "--separation", type=float, default=1.,
                 help='Angular separation at which to match secondary targets to themselves. Defaults to [1] arcsec.')
 ap.add_argument("--scnddir",
@@ -56,6 +55,12 @@ scx = select_secondary(ns.priminfodir, sep=ns.separation, scxdir=scxdir, darkbri
 hdr['PRIMDIR'] = ns.priminfodir
 hdr['SEP'] = float(ns.separation)
 
+# ADM try to determine the Data Release from the priminfo file.
+try:
+    drint =ns. priminfodir.split('dr')[1].split('-')[0]
+except (ValueError, IndexError, AttributeError):
+    drint = "X"
+
 # ADM write out the secondary targets, with bright-time
 # ADM and dark-time targets written separately.
 obscons = ["BRIGHT", "DARK"]
@@ -65,7 +70,8 @@ if ns.writeall:
 for obscon in obscons:
     # ADM the dict() here is to make hdr immutable.
     ntargs, outfile = io.write_secondary(ns.dest, scx, primhdr=dict(hdr),
-                                         scxdir=scxdir, obscon=obscon)
+                                         scxdir=scxdir, obscon=obscon,
+                                         drint=drint)
 
-    log.info('{} secondary targets written to {}...t={:.1f}mins'
+    log.info('{} standalone secondary targets written to {}...t={:.1f}mins'
              .format(ntargs, outfile, (time()-time0)/60.))

--- a/bin/supplement_randoms
+++ b/bin/supplement_randoms
@@ -21,7 +21,7 @@ log = get_logger()
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Make a random catalog with "zeros" for pixel-level quantities in missing (i.e. outside-of-the-footprint) bricks')
 ap.add_argument("randomcat",
-                help='An existing "inside-of-the-footprint" random catalog. Must contain at least the column "BRICKNAME" (e.g /project/projectdirs/desi/target/catalogs/randoms-dr4-0.20.0.fits)')
+                help='An existing "inside-of-the-footprint" random catalog. Must contain at least the column "BRICKNAME" and the header card "SEED" (e.g /project/projectdirs/desi/target/catalogs/randoms-dr4-0.20.0.fits). If SEED does not exist in the header, the seed defaults to 1 in desitarget.randoms.supplement_randoms()"')
 ap.add_argument("dest",
                 help="Output directory for random catalog (the file name is built on-the-fly from other inputs)")
 ap.add_argument("--density", type=int,
@@ -45,16 +45,22 @@ log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-star
 # ADM just the filename for the input random catalog.
 rancatfn = os.path.basename(ns.randomcat)
 
-# ADM determine the bricknames that are already covered by the existing random catalog.
+# ADM find the bricknames covered by the existing random catalog.
 donebns = fitsio.read(ns.randomcat, columns="BRICKNAME")
 
+# ADM determine the seed used for the existing random catalog.
+try:
+    seed = fitsio.read_header(ns.randomcat, "RANDOMS")["SEED"]
+except KeyError:
+    seed = 1
+
 # ADM make the array of "zerod" bricks.
-randoms = supplement_randoms(
-    donebns, density=ns.density, numproc=ns.numproc, dustdir=ns.dustdir)
+randoms = supplement_randoms(donebns, density=ns.density, numproc=ns.numproc,
+                             dustdir=ns.dustdir, seed=seed)
 
 # ADM write out the supplemental random catalog.
 nrands, outfile = io.write_randoms(ns.dest, randoms, indir=ns.randomcat,
-                                   supp=True, density=ns.density)
+                                   supp=True, density=ns.density, seed=seed)
 
 log.info('wrote file of {} randoms to {}...t = {:.1f}s'
          .format(nrands, outfile, time()-start))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,13 @@ desitarget Change Log
 0.34.1 (unreleased)
 -------------------
 
+* Preparation for DR9 [`PR #573`_]. Includes:
+    * Update data model, maintaining backwards-compatability with DR8.
+    * Don't set the ``SKY`` bit when setting the ``SUPP_SKY`` bit.
+    * Users can input a seed (1, 2, 3, etc.) to ``bin/select_randoms``:
+        * This user-provided seed is added to the output file name.
+        * Facilitates generating a range of numbered random catalogs.
+    * Write out final secondaries using :func:`io.find_target_files()`.
 * More clean-up of glitches and minor bugs [`PR #570`_]. Includes:
     * Remove Python 3.5 unit tests.
     * Catch AssertionError if NoneType input directory when writing.
@@ -46,6 +53,7 @@ desitarget Change Log
 .. _`PR #564`: https://github.com/desihub/desitarget/pull/564
 .. _`PR #569`: https://github.com/desihub/desitarget/pull/569
 .. _`PR #570`: https://github.com/desihub/desitarget/pull/570
+.. _`PR #573`: https://github.com/desihub/desitarget/pull/573
 
 0.34.0 (2019-11-03)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,7 @@ desitarget Change Log
 * More clean-up of glitches and minor bugs [`PR #570`_]. Includes:
     * Remove Python 3.5 unit tests.
     * Catch AssertionError if NoneType input directory when writing.
+        * Later (correctly) updated to AttributeError directly in master.
     * Assert the data model when reading secondary target files.
     * Use io.find_target_files() to name priminfo file for secondaries.
     * Allow N < 16 nodes when bundling files for slurm.

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -605,7 +605,7 @@ def circle_boundaries(RAcens, DECcens, r, nloc):
 
 
 def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
-                  gather=True, surveydirs=None, extra=None):
+                  gather=True, surveydirs=None, extra=None, seed=None):
     """Determine the optimal packing for bricks collected by HEALpixel integer.
 
     Parameters
@@ -637,6 +637,8 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     extra : :class:`str`, optional
         Extra command line flags to be passed to the executable lines in
         the output slurm script.
+    seed : :class:`int`, optional, defaults to 1
+        Random seed for file name. Only relevant for `prefix='randoms'`.
 
     Returns
     -------
@@ -790,6 +792,9 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             # ADM the replace is to handle inputs that look like "sv1_targets".
             outfile = "$CSCRATCH/{}/{}{}-hp-{}.fits".format(
                 prefix2, prefix.replace("_", "-"), drstr, strgoodpix)
+            # ADM random catalogs have an additional seed in their file name.
+            if prefix=='randoms':
+                outfile = outfile.replace(".fits", "-{}.fits".format(seed))
             outfiles.append(outfile)
             if extra is not None:
                 strgoodpix += extra

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1351,14 +1351,14 @@ def radec_match_to(matchto, objs, sep=1., radec=False, return_sep=False):
     Parameters
     ----------
     matchto : :class:`~numpy.ndarray` or `list`
-        Coordinates to match TO. Must include the columns "RA" and "DEC".
+        Coordinates to match TO. Must include columns "RA" and "DEC".
     objs : :class:`~numpy.ndarray` or `list`
-        Objects that will be matched to `matchto`. Must include "RA" and "DEC".
+        Objects matched to `matchto`. Must include "RA" and "DEC".
     sep : :class:`float`, defaults to 1 arcsecond
-        The separation at which to match `objs` to `matchto` in ARCSECONDS.
+        Separation at which to match `objs` to `matchto` in ARCSECONDS.
     radec : :class:`bool`, optional, defaults to ``False``
-        If ``True`` then `objs` and `matchto` are [RA, Dec] lists instead of
-        rec arrays.
+        If ``True`` then `objs` and `matchto` are [RA, Dec] lists
+        instead of rec arrays.
     return_sep : :class:`bool`, optional, defaults to ``False``
         If ``True`` then return the separation between each object, not
         just the indexes of the match.
@@ -1366,21 +1366,21 @@ def radec_match_to(matchto, objs, sep=1., radec=False, return_sep=False):
     Returns
     -------
     :class:`~numpy.ndarray` (of integers)
-        The indexes in `match2` for which `objs` matches `match2` at < `sep`.
+        Indexes in `matchto` where `objs` matches `matchto` at < `sep`.
     :class:`~numpy.ndarray` (of integers)
-        The indexes in `objs` for which `objs` matches `match2` at < `sep`.
+        Indexes in `objs` where `objs` matches `matchto` at < `sep`.
     :class:`~numpy.ndarray` (of floats)
         The distances in ARCSECONDS of the matches.
         Only returned if `return_sep` is ``True``.
 
     Notes
     -----
-        - Sense is important, here. Every coordinate pair in `objs` is matched
-          to `matchto`, but NOT every coordinate pair in `matchto` is matched to
-          `objs`. `matchto` should be thought of as the parent catalog being
-          matched to, in that we are looking for all the instances where `objs`
-          has a match in `matchto`. The returned indexes thus can never be longer
-          than `objs`. Consider this example:
+        - Sense is important. Every coordinate pair in `objs` is matched
+          to `matchto`, but NOT every coordinate pair in `matchto` is
+          matched to `objs`. `matchto` is the "parent" catalog being
+          matched to, i.e. we're looking for the instances where `objs`
+          has a match in `matchto`. The array of returned indexes thus
+          can't be longer than `objs`. Consider this example:
 
           >>> mainra, maindec = [100], [30]
           >>> ras, decs = [100, 100, 100], [30, 30, 30]

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -793,7 +793,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             outfile = "$CSCRATCH/{}/{}{}-hp-{}.fits".format(
                 prefix2, prefix.replace("_", "-"), drstr, strgoodpix)
             # ADM random catalogs have an additional seed in their file name.
-            if prefix=='randoms':
+            if prefix == 'randoms':
                 outfile = outfile.replace(".fits", "-{}.fits".format(seed))
             outfiles.append(outfile)
             if extra is not None:

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1281,10 +1281,11 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
     # ADM if the bundlebricks option was sent, call the packing code.
     if bundlebricks is not None:
         # ADM pixnum only contains unique bricks, need to add duplicates.
-        allpixnum = np.concatenate([np.zeros(cnt, dtype=int)+pix
-                                    for cnt, pix in zip(cnts.astype(int), pixnum)])
-        bundle_bricks(allpixnum, bundlebricks, nside, brickspersec=brickspersec,
-                      prefix='randoms', surveydirs=[drdir], extra=extra)
+        allpixnum = np.concatenate([np.zeros(cnt, dtype=int)+pix for
+                                    cnt, pix in zip(cnts.astype(int), pixnum)])
+        bundle_bricks(allpixnum, bundlebricks, nside,
+                      brickspersec=brickspersec, prefix='randoms',
+                      surveydirs=[drdir], extra=extra, seed=seed)
         return
 
     # ADM restrict to only bricks in a set of HEALPixels, if requested.

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -66,8 +66,8 @@ def dr_extension(drdir):
     return 'fz', 1
 
 
-def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
-                                  density=100000, poisson=True, wrap=True):
+def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax, density=100000,
+                                  poisson=True, wrap=True, seed=1):
     """For brick edges, return random (RA/Dec) positions in the brick.
 
     Parameters
@@ -90,7 +90,10 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
         If ``True``, bricks with `ramax`-`ramin` > 350o are assumed to
         wrap, which is corrected by subtracting 360o from `ramax`, as is
         reasonable for small bricks. ``False`` turns of this correction.
-
+    seed : :class:`int`, optional, defaults to 1
+        Random seed to use when shuffling across brick boundaries.
+        The actual np.random.seed defaults to:
+            seed*int(1e7)+int(4*ramin)*1000+int(4*(decmin+90))
     Returns
     -------
     :class:`~numpy.array`
@@ -101,7 +104,7 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
     # ADM create a unique random seed on the basis of the brick.
     # ADM note this is only unique for bricksize=0.25 for bricks
     # ADM that are more than 0.25 degrees from the poles.
-    uniqseed = int(4*ramin)*1000+int(4*(decmin+90))
+    uniqseed = seed*int(1e7)+int(4*ramin)*1000+int(4*(decmin+90))
     np.random.seed(uniqseed)
 
     # ADM generate random points within the brick at the requested density
@@ -472,30 +475,34 @@ def hp_with_nobs_in_a_brick(ramin, ramax, decmin, decmax, brickname, drdir,
         - In the event that there are no pixels with one or more observations in the passed
           brick, and empty structured array will be returned.
     """
-    # ADM this is only intended to work on one brick, so die if a larger array is passed.
+    # ADM this is only intended to work on one brick, so die if a larger
+    # ADM array is passed.
     if not isinstance(brickname, str):
         log.fatal("Only one brick can be passed at a time!")
         raise ValueError
 
-    # ADM generate an empty structured array to return in the event that no pixels with
-    # ADM counts were found.
+    # ADM generate an empty structured array to return in the event that
+    # ADM no pixels with counts were found.
     hpxinfo = np.zeros(0, dtype=[('HPXPIXEL', '>i4'), ('HPXCOUNT', '>i4')])
 
-    # ADM generate random points within the brick at the requested density.
+    # ADM generate random points in the brick at the requested density.
     ras, decs = randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
                                               density=density, wrap=False)
 
     # ADM retrieve the number of observations for each random point.
-    nobs_g, nobs_r, nobs_z = nobs_at_positions_in_a_brick(ras, decs, brickname, drdir=drdir)
+    nobs_g, nobs_r, nobs_z = nobs_at_positions_in_a_brick(ras, decs, brickname,
+                                                          drdir=drdir)
 
     # ADM only retain points with one or more observations in all bands.
     w = np.where((nobs_g > 0) & (nobs_r > 0) & (nobs_z > 0))
 
-    # ADM if there were some non-zero observations, populate the pixel numbers and counts.
+    # ADM for non-zero observations, populate pixel numbers and counts.
     if len(w[0]) > 0:
-        pixnums = hp.ang2pix(nside, np.radians(90.-decs[w]), np.radians(ras[w]), nest=True)
+        pixnums = hp.ang2pix(nside, np.radians(90.-decs[w]), np.radians(ras[w]),
+                             nest=True)
         pixnum, pixcnt = np.unique(pixnums, return_counts=True)
-        hpxinfo = np.zeros(len(pixnum), dtype=[('HPXPIXEL', '>i4'), ('HPXCOUNT', '>i4')])
+        hpxinfo = np.zeros(len(pixnum),
+                           dtype=[('HPXPIXEL', '>i4'), ('HPXCOUNT', '>i4')])
         hpxinfo['HPXPIXEL'] = pixnum
         hpxinfo['HPXCOUNT'] = pixcnt
 
@@ -529,7 +536,7 @@ def get_dust(ras, decs, scaling=1, dustdir=None):
 
 def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
                               density=100000, dustdir=None, aprad=0.75,
-                              zeros=False, drdir=None):
+                              zeros=False, drdir=None, seed=1):
     """NOBS, DEPTHS etc. (per-band) for random points in a brick of the Legacy Surveys
 
     Parameters
@@ -562,6 +569,8 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
         The root directory pointing to a DR from the Legacy Surveys
         e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
         Only necessary to pass if zeros is ``False``.
+    seed : :class:`int`, optional, defaults to 1
+        See :func:`~desitarget.randoms.randoms_in_a_brick_from_edges`.
 
     Returns
     -------
@@ -584,14 +593,15 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
               'coadd/132/1320p317/legacysurvey-1320p317-maskbits.fits.fz'
             EBV: E(B-V) at this location from the SFD dust maps.
     """
-    # ADM this is only intended to work on one brick, so die if a larger array is passed.
+    # ADM only intended to work on one brick, so die for larger arrays.
     if not isinstance(brickname, str):
         log.fatal("Only one brick can be passed at a time!")
         raise ValueError
 
-    # ADM generate random points within the brick at the requested density.
+    # ADM generate random points in the brick at the requested density.
     ras, decs = randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax,
-                                              density=density, wrap=False)
+                                              density=density, wrap=False,
+                                              seed=seed)
 
     # ADM only look up pixel-level quantities if zeros was not sent.
     if not zeros:
@@ -599,7 +609,7 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
         qdict = dr8_quantities_at_positions_in_a_brick(ras, decs, brickname,
                                                        drdir, aprad=aprad)
 
-        # ADM catch the case where a coadd directory is completely missing.
+        # ADM catch where a coadd directory is completely missing.
         if len(qdict) > 0:
             # ADM if 2 different camera combinations overlapped a brick
             # ADM then we need to duplicate the ras, decs as well.
@@ -1058,8 +1068,8 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
 
 
 def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
-                          zeros=False, cnts=True,
-                          density=None, dustdir=None, aprad=None):
+                          zeros=False, cnts=True, density=None,
+                          dustdir=None, aprad=None, seed=1):
 
     """Parallel-process a random catalog for a set of brick names.
 
@@ -1076,6 +1086,8 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
         See :func:`~desitarget.randoms.get_quantities_in_a_brick`.
     cnts : :class:`bool`, optional, defaults to ``True``
         See :func:`~desitarget.skyfibers.get_brick_info`.
+    seed : :class:`int`, optional, defaults to 1
+        See :func:`~desitarget.randoms.randoms_in_a_brick_from_edges`.
 
     Returns
     -------
@@ -1105,7 +1117,8 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
         # ADM of interest at those points.
         return get_quantities_in_a_brick(
             bramin, bramax, bdecmin, bdecmax, brickname, drdir=drdir,
-            density=density, dustdir=dustdir, aprad=aprad, zeros=zeros)
+            density=density, dustdir=dustdir, aprad=aprad, zeros=zeros,
+            seed=seed)
 
     # ADM this is just to count bricks in _update_status.
     nbrick = np.zeros((), dtype='i8')
@@ -1147,7 +1160,8 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
     return qinfo
 
 
-def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None):
+def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None,
+                       seed=1):
     """Random catalogs of "zeros" for missing bricks.
 
     Parameters
@@ -1159,6 +1173,10 @@ def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None):
     density : :class:`int`, optional, defaults to 10,000
         Number of random points per sq. deg. A typical brick is ~0.25 x
         0.25 sq. deg. so ~(0.0625*density) points will be returned.
+    seed : :class:`int`, optional, defaults to 1
+        Random seed to use when shuffling across brick boundaries.
+        The actual np.random.seed defaults to 615+`seed`. Also see use
+        in :func:`~desitarget.randoms.randoms_in_a_brick_from_edges`.
 
     Returns
     -------
@@ -1180,10 +1198,10 @@ def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None):
 
     qzeros = select_randoms_bricks(brickdict, bricknames, numproc=numproc,
                                    zeros=True, cnts=False, density=density,
-                                   dustdir=dustdir)
+                                   dustdir=dustdir, seed=seed)
 
     # ADM one last shuffle to randomize across brick boundaries.
-    np.random.seed(616)
+    np.random.seed(615+seed)
     np.random.shuffle(qzeros)
 
     return qzeros
@@ -1191,7 +1209,7 @@ def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None):
 
 def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
                    bundlebricks=None, brickspersec=2.5, extra=None,
-                   dustdir=None, resolverands=True, aprad=0.75):
+                   dustdir=None, resolverands=True, aprad=0.75, seed=1):
     """NOBS, DEPTHs (per-band), MASKs for random points in a Legacy Surveys DR.
 
     Parameters
@@ -1235,6 +1253,10 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
     aprad : :class:`float`, optional, defaults to 0.75
         Radii in arcsec of aperture for which to derive sky fluxes
         defaults to the DESI fiber radius.
+    seed : :class:`int`, optional, defaults to 1
+        Random seed to use when shuffling across brick boundaries.
+        The actual np.random.seed defaults to 615+`seed`. See also use
+        in :func:`~desitarget.randoms.randoms_in_a_brick_from_edges`.
 
     Returns
     -------
@@ -1284,13 +1306,13 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
     # ADM recover the pixel-level quantities in the DR bricks.
     qinfo = select_randoms_bricks(brickdict, bricknames, numproc=numproc,
                                   drdir=drdir, density=density, dustdir=dustdir,
-                                  aprad=aprad)
+                                  aprad=aprad, seed=seed)
     # ADM remove bricks that overlap between two surveys, if requested.
     if resolverands:
         qinfo = resolve(qinfo)
 
     # ADM one last shuffle to randomize across brick boundaries.
-    np.random.seed(616)
+    np.random.seed(615+seed)
     np.random.shuffle(qinfo)
 
     return qinfo

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -937,7 +937,6 @@ def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
     # ADM add the TARGETID, DESITARGET bits etc.
     nskies = len(supp)
     desi_target = np.zeros(nskies, dtype='>i8')
-    desi_target |= desi_mask.SKY
     desi_target |= desi_mask.SUPP_SKY
     dum = np.zeros_like(desi_target)
     supp = finalize(supp, desi_target, dum, dum, sky=1)

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -67,20 +67,24 @@ class TestIO(unittest.TestCase):
         # ADM Gaia columns that get added on input.
         from desitarget.gaiamatch import gaiadatamodel
         from desitarget.gaiamatch import pop_gaia_coords, pop_gaia_columns
-        # ADM have to remove the GAIA_RA, GAIA_DEC columns used for matching.
+        # ADM remove the GAIA_RA, GAIA_DEC columns used for matching.
         gaiadatamodel = pop_gaia_coords(gaiadatamodel)
-        # ADM prior to DR8, we're also missing some other Gaia columns.
-#        gaiadatamodel = pop_gaia_columns(
-#            gaiadatamodel,
-#            ['REF_CAT', 'GAIA_PHOT_BP_RP_EXCESS_FACTOR',
-#             'GAIA_ASTROMETRIC_SIGMA5D_MAX', 'GAIA_ASTROMETRIC_PARAMS_SOLVED']
-#        )
-        # ADM PHOTSYS gets added on input.
-        tscolumns = list(io.tsdatamodel.dtype.names)     \
-            + ['PHOTSYS']                                \
-            + list(gaiadatamodel.dtype.names)
         tractorfile = io.list_tractorfiles(self.datadir)[0]
         data = io.read_tractor(tractorfile)
+        # ADM form the final data model in a manner that maintains
+        # ADM backwards-compatability with DR8.
+        if "FRACDEV" in data.dtype.names:
+            tsdatamodel = np.array(
+                [], dtype=io.basetsdatamodel.dtype.descr +
+                io.dr8addedcols.dtype.descr)
+        else:
+            tsdatamodel = np.array(
+                [], dtype=io.basetsdatamodel.dtype.descr +
+                io.dr9addedcols.dtype.descr)
+        # ADM PHOTSYS gets added on input.
+        tscolumns = list(tsdatamodel.dtype.names)           \
+            + ['PHOTSYS']                                   \
+            + list(gaiadatamodel.dtype.names)
         self.assertEqual(set(data.dtype.names), set(tscolumns))
 #        columns = ['BX', 'BY']
         columns = ['RA', 'DEC']


### PR DESCRIPTION
Includes:
- Update the data model for DR9c imaging files, while maintaining backwards-compatability with DR8.
- Don't set the `SKY` bit in `DESI_TARGET` when setting the `SUPP_SKY` bit.
- Users can now input a seed (1, 2, 3, etc.) to `bin/select_randoms`:
    - This user-provided seed is also added to the output file name and file header.
    - This facilitates generating a range of numbered random catalogs.
    - For instance, `randoms/randoms-dr8-hp-127,191-4.fits` for a seed of `4`.
- Write out final secondaries using `desitarget.io.find_target_files()`
