### PR TITLE
Fix bugs triggered by empty files or regions of the sky

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.35.1 (unreleased)
 -------------------
 
-* Fix bugs triggered by empty files or regions of the sky [`PR #575`].
+* Fix bugs triggered by empty files or regions of the sky [`PR #575`_].
 
 .. _`PR #575`: https://github.com/desihub/desitarget/pull/575
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.35.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Fix bugs triggered by empty files or regions of the sky [`PR #575`].
+
+.. _`PR #575`: https://github.com/desihub/desitarget/pull/575
 
 0.35.0 (2019-12-15)
 -------------------

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -151,9 +151,10 @@ def gaia_gfas_from_sweep(filename, maglim=18.):
     # ADM remove any sources based on LSLGA (retain Tycho/T2 sources).
     # ADM the try/except/decode catches both bytes and unicode strings.
     try:
-        ii = np.array(rc.decode()[0] == "L" for rc in gfas["REF_CAT"])
+        ii = np.array([rc.decode()[0] == "L" for rc in gfas["REF_CAT"]],
+                      dtype=bool)
     except AttributeError:
-        ii = np.array([i[0] == "L" for rc in gfas["REF_CAT"]])
+        ii = np.array([i[0] == "L" for rc in gfas["REF_CAT"]], dtype=bool)
     gfas = gfas[~ii]
 
     return gfas
@@ -334,7 +335,7 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
         return result
 
     # - Parallel process Gaia files.
-    if numproc > 1:
+    if numproc > 1 and nfiles > 0:
         pool = sharedmem.MapReduce(np=numproc)
         with pool:
             gfas = pool.map(_get_gaia_gfas, infiles, reduce=_update_status)


### PR DESCRIPTION
When running targeting files using `0.35.0`, I found a few instances where errors were triggered in empty HEALPixels, or for missing file information. This tended to scupper all processing in the HEALPixel. This small PR fixes those instances.

I'll probably merge this in a few hours, if tests pass, and tag `0.35.1` to resume making new targeting files.