### PR TITLE
Fix z~5 QSO commissioning (SV0) bug that was already fixed for SV

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.35.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Fix z~5 QSO bug in CMX/SV0 that was already fixed for SV [`PR #576`_].
+
+.. _`PR #576`: https://github.com/desihub/desitarget/pull/576
 
 0.35.1 (2019-12-16)
 -------------------

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1214,7 +1214,7 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
 
     # ADM perform the color cuts to finish the selection.
     qso &= isQSOz5_colors(gflux=gflux, rflux=rflux, zflux=zflux,
-                          gsnr=gsnr, rsnr=gsnr, zsnr=gsnr,
+                          gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
                           w1flux=w1flux, w2flux=w2flux,
                           primary=primary, south=south)
 


### PR DESCRIPTION
In #569, @jinyiY fixed a function I/O bug for SV. This PR fixes the same bug, but for commissioning (where we have SV-like, or "SV0" target classes).

This is a very minor change, so I'll merge it when tests pass.