### PR TITLE
Further preparation for DR9, particularly the DR9d imaging files.

### DIFF
--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -37,7 +37,7 @@ ap.add_argument("--numproc", type=int,
                 help='number of concurrent processes to use [{}]'.format(nproc),
                 default=nproc)
 ap.add_argument('--nside', type=int,
-                help='Process random points in parallel in bricks that have centers within HEALPixels at this resolution (defaults to 4)',
+                help='Process random points in parallel in bricks that have centers within HEALPixels at this resolution (defaults to None)',
                 default=None)
 ap.add_argument('--healpixels',
                 help='HEALPixels (corresponding to nside) to process (e.g. "6,21,57"). If not passed, run all bricks in the Data Release',

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -38,7 +38,7 @@ ap.add_argument("--numproc", type=int,
                 default=nproc)
 ap.add_argument('--nside', type=int,
                 help='Process random points in parallel in bricks that have centers within HEALPixels at this resolution (defaults to 4)',
-                default=4)
+                default=None)
 ap.add_argument('--healpixels',
                 help='HEALPixels (corresponding to nside) to process (e.g. "6,21,57"). If not passed, run all bricks in the Data Release',
                 default=None)

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -99,7 +99,7 @@ if ns.surveydir2 is not None:
 if ns.bundlebricks is not None:
     drdirs = [survey.survey_dir for survey in surveys]
     brickdict = get_brick_info(drdirs, counts=True)
-    bra, bdec, _, _, _, _, cnts = np.vstack(brickdict.values()).T
+    bra, bdec, _, _, _, _, cnts = np.vstack(list(brickdict.values())).T
     theta, phi = np.radians(90-bdec), np.radians(bra)
     pixnum = hp.ang2pix(ns.nside, theta, phi, nest=True)
     # ADM pixnum only contains unique bricks, need to add duplicates.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.35.3 (unreleased)
 -------------------
 
-* Further fixes for DR9 [`PR #578`_]. Includes:
+* Further fixes for DR9 [`PR #579`_]. Includes:
     * Add ``SERSIC`` columns for the DR9 data model.
     * Read the bricks file in lower-case in :func:`get_brick_info()`:
         * As, during DR9 testing, it's been both upper- and lower-case.
@@ -20,7 +20,7 @@ desitarget Change Log
 .. _`PR #565`: https://github.com/desihub/desitarget/pull/565
 .. _`PR #574`: https://github.com/desihub/desitarget/pull/574
 .. _`PR #577`: https://github.com/desihub/desitarget/pull/577
-.. _`PR #578`: https://github.com/desihub/desitarget/pull/578
+.. _`PR #579`: https://github.com/desihub/desitarget/pull/579
 
 0.35.2 (2019-12-20)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,13 @@ desitarget Change Log
 0.35.3 (unreleased)
 -------------------
 
+* Further fixes for DR9 [`PR #578`_]. Includes:
+    * Add ``SERSIC`` columns for the DR9 data model.
+    * Read the bricks file in lower-case in :func:`get_brick_info()`:
+        * As, during DR9 testing, it's been both upper- and lower-case.
+    * Set the default ``nside`` to ``None`` for the randoms:
+        * To force the user to choose an ``nside``, or fail otherwise.
+    * Fix a numpy future/deprecation warning.
 * Add LyA features to ``select_mock_targets`` [`PR #565`_].
 * Load yaml config file safely in ``mpi_select_mock_targets`` [`PR #577`_].
 * Fix bugs in updating primary targets with secondary bits set [`PR #574`_].
@@ -13,6 +20,7 @@ desitarget Change Log
 .. _`PR #565`: https://github.com/desihub/desitarget/pull/565
 .. _`PR #574`: https://github.com/desihub/desitarget/pull/574
 .. _`PR #577`: https://github.com/desihub/desitarget/pull/577
+.. _`PR #578`: https://github.com/desihub/desitarget/pull/578
 
 0.35.2 (2019-12-20)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,12 @@ desitarget Change Log
 0.35.3 (unreleased)
 -------------------
 
-* Load yaml configuration file safely in ``mpi_select_mock_targets`` [`PR
-  #577`_] 
-* Fixes bugs in updating primary targets with secondary bits set [`PR #574`_]
-* Adds more stellar SV targets [`PR #574`_]
+* Add LyA features to ``select_mock_targets`` [`PR #565`_].
+* Load yaml config file safely in ``mpi_select_mock_targets`` [`PR #577`_].
+* Fix bugs in updating primary targets with secondary bits set [`PR #574`_].
+* Adds more stellar SV targets [`PR #574`_].
 
+.. _`PR #565`: https://github.com/desihub/desitarget/pull/565
 .. _`PR #574`: https://github.com/desihub/desitarget/pull/574
 .. _`PR #577`: https://github.com/desihub/desitarget/pull/577
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1759,9 +1759,9 @@ def find_target_files(targdir, dr=None, flavor="targets", survey="main",
 
     # ADM if a HEALPixel number was passed, we want the filename.
     if hp is not None:
-            hpstr = ",".join([str(pix) for pix in np.atleast_1d(hp)])
-            backend = "{}-{}-hp-{}.fits".format(prefix, drstr, hpstr)
-            fn = os.path.join(fn, backend)
+        hpstr = ",".join([str(pix) for pix in np.atleast_1d(hp)])
+        backend = "{}-{}-hp-{}.fits".format(prefix, drstr, hpstr)
+        fn = os.path.join(fn, backend)
     else:
         if nohp:
             backend = "{}-{}.fits".format(prefix, drstr)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -72,8 +72,9 @@ dr9addedcols = np.array([], dtype=[
     ('LC_NOBS_W1', '>i2', (13,)), ('LC_NOBS_W2', '>i2', (13,)),
     ('LC_MJD_W1', '>f8', (13,)), ('LC_MJD_W2', '>f8', (13,)),
     ('SHAPE_R', '>f4'), ('SHAPE_E1', '>f4'), ('SHAPE_E2', '>f4'),
-    ('SHAPE_R_IVAR', '>f4'), ('SHAPE_E1_IVAR', '>f4'), ('SHAPE_E2_IVAR', '>f4')
-    ])
+    ('SHAPE_R_IVAR', '>f4'), ('SHAPE_E1_IVAR', '>f4'), ('SHAPE_E2_IVAR', '>f4'),
+    ('SERSIC', '>f4'), ('SERSIC_IVAR', '>f4')
+])
 
 # ADM columns that were deprecated in the DR8 data model.
 dr8addedcols = np.array([], dtype=[

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1207,7 +1207,7 @@ def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None,
     return qzeros
 
 
-def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
+def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
                    bundlebricks=None, brickspersec=2.5, extra=None,
                    dustdir=None, resolverands=True, aprad=0.75, seed=1):
     """NOBS, DEPTHs (per-band), MASKs for random points in a Legacy Surveys DR.
@@ -1222,7 +1222,7 @@ def select_randoms(drdir, density=100000, numproc=32, nside=4, pixlist=None,
         ~0.25 x 0.25 sq. deg. about (0.0625*density) points will be returned.
     numproc : :class:`int`, optional, defaults to 32
         The number of processes over which to parallelize.
-    nside : :class:`int`, optional, defaults to nside=4 (214.86 sq. deg.)
+    nside : :class:`int`, optional, defaults to `None`
         The (NESTED) HEALPixel nside to be used with the `pixlist` and `bundlebricks` input.
     pixlist : :class:`list` or `int`, optional, defaults to None
         Bricks will only be processed if the CENTER of the brick lies within the bounds of

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -108,11 +108,11 @@ def get_brick_info(drdirs, counts=False, allbricks=False):
         # ADM the bricks of interest for this DR.
         sbfile = glob(dd+'/*bricks-dr*')
         if len(sbfile) > 0:
-            brickinfo = fitsio.read(sbfile[0])
+            brickinfo = fitsio.read(sbfile[0], lower=True)
             # ADM fitsio reads things in as bytes, so convert to unicode.
             bricknames.append(brickinfo['brickname'].astype('U'))
         else:
-            # ADM hack for test bricks where we didn't generate the bricks file.
+            # ADM hack for test bricks where we don't generate the bricks file.
             fns = glob(os.path.join(dd, 'tractor', '*', '*fits'))
             bricknames.append([brickname_from_filename(fn) for fn in fns])
 

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -108,9 +108,9 @@ def get_brick_info(drdirs, counts=False, allbricks=False):
         # ADM the bricks of interest for this DR.
         sbfile = glob(dd+'/*bricks-dr*')
         if len(sbfile) > 0:
-            brickinfo = fitsio.read(sbfile[0], lower=True)
+            brickinfo = fitsio.read(sbfile[0], upper=True)
             # ADM fitsio reads things in as bytes, so convert to unicode.
-            bricknames.append(brickinfo['brickname'].astype('U'))
+            bricknames.append(brickinfo['BRICKNAME'].astype('U'))
         else:
             # ADM hack for test bricks where we don't generate the bricks file.
             fns = glob(os.path.join(dd, 'tractor', '*', '*fits'))


### PR DESCRIPTION
Includes:
- Add the new `SERSIC` columns for the DR9 data model.
- Force columns read from the bricks file to be lower-case in `desitarget.skyfibers.get_brick_info()` because, for the dr9c/dr9d test runs, columns in the bricks file have been both upper- and lower-case.
- Set the default `nside` to `None` when generating randoms, so the code will fail if `nside` is necessary but is not specified.
- Fix a numpy future/deprecation warning.