### PR TITLE
Updates and fixes to QA for DR9

### DIFF
--- a/bin/run_target_qa
+++ b/bin/run_target_qa
@@ -37,6 +37,9 @@ ap.add_argument('--nosystematics', action='store_true',
 ap.add_argument("--numproc", type=int,
                 help='number of concurrent processes to use when generating plots [defaults to {}]'.format(nproc),
                 default=nproc)
+ap.add_argument("--downsample", type=int,
+                help='downsample the targets by (roughly) this value, as a speed-up.',
+                default=None)
 
 ns = ap.parse_args()
 
@@ -73,8 +76,9 @@ else:
 
 log.info("generating plots on {} processors".format(ns.numproc))
 make_qa_page(ns.src, qadir=ns.dest, numproc=ns.numproc,
-             mocks=ns.mocks, makeplots=makeplots, max_bin_area=max_bin_area, 
-             imaging_map_file=ns.weightmapfile, tcnames=tcnames, systematics=systematics)
+             mocks=ns.mocks, makeplots=makeplots, max_bin_area=max_bin_area,
+             imaging_map_file=ns.weightmapfile, tcnames=tcnames,
+             systematics=systematics, downsample=ns.downsample)
 log.info('Targeting QA pages and plots written to {}'.format(ns.dest))
 log.info('Mocks option was set to {}'.format(ns.mocks))
 log.info('No plots option was set to {}'.format(ns.noplots))

--- a/bin/run_target_qa
+++ b/bin/run_target_qa
@@ -5,6 +5,7 @@ from __future__ import print_function, division
 import os, sys
 import numpy as np
 import fitsio
+from time import time
 
 from desitarget.QA import make_qa_page, _parse_tcnames, read_data
 from desitarget.io import read_targets_header
@@ -43,6 +44,7 @@ ap.add_argument("--downsample", type=int,
 ap.add_argument("--prepare", action='store_true',
                 help='write a file to dest that is the equivalent of what is read from src (and just contains the columns needed for QA). This file can then be used in place of src in a subsequent run as a speed-up. Most effective is to run with --prepare set on a login node and then use the written file on compute nodes. Overrides all inputs except src, dest and downsample.')
 
+start = time()
 ns = ap.parse_args()
 
 # ADM fail if systematics were requested but no systematics map was passed.
@@ -88,7 +90,8 @@ else:
                  mocks=ns.mocks, makeplots=makeplots, max_bin_area=max_bin_area,
                  imaging_map_file=ns.weightmapfile, tcnames=tcnames,
                  systematics=systematics, downsample=ns.downsample)
-    log.info('Targeting QA pages and plots written to {}'.format(ns.dest))
+    log.info('Targeting QA pages and plots written to {}...t={:.1f}s'.format(
+        ns.dest, time()-start))
     log.info('Mocks option was set to {}'.format(ns.mocks))
     log.info('No plots option was set to {}'.format(ns.noplots))
     log.info('No systematics option was set to {}'.format(ns.nosystematics))

--- a/bin/run_target_qa
+++ b/bin/run_target_qa
@@ -6,7 +6,7 @@ import os, sys
 import numpy as np
 import fitsio
 
-from desitarget.QA import make_qa_page, _parse_tcnames
+from desitarget.QA import make_qa_page, _parse_tcnames, read_data
 from desitarget.io import read_targets_header
 
 from desiutil.log import get_logger
@@ -40,11 +40,13 @@ ap.add_argument("--numproc", type=int,
 ap.add_argument("--downsample", type=int,
                 help='downsample the targets by (roughly) this value, as a speed-up.',
                 default=None)
+ap.add_argument("--prepare", action='store_true',
+                help='write a file to dest that is the equivalent of what is read from src (and just contains the columns needed for QA). This file can then be used in place of src in a subsequent run as a speed-up. Most effective is to run with --prepare set on a login node and then use the written file on compute nodes. Overrides all inputs except src, dest and downsample.')
 
 ns = ap.parse_args()
 
-# ADM fail if systematics were requested but no systematics map was passed
-if ns.weightmapfile is None and ns.nosystematics is False:
+# ADM fail if systematics were requested but no systematics map was passed.
+if ns.weightmapfile is None and ns.nosystematics is False and not ns.prepare:
     log.error("The weightmap file was not passed so systematics cannot be tracked. Try again sending --nosystematics.")
     raise IOError
 
@@ -74,12 +76,19 @@ if ns.nside:
 else:
     max_bin_area = 1.0
 
-log.info("generating plots on {} processors".format(ns.numproc))
-make_qa_page(ns.src, qadir=ns.dest, numproc=ns.numproc,
-             mocks=ns.mocks, makeplots=makeplots, max_bin_area=max_bin_area,
-             imaging_map_file=ns.weightmapfile, tcnames=tcnames,
-             systematics=systematics, downsample=ns.downsample)
-log.info('Targeting QA pages and plots written to {}'.format(ns.dest))
-log.info('Mocks option was set to {}'.format(ns.mocks))
-log.info('No plots option was set to {}'.format(ns.noplots))
-log.info('No systematics option was set to {}'.format(ns.nosystematics))
+if ns.prepare:
+    fn = os.path.join(os.getenv("CSCRATCH"), ns.dest)
+    objs, _, _, hdr = read_data(ns.src, header=True, downsample=ns.downsample)
+    fitsio.write(fn+'.tmp', objs, extname='TARGETS', header=hdr, clobber=True)
+    os.rename(fn+'.tmp', fn)
+    log.info('{} targets written to {}'.format(len(objs), fn))
+else:
+    log.info("generating plots on {} processors".format(ns.numproc))
+    make_qa_page(ns.src, qadir=ns.dest, numproc=ns.numproc,
+                 mocks=ns.mocks, makeplots=makeplots, max_bin_area=max_bin_area,
+                 imaging_map_file=ns.weightmapfile, tcnames=tcnames,
+                 systematics=systematics, downsample=ns.downsample)
+    log.info('Targeting QA pages and plots written to {}'.format(ns.dest))
+    log.info('Mocks option was set to {}'.format(ns.mocks))
+    log.info('No plots option was set to {}'.format(ns.noplots))
+    log.info('No systematics option was set to {}'.format(ns.nosystematics))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,17 +5,20 @@ desitarget Change Log
 0.35.4 (unreleased)
 -------------------
 
-* No changes yet.
-
-0.35.3 (02-03-2020)
--------------------
-
+* Tune QSO SV selection for both North and South for dr9d [`PR #580`_].
 * Updates and fixes to QA for DR9 [`PR #584`_]. Includes:
     * Options to pre-process and downsample input files to speed testing.
     * Better labeling of QA output, including cleaning up labeling bugs.
     * Make points in scatter plots black to contrast with blue contours.
     * Smarter clipping of dense pixels in histogram plots and sky maps.
     * Print out densest pixels for each target class, with viewer links.
+
+.. _`PR #580`: https://github.com/desihub/desitarget/pull/580
+.. _`PR #584`: https://github.com/desihub/desitarget/pull/584
+
+0.35.3 (02-03-2020)
+-------------------
+
 * Further fixes for DR9 [`PR #579`_]. Includes:
     * Add ``SERSIC`` columns for the DR9 data model.
     * Read the bricks file in lower-case in :func:`get_brick_info()`:
@@ -32,7 +35,6 @@ desitarget Change Log
 .. _`PR #574`: https://github.com/desihub/desitarget/pull/574
 .. _`PR #577`: https://github.com/desihub/desitarget/pull/577
 .. _`PR #579`: https://github.com/desihub/desitarget/pull/579
-.. _`PR #584`: https://github.com/desihub/desitarget/pull/584
 
 0.35.2 (2019-12-20)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,12 @@ desitarget Change Log
 0.35.3 (02-03-2020)
 -------------------
 
+* Updates and fixes to QA for DR9 [`PR #584`_]. Includes:
+    * Options to pre-process and downsample input files to speed testing.
+    * Better labeling of QA output, including cleaning up labeling bugs.
+    * Make points in scatter plots black to contrast with blue contours.
+    * Smarter clipping of dense pixels in histogram plots and sky maps.
+    * Print out densest pixels for each target class, with viewer links.
 * Further fixes for DR9 [`PR #579`_]. Includes:
     * Add ``SERSIC`` columns for the DR9 data model.
     * Read the bricks file in lower-case in :func:`get_brick_info()`:
@@ -17,15 +23,16 @@ desitarget Change Log
     * Set the default ``nside`` to ``None`` for the randoms:
         * To force the user to choose an ``nside``, or fail otherwise.
     * Fix a numpy future/deprecation warning.
-* Add LyA features to ``select_mock_targets`` [`PR #565`_].
 * Load yaml config file safely in ``mpi_select_mock_targets`` [`PR #577`_].
 * Fix bugs in updating primary targets with secondary bits set [`PR #574`_].
 * Adds more stellar SV targets [`PR #574`_].
+* Add LyA features to ``select_mock_targets`` [`PR #565`_].
 
 .. _`PR #565`: https://github.com/desihub/desitarget/pull/565
 .. _`PR #574`: https://github.com/desihub/desitarget/pull/574
 .. _`PR #577`: https://github.com/desihub/desitarget/pull/577
 .. _`PR #579`: https://github.com/desihub/desitarget/pull/579
+.. _`PR #584`: https://github.com/desihub/desitarget/pull/584
 
 0.35.2 (2019-12-20)
 -------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -1866,7 +1866,8 @@ def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.'
         DRs = 'Mock Targets'
     else:
         if 'RELEASE' in targs.dtype.names:
-            DRs = ", ".join(["DR{}".format(release) for release in np.unique(targs["RELEASE"])//1000])
+            DRs = ", ".join(["DR{}".format(release)
+                             for release in np.unique(targs["RELEASE"]//1000)])
         else:
             DRs = "DR Unknown"
 
@@ -2059,6 +2060,8 @@ def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.'
         if svs[0:2] == 'SV':
             for tc in 'QSO', 'ELG', 'LRG', 'BGS', 'MWS':
                 hl = [h.replace(tc, tc[0]) for h in hl]
+                # ADM also change SUPER->SUP to squeeze space
+                hl = [h.replace('SUPER', 'SUP') for h in hl]
         # ADM truncate the bit names at "trunc" characters to pack them more easily.
         trunc = 8
         truncform = '{:>'+str(trunc)+'s}'

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -334,7 +334,7 @@ def _javastring():
     return js
 
 
-def read_data(targfile, mocks=False, downsample=None):
+def read_data(targfile, mocks=False, downsample=None, header=False):
     """Read in the data, including any mock data (if present).
 
     Parameters
@@ -346,12 +346,16 @@ def read_data(targfile, mocks=False, downsample=None):
         or to a data file, or to a directory of HEALPixel-split target
         files which will be read in with
         :func:`desitarget.io.read_targets_in_box`.
-    mocks : :class:`boolean`, optional, default=False
+    mocks : :class:`boolean`, optional, defaults to ``False``
         If ``True``, read in mock data.
     downsample : :class:`int`, optional, defaults to `None`
         If not `None`, downsample targets by (roughly) this value, e.g.
         for `downsample=10` a set of 900 targets would have ~90 random
         targets returned. A speed-up for experimenting with large files.
+    header : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then return the header of the file as an additional
+        output (targs, truths, objtruths, header) instead of (targs,
+        truths, objtruths).
 
     Returns
     -------
@@ -361,7 +365,6 @@ def read_data(targfile, mocks=False, downsample=None):
         A rec array containing the truths catalog (if present and `mocks=True`).
     objtruths : :class:`dict`
         Object type-specific truth metadata (if present and `mocks=True`).
-
     """
     start = time()
 
@@ -385,7 +388,11 @@ def read_data(targfile, mocks=False, downsample=None):
     cols = np.concatenate([colnames, targcols])
 
     # ADM read in the targets catalog and return it.
-    targs = read_targets_in_box(targfile, columns=cols, downsample=downsample)
+    if header:
+        targs, hdr = read_targets_in_box(targfile, columns=cols,
+                                         downsample=downsample, header=True)
+    else:
+        targs =  read_targets_in_box(targfile, columns=cols, header=False)
     log.info('Read in targets...t = {:.1f}s'.format(time()-start))
     truths, objtruths = None, None
 
@@ -410,7 +417,10 @@ def read_data(targfile, mocks=False, downsample=None):
 
         return targs, truths, objtruths
     else:
-        return targs, None, None
+        if header:
+            return targs, None, None, hdr
+        else:
+            return targs, None, None
 
 
 def qaskymap(cat, objtype, qadir='.', upclip=None, weights=None, max_bin_area=1.0, fileprefix="skymap"):

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -216,7 +216,8 @@ def _load_targdens(tcnames=None, bit_mask=None):
         names = []
         for bit_mask in bit_masks:
             # ADM this is the list of words contained in bits that we don't want to consider for QA.
-            badnames = ["NORTH", "SOUTH", "NO_TARGET", "SECONDARY", "BRIGHT_OBJECT", "SKY", "KNOWN"]
+            badnames = ["NORTH", "SOUTH", "NO_TARGET", "SECONDARY",
+                        "BRIGHT_OBJECT", "SKY", "KNOWN", "BACKUP", "SCND"]
             names.append([name for name in bit_mask.names()
                           if not any(badname in name for badname in badnames)])
         targdens = {k: 0. for k in np.concatenate(names)}
@@ -1995,21 +1996,22 @@ def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.'
         # ADM Target Densities.
         html.write('<h2>Target density</h2>\n')
         # ADM Write out the densest pixels.
-        html.write('<pre>')
-        html.write('Densest HEALPixels (NSIDE={}; links are to LS viewer):\n'.format(
-            densdict[objtype]["NSIDE"]))
-        ras, decs, dens = densdict[objtype]["RA"], densdict[objtype]["DEC"], densdict[objtype]["DENSITY"]
-        for i in range(len(ras)):
-            ender = "   "
-            if i % 2 == 1:
-                ender = "\n"
-            link = '<A HREF="http://legacysurvey.org/viewer?'
-            link += 'ra={}&dec={}&layer={}&zoom=10" target="external">'.format(
-                ras[i], decs[i], DRs.split(",")[0].lower())
-            label = "RA: {:.3f}&deg; DEC: {:.3f}&deg;</A> DENSITY: {:.0f} deg<sup>-2</sup>".format(
-                ras[i], decs[i], dens[i])
-            html.write(link+label+ender)
-        html.write('</pre>')
+        if makeplots:
+            html.write('<pre>')
+            html.write('Densest HEALPixels (NSIDE={}; links are to LS viewer):\n'.format(
+                densdict[objtype]["NSIDE"]))
+            ras, decs, dens = densdict[objtype]["RA"], densdict[objtype]["DEC"], densdict[objtype]["DENSITY"]
+            for i in range(len(ras)):
+                ender = "   "
+                if i % 2 == 1:
+                    ender = "\n"
+                link = '<A HREF="http://legacysurvey.org/viewer?'
+                link += 'ra={}&dec={}&layer={}&zoom=10" target="external">'.format(
+                    ras[i], decs[i], DRs.split(",")[0].lower())
+                label = "RA: {:.3f}&deg; DEC: {:.3f}&deg;</A> DENSITY: {:.0f} deg<sup>-2</sup>".format(
+                    ras[i], decs[i], dens[i])
+                html.write(link+label+ender)
+            html.write('</pre>')
         html.write('<table COLS=2 WIDTH="100%">\n')
         html.write('<tr>\n')
         # ADM add the plots...

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -735,7 +735,8 @@ def qahisto(cat, objtype, qadir='.', targdens=None, upclip=None, weights=None, m
 
     if objtype in targdens.keys():
         plt.axvline(targdens[objtype], ymax=0.8, ls='--', color='k',
-                    label=r'Goal {} Density (Goal={:.0f} deg$^{{-2}}$)'.format(objtype, targdens[objtype]))
+                    label=r'Goal {} Density (Goal={:.0f} deg$^{{-2}}$)'.format(
+                        objtype, targdens[objtype]))
     plt.legend(loc='upper left', frameon=False, fontsize=11)
 
     # ADM add some metric conditions which are considered a failure for this
@@ -1349,7 +1350,8 @@ def qacolor(cat, objtype, extinction, qadir='.', fileprefix="color",
     r = 22.5-2.5*np.log10(rflux.clip(loclip))
     z = 22.5-2.5*np.log10(zflux.clip(loclip))
     W1 = 22.5-2.5*np.log10(w1flux.clip(loclip))
-    W2 = 22.5-2.5*np.log10(w2flux.clip(loclip))
+    # ADM Modify W2 slightly so the W1-W2 color doesn't pile up at 0.
+    W2 = 22.5-2.5*np.log10(w2flux.clip(loclip*100))
 
     # For QSOs only--
     W = 0.75 * W1 + 0.25 * W2
@@ -1377,12 +1379,12 @@ def qacolor(cat, objtype, extinction, qadir='.', fileprefix="color",
     #     zW1lim = (-3, 2.5)
     #     W1W2lim = (-3, 2.5)
     # else:
-    zW1lim = (-1.0, 3.5)
-    W1W2lim = (-1.0, 1.2)
+    zW1lim = (-1.5, 3.5)
+    W1W2lim = (-1.5, 1.5)
 
     cmap = plt.cm.get_cmap('RdYlBu')
 
-    objcolor = {'ALL': 'black', objtype: 'blue'}
+    objcolor = {'ALL': 'black', objtype: 'black'}
     type2color = {**_type2color, **objcolor}
 
     #  Make the plots!

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -996,10 +996,10 @@ def isBGS(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=None, w2fl
                          gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar, Grr=Grr,
                          gaiagmag=gaiagmag, maskbits=maskbits, targtype=targtype)
 
-    bgs &= isBGS_colors(rfiberflux=rfiberflux, gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, 
+    bgs &= isBGS_colors(rfiberflux=rfiberflux, gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
                         w2flux=w2flux, south=south, targtype=targtype, primary=primary)
-    
-    bgs |= isBGS_lslga(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, refcat=refcat, 
+
+    bgs |= isBGS_lslga(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, refcat=refcat,
                        south=south, targtype=targtype)
 
     return bgs
@@ -1046,7 +1046,7 @@ def notinBGS_mask(gnobs=None, rnobs=None, znobs=None, primary=None,
     return bgs
 
 
-def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=None, 
+def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=None,
                  w2flux=None, south=True, targtype=None, primary=None):
     """Standard set of color-based cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
@@ -1086,7 +1086,7 @@ def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=Non
     fmc |= ((rfib < 2.9 + r) & (r > 20))
 
     bgs &= fmc
-    
+
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)
     elif targtype == 'faint':
@@ -1098,20 +1098,22 @@ def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=Non
 
     return bgs
 
-def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None, 
+
+def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
                 south=True, targtype=None):
     """Module to recover the LSLGA objects in all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
     _check_BGS_targtype(targtype)
-    
+
     bgs = np.zeros_like(rflux, dtype='?')
-    
-    #the LSLGA galaxies
+
+    # the LSLGA galaxies.
     if refcat is None:
         LX = bgs.copy()
     else:
-        #LX |= ((refcat == 'L2') | (refcat == b'L2') | (refcat == 'L2 ') | (refcat == b'L2 ')) #for DR8
+        # LX |= ((refcat == 'L2') | (refcat == b'L2') |
+        # (refcat == 'L2 ') | (refcat == b'L2 ')) #for DR8.
         LX = bgs.copy()
         try:
             LX = np.array([rc.decode()[0] == "L" for rc in refcat], dtype=bool)
@@ -1122,11 +1124,11 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
             for i, rc in enumerate(refcat):
                 if len(rc) > 0:
                     LX[i] = ((rc.decode()[0] == "L") | (rc[0] == ord("L")))
-                else: 
+                else:
                     LX[i] = False
-        
+
     bgs |= LX
-    
+
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)
     elif targtype == 'faint':
@@ -1535,7 +1537,7 @@ def _prepare_optical_wise(objects, mask=True):
     zsnr = objects['FLUX_Z'] * np.sqrt(objects['FLUX_IVAR_Z'])
     w1snr = objects['FLUX_W1'] * np.sqrt(objects['FLUX_IVAR_W1'])
     w2snr = objects['FLUX_W2'] * np.sqrt(objects['FLUX_IVAR_W2'])
-    
+
     refcat = objects['REF_CAT']
 
     maskbits = objects['MASKBITS']

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2033,7 +2033,7 @@ def read_targets_in_box(hpdirname, radecbox=[0., 360., -90., 90.],
     header : :class:`bool`, optional, defaults to ``False``
         If ``True`` then return the header of either the `hpdirname`
         file, or the last file read from the `hpdirname` directory.
-   downsample : :class:`int`, optional, defaults to `None`
+    downsample : :class:`int`, optional, defaults to `None`
         If not `None`, downsample targets by (roughly) this value, e.g.
         for `downsample=10` a set of 900 targets would have ~90 random
         targets returned.

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1776,7 +1776,7 @@ def find_target_files(targdir, dr=None, flavor="targets", survey="main",
 
 
 def read_target_files(filename, columns=None, rows=None, header=False,
-                      verbose=False):
+                      verbose=True):
     """Wrapper to cycle through allowed extensions to read target files.
 
     Parameters
@@ -1791,8 +1791,9 @@ def read_target_files(filename, columns=None, rows=None, header=False,
     header : :class:`bool`, optional, defaults to ``False``
         If ``True`` then return the header of the file.
     verbose : :class:`bool`, optional, defaults to ``False``
-        If ``True`` then log the file extension that was read.
+        If ``True`` then log the file and extension that was read.
     """
+    start = time()
     # ADM start with some checking that this is a target file.
     targtypes = "TARGETS", "GFA_TARGETS", "SKY_TARGETS"
     # ADM read in the FITS extention info.
@@ -1812,6 +1813,10 @@ def read_target_files(filename, columns=None, rows=None, header=False,
 
     targs, hdr = fitsio.read(filename, extname,
                              columns=columns, rows=rows, header=True)
+
+    if verbose:
+        log.info("Read {} targets from {}, extension {}...Took {:.1f}s".format(
+            len(targs), os.path.basename(filename), extname, time()-start))
 
     if header:
         return targs, hdr
@@ -2140,7 +2145,7 @@ def read_targets_header(hpdirname):
 
     # ADM rows=[0] here, speeds up read_target_files retrieval
     # ADM of the header.
-    _, hdr = read_target_files(hpdirname, rows=[0], header=True)
+    _, hdr = read_target_files(hpdirname, rows=[0], header=True, verbose=False)
 
     return hdr
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1776,7 +1776,7 @@ def find_target_files(targdir, dr=None, flavor="targets", survey="main",
 
 
 def read_target_files(filename, columns=None, rows=None, header=False,
-                      verbose=True):
+                      downsample=None, verbose=True):
     """Wrapper to cycle through allowed extensions to read target files.
 
     Parameters
@@ -1790,6 +1790,10 @@ def read_target_files(filename, columns=None, rows=None, header=False,
         Only read in these rows from the target file.
     header : :class:`bool`, optional, defaults to ``False``
         If ``True`` then return the header of the file.
+    downsample : :class:`int`, optional, defaults to `None`
+        If not `None`, downsample the file by this integer value, e.g.
+        for `downsample=10` a file with 900 rows would have 90 random
+        rows read in. Overrode by the `rows` kwarg if it is not `None`.
     verbose : :class:`bool`, optional, defaults to ``False``
         If ``True`` then log the file and extension that was read.
     """
@@ -1811,6 +1815,11 @@ def read_target_files(filename, columns=None, rows=None, header=False,
         log.error(msg)
         raise IOError(msg)
 
+    if downsample is not None and rows is None:
+        np.random.seed(616)
+        ntargs = fitsio.read_header(filename, extname)["NAXIS2"]
+        rows = np.random.choice(ntargs, ntargs//downsample, replace=False)
+
     targs, hdr = fitsio.read(filename, extname,
                              columns=columns, rows=rows, header=True)
 
@@ -1825,7 +1834,7 @@ def read_target_files(filename, columns=None, rows=None, header=False,
 
 
 def read_targets_in_hp(hpdirname, nside, pixlist, columns=None,
-                       header=False):
+                       header=False, downsample=None):
     """Read in targets in a set of HEALPixels.
 
     Parameters
@@ -1844,6 +1853,10 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None,
     header : :class:`bool`, optional, defaults to ``False``
         If ``True`` then return the header of either the `hpdirname`
         file, or the last file read from the `hpdirname` directory.
+    downsample : :class:`int`, optional, defaults to `None`
+        If not `None`, downsample targets by (roughly) this value, e.g.
+        for `downsample=10` a set of 900 targets would have ~90 random
+        targets returned.
 
     Returns
     -------
@@ -1877,7 +1890,8 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None,
         # ADM read in the first file to grab the data model for
         # ADM cases where we find no targets in the box.
         fn0 = list(filedict.values())[0]
-        notargs, nohdr = read_target_files(fn0, columns=columnscopy, header=True)
+        notargs, nohdr = read_target_files(fn0, columns=columnscopy,
+                                           header=True, downsample=downsample)
         notargs = np.zeros(0, dtype=notargs.dtype)
 
         # ADM change the passed pixels to the nside of the file schema.
@@ -1895,7 +1909,7 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None,
         start = time()
         for infile in infiles:
             targs, hdr = read_target_files(infile, columns=columnscopy,
-                                           header=True)
+                                           header=True, downsample=downsample)
             targets.append(targs)
         # ADM if targets is empty, return no targets.
         if len(targets) == 0:
@@ -1907,7 +1921,7 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None,
     # ADM ...otherwise just read in the targets.
     else:
         targets, hdr = read_target_files(hpdirname, columns=columnscopy,
-                                         header=True)
+                                         header=True, downsample=downsample)
 
     # ADM restrict the targets to the actual requested HEALPixels...
     ii = is_in_hp(targets, nside, pixlist)
@@ -2001,7 +2015,7 @@ def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False):
 
 
 def read_targets_in_box(hpdirname, radecbox=[0., 360., -90., 90.],
-                        columns=None, header=False):
+                        columns=None, header=False, downsample=None):
     """Read in targets in an RA/Dec box.
 
     Parameters
@@ -2019,6 +2033,10 @@ def read_targets_in_box(hpdirname, radecbox=[0., 360., -90., 90.],
     header : :class:`bool`, optional, defaults to ``False``
         If ``True`` then return the header of either the `hpdirname`
         file, or the last file read from the `hpdirname` directory.
+   downsample : :class:`int`, optional, defaults to `None`
+        If not `None`, downsample targets by (roughly) this value, e.g.
+        for `downsample=10` a set of 900 targets would have ~90 random
+        targets returned.
 
     Returns
     -------
@@ -2045,17 +2063,16 @@ def read_targets_in_box(hpdirname, radecbox=[0., 360., -90., 90.],
     if os.path.isdir(hpdirname):
         # ADM approximate nside for area of passed box.
         nside = pixarea2nside(box_area(radecbox))
-
         # ADM HEALPixels that touch the box for that nside.
         pixlist = hp_in_box(nside, radecbox)
         # ADM read in targets in these HEALPixels.
         targets, hdr = read_targets_in_hp(hpdirname, nside, pixlist,
-                                          columns=columnscopy,
-                                          header=True)
+                                          columns=columnscopy, header=True,
+                                          downsample=downsample)
     # ADM ...otherwise just read in the targets.
     else:
         targets, hdr = read_target_files(hpdirname, columns=columnscopy,
-                                         header=True)
+                                         header=True, downsample=downsample)
 
     # ADM restrict only to targets in the requested RA/Dec box...
     ii = is_in_box(targets, radecbox)

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -584,8 +584,8 @@ def isQSO_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         mainseq &= rflux**(1+1.53) > gflux * zflux**1.53 * 10**((-0.090+0.20)/2.5)
         mainseq &= rflux**(1+1.53) < gflux * zflux**1.53 * 10**((+0.090+0.20)/2.5)
     else:
-        mainseq &= rflux**(1+1.53) > gflux * zflux**1.53 * 10**((-0.100+0.20)/2.5) 
-        mainseq &= rflux**(1+1.53) < gflux * zflux**1.53 * 10**((+0.100+0.20)/2.5) 
+        mainseq &= rflux**(1+1.53) > gflux * zflux**1.53 * 10**((-0.100+0.20)/2.5)
+        mainseq &= rflux**(1+1.53) < gflux * zflux**1.53 * 10**((+0.100+0.20)/2.5)
 
     mainseq &= w2flux < w1flux * 10**(0.3/2.5)  # ADM W1 - W2 !(NOT) > 0.3
     qso &= ~mainseq
@@ -830,7 +830,7 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
         if south:
             pcut = np.where(r_Reduced < 23.2,  0.40 + (r_Reduced-22.8)*.9, .76 + (r_Reduced-23.2)*.4)
         else:
-            pcut = np.where(r_Reduced < 23.2,  0.50 + (r_Reduced-22.8)*.75, .80 + (r_Reduced-23.2)*.5) 
+            pcut = np.where(r_Reduced < 23.2,  0.50 + (r_Reduced-22.8)*.75, .80 + (r_Reduced-23.2)*.5)
 
         # Add rf proba test result to "qso" mask
         qso[colorsReducedIndex] = (tmp_rf_proba >= pcut)


### PR DESCRIPTION
Includes:

- Command-line options to pre-process and downsample input files. This facilitates making smaller input files for speedier testing.
- Better labeling of QA output, including cleaning up some long-standing labeling bugs.
- Change the color of the points in scatter plots to black so they contrast with the blue hex-contours.
- Smarter clipping of over-dense (and under-dense) pixels in the 1-D histogram plots and sky maps (addresses #445).
- Print out the densest pixels for each target class. The RA/Dec of these pixels includes links to the Legacy Surveys viewer.