### PR TITLE
Minimal hack to get desitarget running from refcat workaround.

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1106,6 +1106,8 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
     _check_BGS_targtype(targtype)
     
     bgs = np.zeros_like(rflux, dtype='?')
+
+    refcat = [x.replace('', '  ') for x in refcat]
     
     #the LSLGA galaxies
     if refcat is None:


### PR DESCRIPTION
Minimal hack to get desitarget running from refcat workaround.  Likely not an acceptable approach, but illustrates what needs fixed.  Maybe useful in the meantime.  Runs to completion.