### PR TITLE
Fix bug when adding LSLGA galaxies into Main Survey BGS

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 0.35.4 (unreleased)
 -------------------
 
+* Fix bug when adding LSLGA galaxies into Main Survey BGS [`PR #588`_]:
+    * Catch cases of bytes/str types as well as zero-length strings.
 * Updates and fixes to QA for DR9 [`PR #584`_]. Includes:
     * Options to pre-process and downsample input files to speed testing.
     * Better labeling of QA output, including cleaning up labeling bugs.
@@ -21,6 +23,7 @@ desitarget Change Log
 .. _`PR #580`: https://github.com/desihub/desitarget/pull/580
 .. _`PR #581`: https://github.com/desihub/desitarget/pull/581
 .. _`PR #584`: https://github.com/desihub/desitarget/pull/584
+.. _`PR #588`: https://github.com/desihub/desitarget/pull/588
 
 0.35.3 (02-03-2020)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1109,23 +1109,14 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
     bgs = np.zeros_like(rflux, dtype='?')
 
     # the LSLGA galaxies.
-    if refcat is None:
-        LX = bgs.copy()
-    else:
-        # LX |= ((refcat == 'L2') | (refcat == b'L2') |
-        # (refcat == 'L2 ') | (refcat == b'L2 ')) #for DR8.
-        LX = bgs.copy()
-        try:
-            LX = np.array([rc.decode()[0] == "L" for rc in refcat], dtype=bool)
-        except AttributeError:
-            LX = np.array([rc[0] == "L" for rc in refcat], dtype=bool)
-        except IndexError:
-            LX = np.empty(len(refcat), dtype=bool)
-            for i, rc in enumerate(refcat):
-                if len(rc) > 0:
-                    LX[i] = ((rc.decode()[0] == "L") | (rc[0] == ord("L")))
-                else:
-                    LX[i] = False
+    LX = bgs.copy()
+    # ADM Could check on "L2" for DR8, need to check on "LX" post-DR8.
+    if refcat is not None:
+        if isinstance(np.atleast_1d(refcat)[0], str):
+            LX = [(rc[0] == "L") if len(rc) > 0 else False for rc in refcat]
+        else:
+            LX = [(rc.decode()[0] == "L") if len(rc) > 0 else False for rc in refcat]
+        LX = np.array(LX, dtype=bool)
 
     bgs |= LX
 


### PR DESCRIPTION
The new process to add LSLGA galaxies as BGS targets in the Main Survey was failing for mocks because `REF_CAT` was a zero-length string. This PR updates the code to catch the 3 possible flavors of `REF_CAT` string:

- zero-length.
- has length and is of type `str`.
- has length and is of type `bytes`.

This supplants PR #586 and should fix issues with unit tests. Once everyone agrees that this works, I'll merge this and close PR #586.