### PR TITLE
Cut on NOBS > 0 for QSOs and LRGs for both the Main Survey and SV

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.35.4 (unreleased)
 -------------------
 
+* Cut on NOBS > 0 for QSOs and LRGs for Main Survey and SV [`PR #589`_]
 * Fix bug when adding LSLGA galaxies into Main Survey BGS [`PR #588`_]:
     * Catch cases of bytes/str types as well as zero-length strings.
 * Noting (here) that we used the BFG to excise lots of junk [`PR #587`_].
@@ -26,6 +27,7 @@ desitarget Change Log
 .. _`PR #584`: https://github.com/desihub/desitarget/pull/584
 .. _`PR #587`: https://github.com/desihub/desitarget/pull/587
 .. _`PR #588`: https://github.com/desihub/desitarget/pull/588
+.. _`PR #589`: https://github.com/desihub/desitarget/pull/589
 
 0.35.3 (02-03-2020)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1137,6 +1137,7 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
 
 def isQSO_cuts(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
                w1snr=None, w2snr=None, deltaChi2=None, maskbits=None,
+               gnobs=None, rnobs=None, znobs=None,
                release=None, objtype=None, primary=None, optical=False, south=True):
     """Definition of QSO target classes from color cuts. Returns a boolean array.
 
@@ -1172,6 +1173,9 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     else:
         qso &= w1snr > 4
         qso &= w2snr > 3
+
+    # ADM observed in every band.
+    qso &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM default to RELEASE of 6000 if nothing is passed.
     if release is None:
@@ -1234,9 +1238,10 @@ def isQSO_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     return qso
 
 
-def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-                       objtype=None, release=None, deltaChi2=None, maskbits=None,
-                       primary=None, south=True):
+def isQSO_randomforest(gflux=None, rflux=None, zflux=None,
+                       w1flux=None, w2flux=None, objtype=None, release=None,
+                       gnobs=None, rnobs=None, znobs=None,
+                       deltaChi2=None, maskbits=None, primary=None, south=True):
     """Definition of QSO target classes from a Random Forest. Returns a boolean array.
 
     Parameters
@@ -1277,6 +1282,9 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
     rMax = 22.7   # r < 22.7
     rMin = 17.5   # r > 17.5
     preSelection = (r < rMax) & (r > rMin) & photOK & primary
+
+    # ADM targets have to be observed in every band.
+    preSelection &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     if objtype is not None:
         preSelection &= _psflike(objtype)
@@ -1830,6 +1838,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                     w1flux=w1flux, w2flux=w2flux,
                     deltaChi2=deltaChi2, maskbits=maskbits,
+                    gnobs=None, rnobs=None, znobs=None,
                     objtype=objtype, w1snr=w1snr, w2snr=w2snr, release=release,
                     optical=qso_optical_cuts, south=south
                 )
@@ -1837,8 +1846,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 # ADM determine quasar targets in the north and the south separately
                 qso_classes[int(south)] = isQSO_randomforest(
                     primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
-                    w1flux=w1flux, w2flux=w2flux,
-                    deltaChi2=deltaChi2, maskbits=maskbits,
+                    w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2,
+                    maskbits=maskbits, gnobs=None, rnobs=None, znobs=None,
                     objtype=objtype, release=release, south=south
                 )
             else:

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -225,7 +225,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     # ADM basic quality cuts.
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
-        zfiberflux=zfiberflux, gnobs=None, rnobs=None, znobs=None,
+        zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
         rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
     )
 
@@ -1803,7 +1803,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
             lrg_classes[int(south)] = isLRG(
                 primary=primary,
                 gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
-                zfiberflux=zfiberflux,
+                zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                 rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr, south=south
             )
     lrg_north, lrg_south = lrg_classes
@@ -1838,7 +1838,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                     w1flux=w1flux, w2flux=w2flux,
                     deltaChi2=deltaChi2, maskbits=maskbits,
-                    gnobs=None, rnobs=None, znobs=None,
+                    gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                     objtype=objtype, w1snr=w1snr, w2snr=w2snr, release=release,
                     optical=qso_optical_cuts, south=south
                 )
@@ -1847,7 +1847,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 qso_classes[int(south)] = isQSO_randomforest(
                     primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                     w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2,
-                    maskbits=maskbits, gnobs=None, rnobs=None, znobs=None,
+                    maskbits=maskbits, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                     objtype=objtype, release=release, south=south
                 )
             else:

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -198,7 +198,7 @@ def isBACKUP(ra=None, dec=None, gaiagmag=None, primary=None):
 
 def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
           zfiberflux=None, rflux_snr=None, zflux_snr=None, w1flux_snr=None,
-          primary=None, south=True):
+          gnobs=None, rnobs=None, znobs=None, primary=None, south=True):
     """
     Parameters
     ----------
@@ -225,7 +225,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     # ADM basic quality cuts.
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
-        zfiberflux=zfiberflux,
+        zfiberflux=zfiberflux, gnobs=None, rnobs=None, znobs=None,
         rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
     )
 
@@ -239,7 +239,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
 
 def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
-                  zfiberflux=None,
+                  zfiberflux=None, gnobs=None, rnobs=None, znobs=None,
                   rflux_snr=None, zflux_snr=None, w1flux_snr=None):
     """See :func:`~desitarget.cuts.isLRG` for details.
 
@@ -260,6 +260,9 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     lrg &= (rflux_snr > 0) & (rflux > 0)   # ADM quality in r.
     lrg &= (zflux_snr > 0) & (zflux > 0) & (zfiberflux > 0)   # ADM quality in z.
     lrg &= (w1flux_snr > 4) & (w1flux > 0)  # ADM quality in W1.
+
+    # ADM observed in every band.
+    lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     return lrg
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -91,7 +91,7 @@ def isBACKUP(ra=None, dec=None, gaiagmag=None, primary=None):
 
 def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
           zfiberflux=None, rflux_snr=None, zflux_snr=None, w1flux_snr=None,
-          primary=None, south=True):
+          gnobs=None, rnobs=None, znobs=None, primary=None, south=True):
     """Target Definition of LRG. Returns a boolean array.
 
     Parameters
@@ -126,7 +126,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
-        zfiberflux=zfiberflux,
+        zfiberflux=zfiberflux, gnobs=None, rnobs=None, znobs=None,
         rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
     )
 
@@ -141,7 +141,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
 
 def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
-                  zfiberflux=None,
+                  zfiberflux=None, gnobs=None, rnobs=None, znobs=None,
                   rflux_snr=None, zflux_snr=None, w1flux_snr=None):
     """See :func:`~desitarget.sv1.sv1_cuts.isLRG` for details.
 
@@ -162,6 +162,9 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     lrg &= (rflux_snr > 0) & (rflux > 0)   # ADM quality in r.
     lrg &= (zflux_snr > 0) & (zflux > 0) & (zfiberflux > 0)   # ADM quality in z.
     lrg &= (w1flux_snr > 4) & (w1flux > 0)  # ADM quality in W1.
+
+    # ADM observed in every band.
+    lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     return lrg
 
@@ -1512,7 +1515,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 primary=primary, south=south,
                 gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
                 zfiberflux=zfiberflux, rflux_snr=rsnr, zflux_snr=zsnr,
-                w1flux_snr=w1snr
+                w1flux_snr=w1snr, gnobs=gnobs, rnobs=rnobs, znobs=znobs
             )
     lrg_north, lrginit_n_4, lrgsup_n_4, lrginit_n_8, lrgsup_n_8 = lrg_classes[0]
     lrg_south, lrginit_s_4, lrgsup_s_4, lrginit_s_8, lrgsup_s_8 = lrg_classes[1]

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -481,7 +481,7 @@ def isSTD_gaia(primary=None, gaia=None, astrometricexcessnoise=None,
 def isQSO_cuts(gflux=None, rflux=None, zflux=None,
                w1flux=None, w2flux=None, w1snr=None, w2snr=None,
                dchisq=None, maskbits=None, objtype=None,
-               primary=None, south=True):
+               gnobs=None, rnobs=None, znobs=None, primary=None, south=True):
     """Definition of QSO target classes from color cuts. Returns a boolean array.
 
     Parameters
@@ -512,6 +512,9 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None,
     if maskbits is not None:
         for bit in [1, 10, 12, 13]:
             qso &= ((maskbits & 2**bit) == 0)
+
+    # ADM observed in every band.
+    qso &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM relaxed morphology cut for SV.
     # ADM we never target sources with dchisq[..., 0] = 0, so force
@@ -596,7 +599,8 @@ def isQSO_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     return qso
 
 
-def isQSO_color_high_z(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None, south=True):
+def isQSO_color_high_z(gflux=None, rflux=None, zflux=None,
+                       w1flux=None, w2flux=None, south=True):
     """
     Color cut to select Highz QSO (z>~2.)
     """
@@ -626,8 +630,9 @@ def isQSO_color_high_z(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
     return qso_hz
 
 
-def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-                       objtype=None, release=None, dchisq=None, maskbits=None,
+def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None,
+                       w2flux=None, objtype=None, release=None, dchisq=None,
+                       maskbits=None, gnobs=None, rnobs=None, znobs=None,
                        primary=None, south=True):
     """Definition of QSO target class using random forest. Returns a boolean array.
 
@@ -666,6 +671,9 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
     rMax = 23.0  # r < 23.0 (different for SV)
     rMin = 17.5  # r > 17.5
     preSelection = (r < rMax) & (r > rMin) & photOK & primary
+
+    # ADM observed in every band.
+    preSelection &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM relaxed morphology cut for SV.
     # ADM we never target sources with dchisq[..., 0] = 0, so force
@@ -739,9 +747,10 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
     return qso
 
 
-def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-                      objtype=None, release=None, dchisq=None, maskbits=None,
-                      primary=None, south=True):
+def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None,
+                      w2flux=None, objtype=None, release=None, dchisq=None,
+                      gnobs=None, rnobs=None, znobs=None,
+                      maskbits=None, primary=None, south=True):
     """Definition of QSO target for highz (z>2.0) faint QSOs. Returns a boolean array.
 
     Parameters
@@ -780,6 +789,9 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
     rMax = 23.5  # r < 23.5
     rMin = 22.7  # r > 22.7
     preSelection = (r < rMax) & (r > rMin) & photOK & primary
+
+    # ADM observed in every band.
+    preSelection &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # Color Selection of QSO with z>2.0.
     wflux = 0.75*w1flux + 0.25*w2flux
@@ -848,10 +860,11 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=No
 
 def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
                  gsnr=None, rsnr=None, zsnr=None,
+                 gnobs=None, rnobs=None, znobs=None,
                  w1flux=None, w2flux=None, w1snr=None, w2snr=None,
                  dchisq=None, maskbits=None, objtype=None, primary=None,
                  south=True):
-    """Definition of z~5 QSO target classes from color cuts. Returns a boolean array.
+    """Definition of z~5 QSO targets from color cuts. Returns a boolean array.
 
     Parameters
     ----------
@@ -882,6 +895,9 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
         # for bit in [1, 10, 12, 13]:
         for bit in [10, 12, 13]:
             qso &= ((maskbits & 2**bit) == 0)
+
+    # ADM observed in every band.
+    qso &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM relaxed morphology cut for SV.
     # ADM we never target sources with dchisq[..., 0] = 0, so force
@@ -1576,6 +1592,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 isQSO_cuts(
                     primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                     w1flux=w1flux, w2flux=w2flux,
+                    gnobs=gnobs, rnobs=rnobs, znobs=znobs
                     dchisq=dchisq, maskbits=maskbits,
                     objtype=objtype, w1snr=w1snr, w2snr=w2snr,
                     south=south
@@ -1591,6 +1608,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     isQSO_randomforest(
                         primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                         w1flux=w1flux, w2flux=w2flux,
+                        gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                         dchisq=dchisq, maskbits=maskbits,
                         objtype=objtype, south=south
                     )
@@ -1599,6 +1617,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     isQSO_highz_faint(
                         primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                         w1flux=w1flux, w2flux=w2flux,
+                        gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                         dchisq=dchisq, maskbits=maskbits,
                         objtype=objtype, south=south
                     )
@@ -1613,6 +1632,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 isQSOz5_cuts(
                     primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
                     gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+                    gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                     w1flux=w1flux, w2flux=w2flux, w1snr=w1snr, w2snr=w2snr,
                     dchisq=dchisq, maskbits=maskbits, objtype=objtype,
                     south=south

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1592,7 +1592,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 isQSO_cuts(
                     primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                     w1flux=w1flux, w2flux=w2flux,
-                    gnobs=gnobs, rnobs=rnobs, znobs=znobs
+                    gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                     dchisq=dchisq, maskbits=maskbits,
                     objtype=objtype, w1snr=w1snr, w2snr=w2snr,
                     south=south

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -126,7 +126,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
-        zfiberflux=zfiberflux, gnobs=None, rnobs=None, znobs=None,
+        zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
         rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
     )
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -143,9 +143,11 @@ class TestCuts(unittest.TestCase):
         for ff in zfiberflux, None:
             lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
                               zflux=zflux, w1flux=w1flux, zfiberflux=ff,
+                              gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                               rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
             lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux, zflux=zflux,
                               w1flux=w1flux, zfiberflux=ff,
+                              gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                               rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
             self.assertTrue(np.all(lrg1 == lrg2))
 
@@ -198,11 +200,15 @@ class TestCuts(unittest.TestCase):
         release = targets['RELEASE']
         # - Test that objtype and primary are optional
         psftype = targets['TYPE']
-        qso1 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
+        qso1 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux,
+                               w1flux=w1flux, w2flux=w2flux,
+                               gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                                deltaChi2=deltaChi2, maskbits=maskbits,
                                w1snr=w1snr, w2snr=w2snr, objtype=psftype, primary=primary,
                                release=release)
-        qso2 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
+        qso2 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux,
+                               w1flux=w1flux, w2flux=w2flux,
+                               gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                                deltaChi2=deltaChi2, maskbits=maskbits,
                                w1snr=w1snr, w2snr=w2snr, objtype=None, primary=None,
                                release=release)


### PR DESCRIPTION
Most other target classes already applied cuts of:
```
(gnobs > 0) & (rnobs > 0) & (znobs > 0)
```
but the QSO and LRG target classes did not. This PR updates the QSO and LRG selections for the Main Survey and SV to cut on `NOBS_G, R, Z` in this manner.