### PR TITLE
Add Main Survey LRG/ELG/QSO/BGS cuts to CMX for Mini-SV.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desitarget Change Log
 0.35.4 (unreleased)
 -------------------
 
-* Cut on NOBS > 0 for QSOs and LRGs for Main Survey and SV [`PR #589`_]
+* Add Main Survey LRG/ELG/QSO/BGS bits to CMX for Mini-SV [`PR #590`_].
+* Cut on NOBS > 0 for QSOs and LRGs for Main Survey and SV [`PR #589`_].
 * Fix bug when adding LSLGA galaxies into Main Survey BGS [`PR #588`_]:
     * Catch cases of bytes/str types as well as zero-length strings.
 * Noting (here) that we used the BFG to excise lots of junk [`PR #587`_].
@@ -28,6 +29,7 @@ desitarget Change Log
 .. _`PR #587`: https://github.com/desihub/desitarget/pull/587
 .. _`PR #588`: https://github.com/desihub/desitarget/pull/588
 .. _`PR #589`: https://github.com/desihub/desitarget/pull/589
+.. _`PR #590`: https://github.com/desihub/desitarget/pull/590
 
 0.35.3 (02-03-2020)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.35.4 (unreleased)
 -------------------
 
-* Add Main Survey LRG/ELG/QSO/BGS bits to CMX for Mini-SV [`PR #590`_].
+* Add Main Survey LRG/ELG/QSO/BGS cuts to CMX for Mini-SV [`PR #590`_].
 * Cut on NOBS > 0 for QSOs and LRGs for Main Survey and SV [`PR #589`_].
 * Fix bug when adding LSLGA galaxies into Main Survey BGS [`PR #588`_]:
     * Catch cases of bytes/str types as well as zero-length strings.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2157,6 +2157,82 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     # ADM identical to the SV0 cuts, so treat accordingly:
     std_faint, std_bright = sv0_std_classes
 
+    # ADM incorporate target classes from the Main Survey for Mini-SV.
+    # ADM this should be the combination of all of the northerna and all
+    # ADM of the southern cuts.
+    south_cuts = [False, True]
+
+    # ADM Main Survey LRGs.
+    from desitarget.cuts import isLRG as isLRG_MS
+    # ADM initially set everything to arrays of False for the LRGs
+    # ADM the zeroth element stores northern targets bits (south=False).
+    lrg_classes = [~primary, ~primary]
+    for south in south_cuts:
+        lrg_classes[int(south)] = isLRG_MS(
+            primary=primary,
+            gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
+            zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+            rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr, south=south
+        )
+    lrg_north, lrg_south = lrg_classes
+    # ADM combine LRG target bits for an LRG target based on any imaging.
+    lrg_mini_sv = (lrg_north & photsys_north) | (lrg_south & photsys_south)
+
+    # ADM Main Survey ELGs.
+    from desitarget.cuts import isELG as isELG_MS
+    # ADM initially set everything to arrays of False for the ELGs
+    # ADM the zeroth element stores northern targets bits (south=False).
+    elg_classes = [~primary, ~primary]
+    for south in south_cuts:
+        elg_classes[int(south)] = isELG_MS(
+            primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
+            gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+            gnobs=gnobs, rnobs=rnobs, znobs=znobs, maskbits=maskbits,
+            south=south
+        )
+    elg_north, elg_south = elg_classes
+    # ADM combine ELG target bits for an ELG target based on any imaging.
+    elg_mini_sv = (elg_north & photsys_north) | (elg_south & photsys_south)
+
+    # ADM Main Survey QSOs.
+    from desitarget.cuts import isQSO_randomforest as isQSO_MS
+    # ADM initially set everything to arrays of False for the QSOs
+    # ADM the zeroth element stores northern targets bits (south=False).
+    qso_classes = [~primary, ~primary]
+    for south in south_cuts:
+        qso_classes[int(south)] = isQSO_MS(
+            primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
+            w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2,
+            maskbits=maskbits, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+            objtype=objtype, release=release, south=south
+        )
+    qso_north, qso_south = qso_classes
+    # ADM combine QSO target bits for a QSO target based on any imaging.
+    qso_mini_sv = (qso_north & photsys_north) | (qso_south & photsys_south)
+
+    # ADM Main Survey BGS (Bright).
+    from desitarget.cuts import isBGS as isBGS_MS
+    # ADM initially set everything to arrays of False for the BGS
+    # ADM the zeroth element stores northern targets bits (south=False).
+
+    bgs_classes = [~primary, ~primary]
+    for south in south_cuts:
+        bgs_classes[int(south)] = isBGS_MS(
+            rfiberflux=rfiberflux, gflux=gflux, rflux=rflux, zflux=zflux,
+            w1flux=w1flux, w2flux=w2flux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+            gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+            gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
+            gfracin=gfracin, rfracin=rfracin, zfracin=zfracin,
+            gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
+            maskbits=maskbits, Grr=Grr, refcat=refcat, w1snr=w1snr, gaiagmag=gaiagmag,
+            objtype=objtype, primary=primary, south=south, targtype="bright"
+        )
+    bgs_north, bgs_south = bgs_classes
+
+    # ADM combine BGS targeting bits for a BGS selected in any imaging.
+    bgs_bright_mini_sv = (
+        bgs_north & photsys_north) | (bgs_south & photsys_south)
+
     # ADM Construct the target flag bits.
     cmx_target = std_dither * cmx_mask.STD_GAIA
     cmx_target |= std_dither_spec * cmx_mask.STD_DITHER

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2214,7 +2214,6 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     from desitarget.cuts import isBGS as isBGS_MS
     # ADM initially set everything to arrays of False for the BGS
     # ADM the zeroth element stores northern targets bits (south=False).
-
     bgs_classes = [~primary, ~primary]
     for south in south_cuts:
         bgs_classes[int(south)] = isBGS_MS(
@@ -2248,6 +2247,10 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     cmx_target |= sv0_wd * cmx_mask.SV0_WD
     cmx_target |= std_faint * cmx_mask.STD_FAINT
     cmx_target |= std_bright * cmx_mask.STD_BRIGHT
+    cmx_target |= lrg_mini_sv * cmx_mask.LRG_MINI_SV
+    cmx_target |= elg_mini_sv * cmx_mask.ELG_MINI_SV
+    cmx_target |= qso_mini_sv * cmx_mask.QSO_MINI_SV
+    cmx_target |= bgs_bright_mini_sv * cmx_mask.BGS_BRIGHT_MINI_SV
 
     # ADM update the priority with any shifts.
     # ADM we may need to update this logic if there are other shifts.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2176,7 +2176,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
         )
     lrg_north, lrg_south = lrg_classes
     # ADM combine LRG target bits for an LRG target based on any imaging.
-    lrg_mini_sv = (lrg_north & photsys_north) | (lrg_south & photsys_south)
+    mini_sv_lrg = (lrg_north & photsys_north) | (lrg_south & photsys_south)
 
     # ADM Main Survey ELGs.
     from desitarget.cuts import isELG as isELG_MS
@@ -2192,7 +2192,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
         )
     elg_north, elg_south = elg_classes
     # ADM combine ELG target bits for an ELG target based on any imaging.
-    elg_mini_sv = (elg_north & photsys_north) | (elg_south & photsys_south)
+    mini_sv_elg = (elg_north & photsys_north) | (elg_south & photsys_south)
 
     # ADM Main Survey QSOs.
     from desitarget.cuts import isQSO_randomforest as isQSO_MS
@@ -2208,7 +2208,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
         )
     qso_north, qso_south = qso_classes
     # ADM combine QSO target bits for a QSO target based on any imaging.
-    qso_mini_sv = (qso_north & photsys_north) | (qso_south & photsys_south)
+    mini_sv_qso = (qso_north & photsys_north) | (qso_south & photsys_south)
 
     # ADM Main Survey BGS (Bright).
     from desitarget.cuts import isBGS as isBGS_MS
@@ -2229,7 +2229,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     bgs_north, bgs_south = bgs_classes
 
     # ADM combine BGS targeting bits for a BGS selected in any imaging.
-    bgs_bright_mini_sv = (
+    mini_sv_bgs_bright = (
         bgs_north & photsys_north) | (bgs_south & photsys_south)
 
     # ADM Construct the target flag bits.
@@ -2247,10 +2247,10 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     cmx_target |= sv0_wd * cmx_mask.SV0_WD
     cmx_target |= std_faint * cmx_mask.STD_FAINT
     cmx_target |= std_bright * cmx_mask.STD_BRIGHT
-    cmx_target |= lrg_mini_sv * cmx_mask.LRG_MINI_SV
-    cmx_target |= elg_mini_sv * cmx_mask.ELG_MINI_SV
-    cmx_target |= qso_mini_sv * cmx_mask.QSO_MINI_SV
-    cmx_target |= bgs_bright_mini_sv * cmx_mask.BGS_BRIGHT_MINI_SV
+    cmx_target |= mini_sv_lrg * cmx_mask.MINI_SV_LRG
+    cmx_target |= mini_sv_elg * cmx_mask.MINI_SV_ELG
+    cmx_target |= mini_sv_qso * cmx_mask.MINI_SV_QSO
+    cmx_target |= mini_sv_bgs_bright * cmx_mask.MINI_SV_BGS_BRIGHT
 
     # ADM update the priority with any shifts.
     # ADM we may need to update this logic if there are other shifts.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -34,6 +34,12 @@ from desitarget.cmx.cmx_targetmask import cmx_mask
 from desitarget.geomask import sweep_files_touch_hp, is_in_hp, bundle_bricks
 from desitarget.gaiamatch import gaia_dr_from_ref_cat, is_in_Galaxy
 
+# ADM Main Survey functions, used for mini-SV.
+from desitarget.cuts import isLRG as isLRG_MS
+from desitarget.cuts import isELG as isELG_MS
+from desitarget.cuts import isQSO_randomforest as isQSO_MS
+from desitarget.cuts import isBGS as isBGS_MS
+
 # ADM set up the DESI default logger
 from desiutil.log import get_logger
 log = get_logger()
@@ -2163,7 +2169,6 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     south_cuts = [False, True]
 
     # ADM Main Survey LRGs.
-    from desitarget.cuts import isLRG as isLRG_MS
     # ADM initially set everything to arrays of False for the LRGs
     # ADM the zeroth element stores northern targets bits (south=False).
     lrg_classes = [~primary, ~primary]
@@ -2179,7 +2184,6 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     mini_sv_lrg = (lrg_north & photsys_north) | (lrg_south & photsys_south)
 
     # ADM Main Survey ELGs.
-    from desitarget.cuts import isELG as isELG_MS
     # ADM initially set everything to arrays of False for the ELGs
     # ADM the zeroth element stores northern targets bits (south=False).
     elg_classes = [~primary, ~primary]
@@ -2195,23 +2199,23 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     mini_sv_elg = (elg_north & photsys_north) | (elg_south & photsys_south)
 
     # ADM Main Survey QSOs.
-    from desitarget.cuts import isQSO_randomforest as isQSO_MS
     # ADM initially set everything to arrays of False for the QSOs
     # ADM the zeroth element stores northern targets bits (south=False).
     qso_classes = [~primary, ~primary]
-    for south in south_cuts:
-        qso_classes[int(south)] = isQSO_MS(
-            primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
-            w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2,
-            maskbits=maskbits, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-            objtype=objtype, release=release, south=south
-        )
+    # ADM don't run quasar cuts if requested, for speed.
+    if not noqso:
+        for south in south_cuts:
+            qso_classes[int(south)] = isQSO_MS(
+                primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
+                w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2,
+                maskbits=maskbits, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                objtype=objtype, release=release, south=south
+            )
     qso_north, qso_south = qso_classes
     # ADM combine QSO target bits for a QSO target based on any imaging.
     mini_sv_qso = (qso_north & photsys_north) | (qso_south & photsys_south)
 
     # ADM Main Survey BGS (Bright).
-    from desitarget.cuts import isBGS as isBGS_MS
     # ADM initially set everything to arrays of False for the BGS
     # ADM the zeroth element stores northern targets bits (south=False).
     bgs_classes = [~primary, ~primary]

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1796,7 +1796,7 @@ def isBACKUP(ra=None, dec=None, gaiagmag=None, primary=None):
 
 
 def isFIRSTLIGHT(gaiadtype, cmxdir=None, nside=None, pixlist=None):
-    """First light targets based on reading in files from Arjun Dey.
+    """First light/Mini-SV targets via reading files from Arjun Dey.
 
     Parameters
     ----------

--- a/py/desitarget/cmx/data/cmx_targetmask.yaml
+++ b/py/desitarget/cmx/data/cmx_targetmask.yaml
@@ -53,8 +53,8 @@ cmx_mask:
 
     - [MINI_SV_LRG,        53, "LRGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
     - [MINI_SV_ELG,        54, "ELGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [MINI_SV_QSO,        55, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [MINI_SV_BGS_BRIGHT, 56, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [MINI_SV_QSO,        55, "QSOs (RF) for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [MINI_SV_BGS_BRIGHT, 56, "BGS (bright) for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
 
     #- Calibration targets. Shared between main/cmx/sv programs.
     - [SKY,         32, "Blank sky locations",

--- a/py/desitarget/cmx/data/cmx_targetmask.yaml
+++ b/py/desitarget/cmx/data/cmx_targetmask.yaml
@@ -55,8 +55,7 @@ cmx_mask:
     - [ELG_MINI_SV,        54, "ELGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
     - [QSO_MINI_SV,        55, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
     - [BGS_BRIGHT_MINI_SV, 56, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [QSO_MINI_SV,        57, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [HYA_MINI_SV,        58, "Hyades for Mini SV ", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [HYA_MINI_SV,        57, "Hyades for Mini SV ", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
 
     #- Calibration targets. Shared between main/cmx/sv programs.
     - [SKY,         32, "Blank sky locations",

--- a/py/desitarget/cmx/data/cmx_targetmask.yaml
+++ b/py/desitarget/cmx/data/cmx_targetmask.yaml
@@ -51,6 +51,13 @@ cmx_mask:
 
     #- ADM retain bits 49-52 for masking/convenience (to mirror the main survey)
 
+    - [LRG_MINI_SV,        53, "LRGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [ELG_MINI_SV,        54, "ELGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [QSO_MINI_SV,        55, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [BGS_BRIGHT_MINI_SV, 56, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [QSO_MINI_SV,        57, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [HYA_MINI_SV,        58, "Hyades for Mini SV ", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+
     #- Calibration targets. Shared between main/cmx/sv programs.
     - [SKY,         32, "Blank sky locations",
         {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
@@ -128,6 +135,11 @@ priorities:
         M33_QSO: {UNOBS: 1005, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
         M33_M33cen: {UNOBS: 1002, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
         M33_M33out: {UNOBS: 1001, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
+        LRG_MINI_SV: {UNOBS: 3201, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        ELG_MINI_SV: {UNOBS: 3001, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        QSO_MINI_SV: {UNOBS: 3401, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BGS_BRIGHT_MINI_SV: {UNOBS: 2101, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        HYA_MINI_SV: {UNOBS: 1005, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FAINT:  -1
@@ -178,6 +190,11 @@ numobs:
         M33_QSO: 100
         M33_M33cen: 100
         M33_M33out: 100
+        ELG_MINI_SV: 1
+        LRG_MINI_SV: 2
+        QSO_MINI_SV: 4
+        BGS_BRIGHT_MINI_SV: 1
+        HYA_MINI_SV: 100
         BAD_SKY: 0
         #- Standards and sky are treated specially; NUMOBS doesn't apply
         STD_FAINT: -1

--- a/py/desitarget/cmx/data/cmx_targetmask.yaml
+++ b/py/desitarget/cmx/data/cmx_targetmask.yaml
@@ -51,11 +51,10 @@ cmx_mask:
 
     #- ADM retain bits 49-52 for masking/convenience (to mirror the main survey)
 
-    - [LRG_MINI_SV,        53, "LRGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [ELG_MINI_SV,        54, "ELGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [QSO_MINI_SV,        55, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [BGS_BRIGHT_MINI_SV, 56, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
-    - [HYA_MINI_SV,        57, "Hyades for Mini SV ", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [MINI_SV_LRG,        53, "LRGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [MINI_SV_ELG,        54, "ELGs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [MINI_SV_QSO,        55, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
+    - [MINI_SV_BGS_BRIGHT, 56, "QSOs for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
 
     #- Calibration targets. Shared between main/cmx/sv programs.
     - [SKY,         32, "Blank sky locations",
@@ -134,11 +133,10 @@ priorities:
         M33_QSO: {UNOBS: 1005, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
         M33_M33cen: {UNOBS: 1002, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
         M33_M33out: {UNOBS: 1001, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
-        LRG_MINI_SV: {UNOBS: 3201, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        ELG_MINI_SV: {UNOBS: 3001, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        QSO_MINI_SV: {UNOBS: 3401, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BGS_BRIGHT_MINI_SV: {UNOBS: 2101, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        HYA_MINI_SV: {UNOBS: 1005, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        MINI_SV_LRG: {UNOBS: 3410, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        MINI_SV_ELG: {UNOBS: 3001, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        MINI_SV_QSO: {UNOBS: 3420, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        MINI_SV_BGS_BRIGHT: {UNOBS: 2101, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FAINT:  -1
@@ -189,11 +187,10 @@ numobs:
         M33_QSO: 100
         M33_M33cen: 100
         M33_M33out: 100
-        ELG_MINI_SV: 1
-        LRG_MINI_SV: 2
-        QSO_MINI_SV: 4
-        BGS_BRIGHT_MINI_SV: 1
-        HYA_MINI_SV: 100
+        MINI_SV_ELG: 1
+        MINI_SV_LRG: 2
+        MINI_SV_QSO: 4
+        MINI_SV_BGS_BRIGHT: 1
         BAD_SKY: 0
         #- Standards and sky are treated specially; NUMOBS doesn't apply
         STD_FAINT: -1

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1115,11 +1115,15 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
     LX = bgs.copy()
     # ADM Could check on "L2" for DR8, need to check on "LX" post-DR8.
     if refcat is not None:
-        if isinstance(np.atleast_1d(refcat)[0], str):
-            LX = [(rc[0] == "L") if len(rc) > 0 else False for rc in refcat]
+        rc1d = np.atleast_1d(refcat)
+        if isinstance(rc1d[0], str):
+            LX = [(rc[0] == "L") if len(rc) > 0 else False for rc in rc1d]
         else:
-            LX = [(rc.decode()[0] == "L") if len(rc) > 0 else False for rc in refcat]
-        LX = np.array(LX, dtype=bool)
+            LX = [(rc.decode()[0] == "L") if len(rc) > 0 else False for rc in rc1d]
+        if np.ndim(refcat) == 0:
+            LX = np.array(LX[0], dtype=bool)
+        else:
+            LX = np.array(LX, dtype=bool)
 
     bgs |= LX
 


### PR DESCRIPTION
This PR adds the Main Survey bits and cuts for Mini-SV in commissioning. Included bits are:

- `MINI_SV_LRG` - Main Survey (_noresolve_) `LRG`.
- `MINI_SV_ELG` - Main Survey (_noresolve_) `ELG`.
- `MINI_SV_QSO` - Main Survey (_noresolve_) `QSO`.
- `MINI_SV_BGS_BRIGHT` - Main Survey (_noresolve_) `BGS_BRIGHT`.

More details are [on the DESI wiki](https://desi.lbl.gov/trac/wiki/TargetSelectionWG/miniSV2).

Plan is to test this PR today, merge it in about 24 hours, make a new tag, and make new targeting files.