### PR TITLE
Changes to commissioning code after running Mini-SV.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -12,6 +12,8 @@ desitarget Change Log
     * Remove the 'low quality' (`lowq`) component of `SV0_BGS`.
     * Add optical `MASKBITS` flags for LRGs (in Main Survey, SV and CMX).
 
+.. _`PR #592`: https://github.com/desihub/desitarget/pull/592
+
 0.36.0 (2020-02-16)
 -------------------
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,12 @@ desitarget Change Log
 0.36.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Changes in CMX after running code for Mini-SV [`PR #592`_]. Includes:
+    * Explicit g/G >= 16 cuts for `SV0_BGS`/`SV0_MWS`/`SV0_WD`.
+    * Remove the LRG `LOWZ_FILLER` class (both in SV and CMX).
+    * Mask on `bright` in `MASKBITS` for z~5 QSOs (both in SV and CMX).
+    * Remove the 'low quality' (`lowq`) component of `SV0_BGS`.
+    * Add optical `MASKBITS` flags for LRGs (in Main Survey, SV and CMX).
 
 0.36.0 (2020-02-16)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desitarget Change Log
 -------------------
 
 * Changes in CMX after running code for Mini-SV [`PR #592`_]. Includes:
-    * Explicit g/G >= 16 cuts for `SV0_BGS`/`SV0_MWS`/`SV0_WD`.
+    * g/G >= 16 for `SV0_BGS`/`SV0_MWS`/`SV0_WD`/`MINI_SV_BGS_BRIGHT`.
     * Remove the LRG `LOWZ_FILLER` class (both in SV and CMX).
     * Mask on `bright` in `MASKBITS` for z~5 QSOs (both in SV and CMX).
     * Remove the 'low quality' (`lowq`) component of `SV0_BGS`.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2178,7 +2178,8 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
             primary=primary,
             gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
             zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-            rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr, south=south
+            rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr,
+            maskbits=maskbits, south=south
         )
     lrg_north, lrg_south = lrg_classes
     # ADM combine LRG target bits for an LRG target based on any imaging.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1158,8 +1158,8 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
     # ADM Reject objects in masks.
     # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
     if maskbits is not None:
-        for bit in [1, 10, 12, 13]:
         # for bit in [10, 12, 13]:
+        for bit in [1, 10, 12, 13]:
             qso &= ((maskbits & 2**bit) == 0)
 
     # ADM observed in every band.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -209,7 +209,7 @@ def isSV0_BGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         primary = np.ones_like(rflux, dtype='?')
     sv0_bgs = np.zeros_like(rflux, dtype='?')
 
-    for targtype in ["bright", "faint", "faint_ext", "lowq", "fibmag"]:
+    for targtype in ["bright", "faint", "faint_ext", "fibmag"]:
         bgs = isBGS(
             gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, w2flux=w2flux,
             rfiberflux=rfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -201,9 +201,10 @@ def isSV0_BGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (10/14/19) is version 105 on `the SV wiki`_.
+    - Current version (02/18/20) is version 49 on `the cmx wiki`_.
     - Hardcoded for south=False.
-    - Combines all BGS-like SV classes into one bit.
+    - Combines bright/faint/faint_ext/fibmag BGS-like SV classes into
+      one bit.
     """
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -510,7 +510,7 @@ def isSV0_LRG(gflux=None, rflux=None, zflux=None, w1flux=None,
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
         zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-        rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
+        rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr,
         maskbits=maskbits
     )
 

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -741,7 +741,7 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (02/19/20) is version 50 on `the cmx wiki`_.
+    - Current version (02/19/20) is version 51 on `the cmx wiki`_.
     - Hardcoded for south=False.
     - Combines all QSO-like SV classes into one bit.
     """
@@ -1217,8 +1217,8 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
     # ADM Reject objects in masks.
     # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
     if maskbits is not None:
-        # for bit in [1, 10, 12, 13]:
-        for bit in [10, 12, 13]:
+        for bit in [1, 10, 12, 13]:
+        # for bit in [10, 12, 13]:
             qso &= ((maskbits & 2**bit) == 0)
 
     # ADM observed in every band.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -483,6 +483,7 @@ def isSV0_MWS(rflux=None, obs_rflux=None, objtype=None, paramssolved=None,
 def isSV0_LRG(gflux=None, rflux=None, zflux=None, w1flux=None,
               rfiberflux=None, zfiberflux=None,
               gflux_snr=None, rflux_snr=None, zflux_snr=None, w1flux_snr=None,
+              gnobs=None, rnobs=None, znobs=None, maskbits=None,
               primary=None):
     """Target Definition of an SV0-like LRG. Returns a boolean array.
 
@@ -498,7 +499,7 @@ def isSV0_LRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     Notes
     -----
-    - Current version (10/14/19) is version 104 on `the SV wiki`_.
+    - Current version (02/19/20) is version 50 on `the cmx wiki`_.
     - Hardcoded for south=False.
     - Combines all LRG-like SV classes into one bit.
     """
@@ -508,8 +509,9 @@ def isSV0_LRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
-        zfiberflux=zfiberflux,
+        zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
         rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
+        maskbits=maskbits
     )
 
     # ADM pass the lrg that pass cuts as primary, to restrict to the
@@ -534,8 +536,9 @@ def isSV0_LRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
 
 def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
-                  zfiberflux=None,
-                  rflux_snr=None, zflux_snr=None, w1flux_snr=None):
+                  zfiberflux=None, gnobs=None, rnobs=None, znobs=None,
+                  rflux_snr=None, zflux_snr=None, w1flux_snr=None,
+                  maskbits=None):
     """See :func:`~desitarget.sv1.sv1_cuts.isLRG` for details.
 
     Returns
@@ -550,6 +553,13 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     lrg &= (rflux_snr > 0) & (rflux > 0)   # ADM quality in r.
     lrg &= (zflux_snr > 0) & (zflux > 0) & (zfiberflux > 0)   # ADM quality in z.
     lrg &= (w1flux_snr > 4) & (w1flux > 0)  # ADM quality in W1.
+
+    # ADM observed in every band.
+    lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
+
+    # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
+    for bit in [1, 5, 6, 7, 11, 12, 13]:
+        lrg &= ((maskbits & 2**bit) == 0)
 
     return lrg
 
@@ -2118,6 +2128,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
         gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
         rfiberflux=rfiberflux, zfiberflux=zfiberflux,
         gflux_snr=gsnr, rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr,
+        gnobs=gnobs, rnobs=rnobs, znobs=znobs, maskbits=maskbits,
         primary=primary
     )
 

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2087,14 +2087,6 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
         galb=galb, gaia=gaia, primary=primary
     )
 
-    # ADM explicitly restrict "bright" target classes to G/g >= 16.
-    # ADM clip to avoid NaN on np.log10 of -ve numbers.
-    obs_gmag = 22.5-2.5*np.log10(np.clip(obs_gflux, 1e-16, 1e16))
-    too_bright = (obs_gmag < 16) | (gaia & (gaiagmag < 16))
-    sv0_bgs &= ~too_bright
-    sv0_mws &= ~too_bright
-    sv0_wd &= ~too_bright
-
     # ADM determine if an object is SV0_LRG.
     sv0_lrg = isSV0_LRG(
         gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
@@ -2221,6 +2213,15 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     # ADM combine BGS targeting bits for a BGS selected in any imaging.
     mini_sv_bgs_bright = (
         bgs_north & photsys_north) | (bgs_south & photsys_south)
+
+    # ADM explicitly restrict "bright" target classes to G/g >= 16.
+    # ADM clip to avoid NaN on np.log10 of -ve numbers.
+    obs_gmag = 22.5-2.5*np.log10(np.clip(obs_gflux, 1e-16, 1e16))
+    too_bright = (obs_gmag < 16) | (gaia & (gaiagmag < 16))
+    sv0_bgs &= ~too_bright
+    sv0_mws &= ~too_bright
+    sv0_wd &= ~too_bright
+    mini_sv_bgs_bright &= ~too_bright
 
     # ADM Construct the target flag bits.
     cmx_target = std_dither * cmx_mask.STD_GAIA

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2166,6 +2166,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
             primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
             w1flux=w1flux, w2flux=w2flux,
             gsnr=gsnr, rsnr=rsnr, zsnr=zsnr, w1snr=w1snr, w2snr=w2snr,
+            gnobs=gnobs, rnobs=rnobs, znobs=znobs,
             objtype=objtype, dchisq=dchisq, maskbits=maskbits
         )
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -198,7 +198,8 @@ def isBACKUP(ra=None, dec=None, gaiagmag=None, primary=None):
 
 def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
           zfiberflux=None, rflux_snr=None, zflux_snr=None, w1flux_snr=None,
-          gnobs=None, rnobs=None, znobs=None, primary=None, south=True):
+          gnobs=None, rnobs=None, znobs=None, maskbits=None, primary=None,
+          south=True):
     """
     Parameters
     ----------
@@ -214,7 +215,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (09/03/19) is version 199 on `the wiki`_.
+    - Current version (02/18/20) is version 215 on `the wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # ADM LRG targets.
@@ -226,7 +227,8 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
         zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-        rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
+        rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr,
+        maskbits=maskbits
     )
 
     # ADM color-based selection of LRGs.
@@ -240,7 +242,8 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
 def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
                   zfiberflux=None, gnobs=None, rnobs=None, znobs=None,
-                  rflux_snr=None, zflux_snr=None, w1flux_snr=None):
+                  rflux_snr=None, zflux_snr=None, w1flux_snr=None,
+                  maskbits=None):
     """See :func:`~desitarget.cuts.isLRG` for details.
 
     Returns
@@ -263,6 +266,10 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
 
     # ADM observed in every band.
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
+
+    # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
+    for bit in [1, 5, 6, 7, 11, 12, 13]:
+        lrg &= ((maskbits & 2**bit) == 0)
 
     return lrg
 
@@ -1808,7 +1815,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 primary=primary,
                 gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
                 zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr, south=south
+                rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr,
+                maskbits=maskbits, south=south
             )
     lrg_north, lrg_south = lrg_classes
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2129,7 +2129,7 @@ def read_targets_in_cap(hpdirname, radecrad, columns=None):
                                      columns=columnscopy)
     # ADM ...otherwise just read in the targets.
     else:
-        targets = read_target_file(hpdirname, columns=columnscopy)
+        targets = read_target_files(hpdirname, columns=columnscopy)
 
     # ADM restrict only to targets in the requested cap...
     ii = is_in_cap(targets, radecrad)

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -91,7 +91,8 @@ def isBACKUP(ra=None, dec=None, gaiagmag=None, primary=None):
 
 def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
           zfiberflux=None, rflux_snr=None, zflux_snr=None, w1flux_snr=None,
-          gnobs=None, rnobs=None, znobs=None, primary=None, south=True):
+          gnobs=None, rnobs=None, znobs=None, maskbits=None,
+          primary=None, south=True):
     """Target Definition of LRG. Returns a boolean array.
 
     Parameters
@@ -116,7 +117,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     Notes
     -----
-    - Current version (10/14/19) is version 104 on `the SV wiki`_.
+    - Current version (02/18/20) is version 123 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # ADM LRG SV targets.
@@ -128,6 +129,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
         zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
         rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
+        maskbits=maskbits
     )
 
     # ADM pass the lrg that pass cuts as primary, to restrict to the
@@ -142,7 +144,8 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
 def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
                   zfiberflux=None, gnobs=None, rnobs=None, znobs=None,
-                  rflux_snr=None, zflux_snr=None, w1flux_snr=None):
+                  rflux_snr=None, zflux_snr=None, w1flux_snr=None,
+                  maskbits=None):
     """See :func:`~desitarget.sv1.sv1_cuts.isLRG` for details.
 
     Returns
@@ -165,6 +168,10 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
 
     # ADM observed in every band.
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
+
+    # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
+    for bit in [1, 5, 6, 7, 11, 12, 13]:
+        lrg &= ((maskbits & 2**bit) == 0)
 
     return lrg
 
@@ -1531,7 +1538,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 primary=primary, south=south,
                 gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
                 zfiberflux=zfiberflux, rflux_snr=rsnr, zflux_snr=zsnr,
-                w1flux_snr=w1snr, gnobs=gnobs, rnobs=rnobs, znobs=znobs
+                w1flux_snr=w1snr, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                maskbits=maskbits
             )
     lrg_north, lrginit_n_4, lrgsup_n_4, lrginit_n_8, lrgsup_n_8 = lrg_classes[0]
     lrg_south, lrginit_s_4, lrgsup_s_4, lrginit_s_8, lrgsup_s_8 = lrg_classes[1]

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -842,8 +842,8 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
     # ADM Reject objects in masks.
     # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
     if maskbits is not None:
-        for bit in [1, 10, 12, 13]:
         # for bit in [10, 12, 13]:
+        for bit in [1, 10, 12, 13]:
             qso &= ((maskbits & 2**bit) == 0)
 
     # ADM observed in every band.

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -886,7 +886,7 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
 
     Notes
     -----
-    - Current version (10/24/19) is version 112 on `the SV wiki`_.
+    - Current version (02/19/20) is version 125 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if not south:
@@ -899,8 +899,8 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
     # ADM Reject objects in masks.
     # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
     if maskbits is not None:
-        # for bit in [1, 10, 12, 13]:
-        for bit in [10, 12, 13]:
+        for bit in [1, 10, 12, 13]:
+        # for bit in [10, 12, 13]:
             qso &= ((maskbits & 2**bit) == 0)
 
     # ADM observed in every band.

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -128,7 +128,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
         zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-        rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr
+        rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr,
         maskbits=maskbits
     )
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -144,10 +144,12 @@ class TestCuts(unittest.TestCase):
             lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
                               zflux=zflux, w1flux=w1flux, zfiberflux=ff,
                               gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                              maskbits=maskbits,
                               rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
             lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux, zflux=zflux,
                               w1flux=w1flux, zfiberflux=ff,
                               gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                              maskbits=maskbits,
                               rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
             self.assertTrue(np.all(lrg1 == lrg2))
 


### PR DESCRIPTION
This PR updates some aspects of commissioning code to facilitate easier processing of targets if we ever have another Mini-SV run. It:

- Adds explicit g-band or G-band >= 16 cuts for the "bright" target classes (`SV0_BGS`/`SV0_MWS`/`SV0_WD`/`MINI_SV_BGS_BRIGHT`) to make sure they don't saturate.
- Removes the LRG `LOWZ_FILLER` class (both in the SV and CMX code).
- Masks on `bright` in `MASKBITS` for the redshift 5 QSO class (both in the SV and CMX code). This class contained a small handful of very bright (g~10) targets.
- Removes the 'low quality' (`lowq`) component of `SV0_BGS`. This class included lots of bright, spurious sources.
- Adds some of the optical `MASKBITS` flags for LRGs (in all of the Main Survey, SV and CMX codes).
