### PR TITLE
Force sky locations to be within the geometric boundaries of their brick.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.36.1 (unreleased)
 -------------------
 
+* Restrict skies to the geometric boundaries of their brick [`PR #595`_].
 * Changes in CMX after running code for Mini-SV [`PR #592`_]. Includes:
     * g/G >= 16 for `SV0_BGS`/`SV0_MWS`/`SV0_WD`/`MINI_SV_BGS_BRIGHT`.
     * Remove the LRG `LOWZ_FILLER` class (both in SV and CMX).
@@ -13,6 +14,7 @@ desitarget Change Log
     * Add optical `MASKBITS` flags for LRGs (in Main Survey, SV and CMX).
 
 .. _`PR #592`: https://github.com/desihub/desitarget/pull/592
+.. _`PR #595`: https://github.com/desihub/desitarget/pull/595
 
 0.36.0 (2020-02-16)
 -------------------

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -88,10 +88,9 @@ def get_brick_info(drdirs, counts=False, allbricks=False):
     if isinstance(drdirs, str):
         drdirs = [drdirs, ]
 
-    # ADM initialize the bricks class, retrieve the brick information look-up
-    # ADM table and turn it into a fast look-up dictionary.
-    from desiutil import brick
-    bricktable = brick.Bricks(bricksize=0.25).to_table()
+    # ADM turn the brick info table into a fast look-up dictionary.
+    # ADM (note the bricks class is instantiated at the top of the code.)
+    bricktable = bricks.to_table()
     brickdict = {}
     for b in bricktable:
         brickdict[b["BRICKNAME"]] = [b["RA"], b["DEC"],


### PR DESCRIPTION
Sky locations are generated at the pixel-level from images, which can "hang" slightly outside of the geometric boundary of the brick. This can produce inconsistencies between the brick information (`BRICKID`, `BRICKNAME`) and the sky location (`RA`, `DEC`).

This PR fixes those inconsistencies by removing any sky locations that are "outside" of the `RA`/`DEC` boundaries of their brick. This removes a tiny fraction of viable locations (~0.1%).