### PR TITLE
Fixing b sleak

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,8 +11,10 @@ desitarget Change Log
     * Mask on `bright` in `MASKBITS` for z~5 QSOs (both in SV and CMX).
     * Remove the 'low quality' (`lowq`) component of `SV0_BGS`.
     * Add optical `MASKBITS` flags for LRGs (in Main Survey, SV and CMX).
+* Leak of Bright Stars in BGS Main Survey and BGS SV fixed [`PR #596`_].
 
 .. _`PR #592`: https://github.com/desihub/desitarget/pull/592
+.. _`PR #596`: https://github.com/desihub/desitarget/pull/596
 
 0.36.0 (2020-02-16)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1010,7 +1010,7 @@ def isBGS(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=None, w2fl
                         w2flux=w2flux, south=south, targtype=targtype, primary=primary)
 
     bgs |= isBGS_lslga(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux, refcat=refcat,
-                       south=south, targtype=targtype)
+                       maskbits=maskbits, south=south, targtype=targtype)
 
     return bgs
 
@@ -1110,7 +1110,7 @@ def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=Non
 
 
 def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
-                south=True, targtype=None):
+                maskbits=None, south=True, targtype=None):
     """Module to recover the LSLGA objects in all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
@@ -1133,6 +1133,7 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
             LX = np.array(LX, dtype=bool)
 
     bgs |= LX
+    bgs &= ((maskbits & 2**1) == 0)
 
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1134,6 +1134,7 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
 
     bgs |= LX
     bgs &= ((maskbits & 2**1) == 0)
+    bgs &= ((maskbits & 2**13) == 0)
 
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1020,7 +1020,7 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
     bgs_qcs &= (gfracflux < 5.0) & (rfracflux < 5.0) & (zfracflux < 5.0)
     bgs_qcs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
     bgs_qcs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
-    bgs_qcs &= (maskbits & 2**1) == 0
+    
     # color box
     bgs_qcs &= rflux > gflux * 10**(-1.0/2.5)
     bgs_qcs &= rflux < gflux * 10**(4.0/2.5)
@@ -1038,6 +1038,9 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
         bgs |= (Grr < 0.6) & (~_psflike(objtype)) & (gaiagmag != 0)
         bgs &= bgs_qcs
 
+    bgs &= (maskbits & 2**1) == 0
+    bgs &= (maskbits & 2**13) == 0
+    
     return bgs
 
 


### PR DESCRIPTION
This fix the leak of bright stars in BGS MAIN and BGS SV. The leak in Main was caused by the LSLGA objects we manually added back to BGS regardless of any of the BGS cuts and hence ignoring the Bright star mask. In SV we were introducing bright stars in the LOWQ (low quality) super set as this includes a sample of objects rejected by the bright star mask in BGS.