### PR TITLE
Update SV0 class in CMX to specifically flag the high-z quasar selection.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.36.1 (unreleased)
 -------------------
 
+* Flag the high-z quasar selection in CMX (as `SV0_QSO_Z5`) [`PR #598`_].
 * Leak of Bright Stars in BGS Main Survey and BGS SV fixed [`PR #596`_].
 * Restrict skies to the geometric boundaries of their brick [`PR #595`_].
 * Changes in CMX after running code for Mini-SV [`PR #592`_]. Includes:
@@ -17,6 +18,7 @@ desitarget Change Log
 .. _`PR #592`: https://github.com/desihub/desitarget/pull/592
 .. _`PR #595`: https://github.com/desihub/desitarget/pull/595
 .. _`PR #596`: https://github.com/desihub/desitarget/pull/596
+.. _`PR #598`: https://github.com/desihub/desitarget/pull/598
 
 0.36.0 (2020-02-16)
 -------------------

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -749,7 +749,7 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     # ADM The individual routines return arrays, so we need
     # ADM a check to preserve the single-object case.
     if _is_row(rflux):
-        return qso_north[0]
+        return qso_north[0], qsoz5_north[0]
 
     return qso_north, qsoz5_north
 

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -693,7 +693,7 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     -----
     - Current version (02/19/20) is version 51 on `the cmx wiki`_.
     - Current version (03/10/20) for the high-z (QSO_Z5 selection)
-      is version 58 on `the cmx wiki`_.
+      is version 59 on `the cmx wiki`_.
     - Hardcoded for south=False.
     - Combines all QSO-like SV classes into one bit.
     """

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -685,10 +685,15 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     :class:`array_like` or :class:`float`
         ``True`` if and only if the object is an SV-like QSO target.
          If `floats` are passed, a `float` is returned.
+    :class:`array_like` or :class:`float`
+        ``True`` if and only if the object is an SV-like QSO target that
+        passes something like the QSO_Z5 (high-z) selection from SV.
 
     Notes
     -----
     - Current version (02/19/20) is version 51 on `the cmx wiki`_.
+    - Current version (03/10/20) for the high-z (QSO_Z5 selection)
+      is version 58 on `the cmx wiki`_.
     - Hardcoded for south=False.
     - Combines all QSO-like SV classes into one bit.
     """
@@ -746,7 +751,7 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     if _is_row(rflux):
         return qso_north[0]
 
-    return qso_north
+    return qso_north, qsoz5_north
 
 
 def isQSO_cuts(gflux=None, rflux=None, zflux=None,
@@ -2107,9 +2112,9 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     # ADM determine if an object is SV0_QSO.
     if noqso:
         # ADM don't run quasar cuts if requested, for speed.
-        sv0_qso = ~primary
+        sv0_qso, sv0_qso_z5 = ~primary, ~primary
     else:
-        sv0_qso = isSV0_QSO(
+        sv0_qso, sv0_qso_z5 = isSV0_QSO(
             primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
             w1flux=w1flux, w2flux=w2flux,
             gsnr=gsnr, rsnr=rsnr, zsnr=zsnr, w1snr=w1snr, w2snr=w2snr,
@@ -2235,6 +2240,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     cmx_target |= sv0_lrg * cmx_mask.SV0_LRG
     cmx_target |= sv0_elg * cmx_mask.SV0_ELG
     cmx_target |= sv0_qso * cmx_mask.SV0_QSO
+    cmx_target |= sv0_qso_z5 * cmx_mask.SV0_QSO_Z5
     cmx_target |= sv0_wd * cmx_mask.SV0_WD
     cmx_target |= std_faint * cmx_mask.STD_FAINT
     cmx_target |= std_bright * cmx_mask.STD_BRIGHT

--- a/py/desitarget/cmx/data/cmx_targetmask.yaml
+++ b/py/desitarget/cmx/data/cmx_targetmask.yaml
@@ -15,6 +15,7 @@ cmx_mask:
     - [SV0_ELG,        11, "SV-like ELG bit is set (very early SV selection)", {obsconditions: DARK|GRAY}]
     - [SV0_QSO,        12, "SV-like QSO bit is set (very early SV/RF selection)", {obsconditions: DARK}]
     - [SV0_WD,         13, "SV-like WD bit is set (very early MWS_WD selection)", {obsconditions: BRIGHT}]
+    - [SV0_QSO_Z5,     14, "SV-like QSO bit is set (specifically for the QSO_Z5 selection from SV", {obsconditions: DARK}]
 
     # ADM back-up targets for poor conditions.
     - [BACKUP_BRIGHT,  16, "Bright Gaia targets for poor conditions",  {obsconditions: POOR|TWILIGHT12|TWILIGHT18}]
@@ -107,6 +108,7 @@ priorities:
         SV0_LRG: {UNOBS: 3200, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         SV0_QSO: {UNOBS: 3400, MORE_ZGOOD: 3500, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         SV0_WD: {UNOBS: 2998, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        SV0_QSO_Z5: {UNOBS: 3600, MORE_ZGOOD: 3700, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         BACKUP_BRIGHT: {UNOBS: 10, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
         BACKUP_FAINT: {UNOBS: 10, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
         M31_STD_BRIGHT: {UNOBS: 1008, DONE: 10, OBS: 10, DONOTOBSERVE: 0}
@@ -161,6 +163,7 @@ numobs:
         SV0_LRG: 2
         SV0_QSO: 4
         SV0_WD: 1
+        SV0_QSO_Z5: 4
         BACKUP_BRIGHT: 1
         BACKUP_FAINT: 1
         M31_STD_BRIGHT: 100

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -829,7 +829,7 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
 
     Notes
     -----
-    - Current version (02/19/20) is version 125 on `the SV wiki`_.
+    - Current version (03/11/20) is version 126 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if not south:

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1020,7 +1020,7 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
     bgs_qcs &= (gfracflux < 5.0) & (rfracflux < 5.0) & (zfracflux < 5.0)
     bgs_qcs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
     bgs_qcs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
-    
+
     # color box
     bgs_qcs &= rflux > gflux * 10**(-1.0/2.5)
     bgs_qcs &= rflux < gflux * 10**(4.0/2.5)
@@ -1040,7 +1040,7 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
 
     bgs &= (maskbits & 2**1) == 0
     bgs &= (maskbits & 2**13) == 0
-    
+
     return bgs
 
 


### PR DESCRIPTION
This PR creates a new targeting class in commissioning (`SV0_QSO_Z5`) that corresponds to the high-redshift (z~4.5-5.0) quasar selection. This high-z class was (and remains) a subset of `SV0_QSO`. But, the class is now also given its own bit to make it easier to track.