### PR TITLE
Fix typo in WD priority for SV1

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desitarget Change Log
 -------------------
 
 * Fixes a typo in the priority of MWS_WD_SV targets [`PR #600`_].
+
 .. _`PR #600`: https://github.com/desihub/desitarget/pull/600
 
 0.37.0 (2020-03-12)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desitarget Change Log
 0.37.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Fixes a typo in the priority of MWS_WD_SV targets [`PR #600`_].
+.. _`PR #600`: https://github.com/desihub/desitarget/pull/600
 
 0.37.0 (2020-03-12)
 -------------------

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -349,7 +349,7 @@ priorities:
     sv1_scnd_mask:
         VETO:                         {UNOBS:  0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
         DR14Q:                        {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_WD_SV:                    {UNOBS: 2296, DONE:  600, OBS: 1, DONOTOBSERVE: 0}
+        MWS_WD_SV:                    {UNOBS: 2996, DONE:  600, OBS: 1, DONOTOBSERVE: 0}
         MWS_WD_SV_VERYBRIGHT:         SAME_AS_MWS_WD_SV
         MWS_CALIB_APOGEE:             {UNOBS: 2995, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
         MWS_CALIB_GAIAESO:            SAME_AS_MWS_CALIB_APOGEE


### PR DESCRIPTION
The priority for MWS_WD_SV should be 2996, but it was set at 2296. This must have been a typo.