### PR TITLE
fix QSO mock density bug (again) reported in #594

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ desitarget Change Log
 0.37.1 (unreleased)
 -------------------
 
+* Fix mock QSO density bug reported in #594 [`PR #602`_].
 * Fixes a typo in the priority of MWS_WD_SV targets [`PR #600`_].
 
 .. _`PR #600`: https://github.com/desihub/desitarget/pull/600
+.. _`PR #602`: https://github.com/desihub/desitarget/pull/602
 
 0.37.0 (2020-03-12)
 -------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -398,7 +398,7 @@ def read_data(targfile, mocks=False, downsample=None, header=False):
     truths, objtruths = None, None
 
     if mocks:
-        truthfile = '{}/truth.fits'.format(targdir)
+        truthfile = targfile.replace('targets-', 'truth-') # fragile!
 
         # ADM check that the truth file exists.
         if not os.path.exists(truthfile):

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -197,7 +197,7 @@ def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
             qsodndz *= np.sum(dndz[target_type]['dndz']) / np.sum(qsodndz)
 
             if target_name == 'QSO' and 'zmax_qso' in params.keys():
-                extrafactor = np.sum(qsodndz[zbins <= 2.1]) / np.sum(qsodndz[zbins <= params['zmax_qso']])
+                extrafactor = np.sum(qsodndz[zbins <= params['zmax_qso']]) / np.sum(qsodndz[zbins <= 2.1])
             if target_name == 'LYA' and 'zmin_lya' in params.keys():
                 extrafactor = np.sum(qsodndz[zbins >= params['zmin_lya']]) / np.sum(qsodndz[zbins >= 2.1])
             log.info('Density adjustment factor for target type {}: {:.3f}.'.format(target_name, extrafactor))

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -197,12 +197,13 @@ def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
             qsodndz *= np.sum(dndz[target_type]['dndz']) / np.sum(qsodndz)
 
             if target_name == 'QSO' and 'zmax_qso' in params.keys():
-                extrafactor = np.sum(qsodndz[zbins >= 2.1]) / np.sum(qsodndz[zbins >= params['zmax_qso']])
+                extrafactor = np.sum(qsodndz[zbins <= 2.1]) / np.sum(qsodndz[zbins <= params['zmax_qso']])
             if target_name == 'LYA' and 'zmin_lya' in params.keys():
                 extrafactor = np.sum(qsodndz[zbins >= params['zmin_lya']]) / np.sum(qsodndz[zbins >= 2.1])
+            log.info('Density adjustment factor for target type {}: {:.3f}.'.format(target_name, extrafactor))
         else:
             extrafactor = 1.0
-            
+
         data['DENSITY_FACTOR'] = extrafactor * data['DENSITY'] / data['MOCK_DENSITY']
             
         if data['DENSITY_FACTOR'] > 1:

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -1286,7 +1286,8 @@ def join_targets_truth(mockdir, outdir=None, overwrite=False, comm=None):
                                    outfile=outdir+'/truth-{}.fits'.format(obscon), comm=comm)
 
         #- Make initial merged target list (MTL) using rank 0
-        if rank == 0 and todo['mtl-{}'.format(obscon)]:
+        exists = os.path.isfile(outdir+'/targets-{}.fits'.format(obscon))
+        if rank == 0 and todo['mtl-{}'.format(obscon)] and exists:
             from desitarget import mtl
             from desiutil.log import get_logger
             log = get_logger()


### PR DESCRIPTION
Fixes #594 (thanks to @alxogm for the bug report). Also fixes two other bugs (impacting just the mocks):  (1) don't crash when joining healpixels if no bright-time targets were simulated; and (2) find the appropriate `truth.fits` file when generating QA.

Tested with:
```
select_mock_targets -c select-targets.yaml --nproc 12 --seed 1 --tiles tiles.fits --nside 32 --no-spectra
join_mock_targets --mockdir ./ --overwrite
run_target_qa ./targets-dark.fits html/ --mocks --nosystematics
```

where the `tiles.fits` file was generated with--
```
import desimodel.io
from astropy.table import Table
alltiles = Table(desimodel.io.load_tiles())
ii = (153 < alltiles['RA']) & (alltiles['RA']<156) & (38<alltiles['DEC']) & (alltiles['DEC']<40)
tiles = Table(alltiles[ii])
tiles.write('tiles.fits', overwrite=True)
```
and `select-targets.yaml` contained just QSOs (tracer+Lya) with no contaminants:
```
targets:
    QSO: {
        target_type: QSO,
        mockfile: '{DESI_ROOT}/mocks/DarkSky/v1.0.1/qso_0_inpt.fits',
        format: gaussianfield,
        zmax_qso: 1.8,
        use_simqso: True,
        density: 120,
    }
    LYA: {
        target_type: QSO,
        mockfile: '{DESI_ROOT}/mocks/lya_forest/london/v9.0/v9.0.0/master.fits',
        format: CoLoRe,
        nside_lya: 16,
        zmin_lya: 1.8,
        density: 50,
        use_simqso: True,
        sqmodel: 'default',  #Other options are 'lya_simqso_model_develop' and 'lya_simqso_model' (same as quickquasars)
        balprob: 0.0,
        add_dla: False,
        add_metals: False,    #If adding metals use 'all', this is to keep the same argument as in quickquasars.
        add_lyb: False
        }
```

And here's the resulting redshift distribution:

<img width="702" alt="Screen Shot 2020-04-05 at 9 27 12 AM" src="https://user-images.githubusercontent.com/1431820/78499618-b2762480-771f-11ea-8943-0972642ae7fd.png">
