### PR TITLE
temporarily remove TRANSIENT_ columns in select_mock_targets truth tables

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.37.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Fix `select_mock_targets` I/O bug reported in #603 [`PR #604`_].
+
+.. _`PR #603`: https://github.com/desihub/desitarget/pull/604
 
 0.37.1 (2020-04-07)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,7 +7,7 @@ desitarget Change Log
 
 * Fix `select_mock_targets` I/O bug reported in #603 [`PR #604`_].
 
-.. _`PR #603`: https://github.com/desihub/desitarget/pull/604
+.. _`PR #604`: https://github.com/desihub/desitarget/pull/604
 
 0.37.1 (2020-04-07)
 -------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -579,10 +579,15 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
         if len(objtruth) > 0:
             for obj in sorted(set(truthdata['TEMPLATETYPE'])):
                 out = objtruth[obj]
+
+                # TODO: fix desitarget #529, double check with #603, then remove this
                 # Temporarily remove the `TRANSIENT_` columns--
                 # see https://github.com/desihub/desitarget/issues/603#issuecomment-612678359 and
                 # https://github.com/desihub/desisim/issues/529
-                [out.remove_column(col) for col in out.colnames if 'TRANSIENT_' in col]
+                for col in out.colnames.copy():
+                    if 'TRANSIENT_' in col:
+                        out.remove_column(col)
+
                 fitsio.write(truthfile+'.tmp', out.as_array(), append=True, extname='TRUTH_{}'.format(obj))
         os.rename(truthfile+'.tmp', truthfile)
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -578,9 +578,12 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
 
         if len(objtruth) > 0:
             for obj in sorted(set(truthdata['TEMPLATETYPE'])):
-                fitsio.write(truthfile+'.tmp', objtruth[obj].as_array(), append=True,
-                             extname='TRUTH_{}'.format(obj))
-
+                out = objtruth[obj]
+                # Temporarily remove the `TRANSIENT_` columns--
+                # see https://github.com/desihub/desitarget/issues/603#issuecomment-612678359 and
+                # https://github.com/desihub/desisim/issues/529
+                [out.remove_column(col) for col in out.colnames if 'TRANSIENT_' in col]
+                fitsio.write(truthfile+'.tmp', out.as_array(), append=True, extname='TRUTH_{}'.format(obj))
         os.rename(truthfile+'.tmp', truthfile)
 
     return ntargs, filename


### PR DESCRIPTION
It's not pretty, but this PR fixes the crash reported in #603.

Once https://github.com/desihub/desisim/issues/529 has been addressed we can restore the writing of the `TRANSIENT_*` columns, first making sure that `fitiso` can handle them.