### PR TITLE
Add some new features and columns to the random catalogs

### DIFF
--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -6,6 +6,7 @@ import argparse
 from desitarget.gfa import select_gfas
 from desitarget.geomask import is_in_gal_box, is_in_box
 from desitarget import io
+from desitarget.io import _check_both_set
 from time import time
 t0 = time()
 
@@ -75,7 +76,11 @@ if len(infiles) == 0:
     log.critical('no sweep or tractor files found')
     sys.exit(1)
 
-log.info('running on {} processors...t = {:.1f} mins'.format(ns.numproc, (time()-t0)/60.))
+if ns.bundlefiles is None:
+    log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-t0))
+    # ADM formally writing pixelized files requires both the nside
+    # ADM and the list of healpixels to be set.
+    _check_both_set(ns.healpixels, ns.nside)
 
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels

--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -6,7 +6,7 @@ import argparse
 from desitarget.gfa import select_gfas
 from desitarget.geomask import is_in_gal_box, is_in_box
 from desitarget import io
-from desitarget.io import _check_both_set
+from desitarget.io import check_both_set
 from time import time
 t0 = time()
 
@@ -80,7 +80,7 @@ if ns.bundlefiles is None:
     log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-t0))
     # ADM formally writing pixelized files requires both the nside
     # ADM and the list of healpixels to be set.
-    _check_both_set(ns.healpixels, ns.nside)
+    check_both_set(ns.healpixels, ns.nside)
 
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -53,7 +53,7 @@ ap.add_argument("--dustdir",
                 help="Directory of SFD dust maps (defaults to the equivalent of $DUST_DIR+'/maps')",
                 default=None)
 ap.add_argument("--aprad", type=float,
-                help="Radius of aperture in arcsec in which to generate sky background flux levels (defaults to 0.75; the DESI fiber radius)",
+                help="Radius of aperture in arcsec in which to generate sky background flux levels (defaults to 0.75; the DESI fiber radius). If aprad < 1e-8 is passed, the code to produce these values is skipped, as a speed-up, and `APFLUX_` output values are set to zero.",
                 default=0.75)
 ap.add_argument("--seed", type=int,
                 help="Random seed passed to desitarget.randoms.select_randoms()",

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -51,8 +51,6 @@ ap.add_argument("--brickspersec", type=float,
 ap.add_argument("--dustdir",
                 help="Directory of SFD dust maps (defaults to the equivalent of $DUST_DIR+'/maps')",
                 default=None)
-ap.add_argument("--noresolve", action='store_true',
-                help="Do NOT resolve into northern randoms in northern regions and southern randoms in southern regions")
 ap.add_argument("--aprad", type=float,
                 help="Radius of aperture in arcsec in which to generate sky background flux levels (defaults to 0.75; the DESI fiber radius)",
                 default=0.75)
@@ -65,7 +63,7 @@ ns = ap.parse_args()
 # ADM bundlefiles potentially needs to know about them.
 extra = " --numproc {}".format(ns.numproc)
 nsdict = vars(ns)
-for nskey in "noresolve", "aprad", "density", "seed":
+for nskey in "aprad", "density", "seed":
     if isinstance(nsdict[nskey], bool):
         if nsdict[nskey]:
             extra += " --{}".format(nskey)
@@ -104,19 +102,24 @@ if not 'dr5' in ns.surveydir and not 'dr6' in ns.surveydir:
         if 'BITNM' in record:
             hdr[record] = rmhdr['_record_map'][record]
 
-randoms = select_randoms(ns.surveydir, density=ns.density, numproc=ns.numproc,
-                         nside=ns.nside, pixlist=pixlist, aprad=ns.aprad, extra=extra,
-                         bundlebricks=ns.bundlebricks, brickspersec=ns.brickspersec,
-                         dustdir=ns.dustdir, resolverands=not(ns.noresolve), seed=ns.seed)
+randres, randnorth, randsouth = select_randoms(
+    ns.surveydir, density=ns.density, numproc=ns.numproc, nside=ns.nside,
+    pixlist=pixlist, aprad=ns.aprad, extra=extra, bundlebricks=ns.bundlebricks,
+    seed=ns.seed, brickspersec=ns.brickspersec, dustdir=ns.dustdir)
 
 if ns.bundlebricks is None:
     # ADM extra header keywords for the output fits file.
     extra = {k: v for k, v in zip(["density", "aprad", "seed"],
                                   [ns.density, ns.aprad, ns.seed])}
 
+    randoms = [randres, randnorth, randsouth]
+    ress = [True, False, False]
+    norths =  [None, True, False]
 
-    nrands, outfile = io.write_randoms(
-        ns.dest, randoms, indir=ns.surveydir, hdr=hdr, nside=nside, extra=extra,
-        resolve=not(ns.noresolve), nsidefile=ns.nside, hpxlist=pixlist)
-    log.info('wrote file of {} randoms to {}...t = {:.1f}s'
-             .format(nrands, outfile, time()-start))
+    for random, res, north in zip(randoms, ress, norths):
+        nrands, outfile = io.write_randoms(
+            ns.dest, random, indir=ns.surveydir, hdr=hdr, nside=nside,
+            extra=extra, resolve=res, nsidefile=ns.nside, hpxlist=pixlist,
+            north=north)
+        log.info('wrote file of {} randoms to {}...t = {:.1f}s'
+                 .format(nrands, outfile, time()-start))

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -92,8 +92,14 @@ if not 'dr5' in ns.surveydir and not 'dr6' in ns.surveydir:
         hdrall = fitsio.read_header(fn, 1)
     except StopIteration:
         gen = iglob(os.path.join(ns.surveydir, "coadd", "*", "*", "*maskbits*"))
-        fn = next(gen)
-        hdrall = fitsio.read_header(fn, 0)
+        try:
+            fn = next(gen)
+            hdrall = fitsio.read_header(fn, 0)
+        except StopIteration:
+            log.critical(
+                "No coadd or north/coadd south/coadd directories in {}?!".format(
+                    ns.surveydir))
+            sys.exit(1)
     # ADM retrieve the record dictionary for the entire header.
     rmhdr = vars(hdrall)
     # ADM write only the maskbits-relevant headers to a new header.

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -8,6 +8,7 @@ from time import time
 start = time()
 
 from desitarget import io
+from desitarget.io import _check_both_set
 from desitarget.randoms import pixweight, select_randoms
 from glob import iglob
 import fitsio
@@ -60,7 +61,7 @@ ap.add_argument("--seed", type=int,
 
 ns = ap.parse_args()
 # ADM build the list of command line arguments as
-# ADM bundlefiles potentially needs to know about them.
+# ADM bundlebricks potentially needs to know about them.
 extra = " --numproc {}".format(ns.numproc)
 nsdict = vars(ns)
 for nskey in "aprad", "density", "seed":
@@ -81,6 +82,9 @@ if not os.path.exists(ns.surveydir):
 
 if ns.bundlebricks is None:
     log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-start))
+    # ADM formally writing pixelized files requires both the nside
+    # ADM and the list of healpixels to be set.
+    _check_both_set(ns.healpixels, ns.nside)
 
 # ADM go looking for a maskbits file to steal the header for the
 # ADM bit names. Try a couple of configurations (pre/post DR8).

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -8,7 +8,7 @@ from time import time
 start = time()
 
 from desitarget import io
-from desitarget.io import _check_both_set
+from desitarget.io import check_both_set
 from desitarget.randoms import pixweight, select_randoms
 from glob import iglob
 import fitsio
@@ -84,7 +84,7 @@ if ns.bundlebricks is None:
     log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-start))
     # ADM formally writing pixelized files requires both the nside
     # ADM and the list of healpixels to be set.
-    _check_both_set(ns.healpixels, ns.nside)
+    check_both_set(ns.healpixels, ns.nside)
 
 # ADM go looking for a maskbits file to steal the header for the
 # ADM bit names. Try a couple of configurations (pre/post DR8).

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -5,7 +5,7 @@ import os, sys
 from desitarget.skyutilities.legacypipe.util import LegacySurveyData
 from desitarget.skyfibers import select_skies, density_of_sky_fibers, get_brick_info
 from desitarget import io
-from desitarget.io import _check_both_set
+from desitarget.io import check_both_set
 from desitarget.geomask import bundle_bricks
 from desitarget.targets import resolve
 
@@ -112,7 +112,7 @@ else:
     log.info("running on {} processors".format(ns.numproc))
     # ADM formally writing pixelized files requires both the nside
     # ADM and the list of healpixels to be set.
-    _check_both_set(ns.healpixels, ns.nside)
+    check_both_set(ns.healpixels, ns.nside)
     # ADM run the main sky selection code over the passed surveys.
     skies = []
     for survey in surveys:

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -5,6 +5,7 @@ import os, sys
 from desitarget.skyutilities.legacypipe.util import LegacySurveyData
 from desitarget.skyfibers import select_skies, density_of_sky_fibers, get_brick_info
 from desitarget import io
+from desitarget.io import _check_both_set
 from desitarget.geomask import bundle_bricks
 from desitarget.targets import resolve
 
@@ -42,8 +43,8 @@ ap.add_argument("--apertures",
                 help='Aperture radii in arcseconds at which to derive flux measurements for each sky location (e.g, "0.75, 1.0"; defaults to "0.75")',
                 default="0.75")
 ap.add_argument('--nside', type=int,
-                help='Process sky locations in parallel in bricks that have centers within HEALPixels at this resolution (defaults to 2)',
-                default=2)
+                help='Process sky locations in parallel in bricks that have centers within HEALPixels at this resolution (defaults to None)',
+                default=None)
 ap.add_argument('--healpixels', 
                 help='HEALPixels (corresponding to nside) to process (e.g. "5,7,11"). If not passed, run all bricks in the Data Release',
                 default=None)
@@ -108,6 +109,10 @@ if ns.bundlebricks is not None:
     bundle_bricks(allpixnum, ns.bundlebricks, ns.nside, prefix='skies',
                   gather=False, surveydirs=drdirs, brickspersec=ns.brickspersec)
 else:
+    log.info("running on {} processors".format(ns.numproc))
+    # ADM formally writing pixelized files requires both the nside
+    # ADM and the list of healpixels to be set.
+    _check_both_set(ns.healpixels, ns.nside)
     # ADM run the main sky selection code over the passed surveys.
     skies = []
     for survey in surveys:

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -7,7 +7,7 @@ import numpy as np
 import fitsio
 
 from desitarget import io
-from desitarget.io import desitarget_version
+from desitarget.io import desitarget_version, _check_both_set
 from desitarget.cuts import select_targets
 from desitarget.brightmask import mask_targets
 from desitarget.QA import _parse_tcnames
@@ -121,6 +121,9 @@ if (np.max(data['PMRA']) == 0.) & np.any(data["RELEASE"] < 7000):
 
 if ns.bundlefiles is None:
     log.info("running on {} processors".format(ns.numproc))
+    # ADM formally writing pixelized files requires both the nside
+    # ADM and the list of healpixels to be set.
+    _check_both_set(ns.healpixels, ns.nside)
 
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels

--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -7,7 +7,7 @@ import numpy as np
 import fitsio
 
 from desitarget import io
-from desitarget.io import desitarget_version, _check_both_set
+from desitarget.io import desitarget_version, check_both_set
 from desitarget.cuts import select_targets
 from desitarget.brightmask import mask_targets
 from desitarget.QA import _parse_tcnames
@@ -123,7 +123,7 @@ if ns.bundlefiles is None:
     log.info("running on {} processors".format(ns.numproc))
     # ADM formally writing pixelized files requires both the nside
     # ADM and the list of healpixels to be set.
-    _check_both_set(ns.healpixels, ns.nside)
+    check_both_set(ns.healpixels, ns.nside)
 
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -7,7 +7,7 @@ import numpy as np
 import fitsio
 
 from desitarget import io
-from desitarget.io import desitarget_version
+from desitarget.io import desitarget_version, _check_both_set
 from desitarget.cuts import select_targets, qso_selection_options
 from desitarget.brightmask import mask_targets
 from desitarget.QA import _parse_tcnames
@@ -121,6 +121,9 @@ if (np.max(data['PMRA']) == 0.) & np.any(data["RELEASE"] < 7000):
 
 if ns.bundlefiles is None:
     log.info("running on {} processors".format(ns.numproc))
+    # ADM formally writing pixelized files requires both the nside
+    # ADM and the list of healpixels to be set.
+    _check_both_set(ns.healpixels, ns.nside)
 
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -7,7 +7,7 @@ import numpy as np
 import fitsio
 
 from desitarget import io
-from desitarget.io import desitarget_version, _check_both_set
+from desitarget.io import desitarget_version, check_both_set
 from desitarget.cuts import select_targets, qso_selection_options
 from desitarget.brightmask import mask_targets
 from desitarget.QA import _parse_tcnames
@@ -123,7 +123,7 @@ if ns.bundlefiles is None:
     log.info("running on {} processors".format(ns.numproc))
     # ADM formally writing pixelized files requires both the nside
     # ADM and the list of healpixels to be set.
-    _check_both_set(ns.healpixels, ns.nside)
+    check_both_set(ns.healpixels, ns.nside)
 
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels

--- a/bin/supplement_randoms
+++ b/bin/supplement_randoms
@@ -25,8 +25,8 @@ ap.add_argument("randomcat",
 ap.add_argument("dest",
                 help="Output directory for random catalog (the file name is built on-the-fly from other inputs)")
 ap.add_argument("--density", type=int,
-                help='Number of points per sq. deg. to generate (defaults to 10,000)',
-                default="10000")
+                help='Number of points per sq. deg. to generate (defaults to the value of DENSITY in the header of the "randomcat" input file)',
+                default=None)
 ap.add_argument("--numproc", type=int,
                 help='number of concurrent processes to use [{}]'.format(nproc),
                 default=nproc)
@@ -42,25 +42,53 @@ if not os.path.exists(ns.randomcat):
 
 log.info('running on {} processors...t = {:.1f}s'.format(ns.numproc, time()-start))
 
-# ADM just the filename for the input random catalog.
-rancatfn = os.path.basename(ns.randomcat)
-
-# ADM find the bricknames covered by the existing random catalog.
-donebns = fitsio.read(ns.randomcat, columns="BRICKNAME")
+# ADM check that the passed file looks like a random catalog.
+try:
+    ranhead = fitsio.read_header(ns.randomcat, "RANDOMS")
+except OSError:
+    msg = 'Passed input file does not appear to be a random catalog: {}'.format(ns.randomcat)
+    log.critical(msg)
+    sys.exit(1)
 
 # ADM determine the seed used for the existing random catalog.
 try:
-    seed = fitsio.read_header(ns.randomcat, "RANDOMS")["SEED"]
+    seed = ranhead["SEED"]
+    log.info('read seed of {} from {}'.format(seed, ns.randomcat))
 except KeyError:
     seed = 1
+    log.info('defaulting to a SEED of {}'.format(seed))
+
+# ADM grab the density used for the existing random catalog, if needed.
+if ns.density is None:
+    try:
+        density = ranhead["DENSITY"]
+        log.info('read DENSITY of {} from {}'.format(density, ns.randomcat))
+    except KeyError:
+        msg = 'No DENSITY keyword in header of: {}, so --density must be passed'.format(ns.randomcat)
+        log.critical(msg)
+        sys.exit(1)
+else:
+    density = ns.density
+
+# ADM find the bricknames covered by the existing random catalog.
+try:
+    donebns = fitsio.read(ns.randomcat, columns="BRICKNAME")
+except ValueError:
+    msg = 'No BRICKNAME column in passed input file: {}'.format(ns.randomcat)
+    log.critical(msg)
+    sys.exit(1)
 
 # ADM make the array of "zerod" bricks.
-randoms = supplement_randoms(donebns, density=ns.density, numproc=ns.numproc,
+randoms = supplement_randoms(donebns, density=density, numproc=ns.numproc,
                              dustdir=ns.dustdir, seed=seed)
+
+# ADM extra header keywords for the output fits file.
+extra = {k: v for k, v in zip(["density", "seed"],
+                              [density, seed])}
 
 # ADM write out the supplemental random catalog.
 nrands, outfile = io.write_randoms(ns.dest, randoms, indir=ns.randomcat,
-                                   supp=True, density=ns.density, seed=seed)
+                                   supp=True, extra=extra)
 
 log.info('wrote file of {} randoms to {}...t = {:.1f}s'
          .format(nrands, outfile, time()-start))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,17 @@ desitarget Change Log
 0.37.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Extra columns and features in the random catalogs [`PR #605`_]:
+    * Pass the randoms through the "finalize" and "make_mtl" functions:
+        * To populate columns needed to run fiberassign on the randoms.
+        * Addresses `issue #597`_.
+    * Add a realistic `TARGETID` (and `RELEASE, OBJID`) to the randoms.
+    * Recognize failure modes more quickly (and fail more quickly).
+    * Add `BRICKID` to the random catalogs.
+    * Write out both "resolve" and "noresolve" (North/South) catalogs.
+
+.. _`issue #597`: https://github.com/desihub/desitarget/issues/597
+.. _`PR #605`: https://github.com/desihub/desitarget/pull/605
 
 0.37.1 (2020-04-07)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desitarget Change Log
 0.37.2 (unreleased)
 -------------------
 
-* Extra columns and features in the random catalogs [`PR #605`_]:
+* Extra columns and features in the random catalogs [`PR #606`_]:
+    * Don't calculate APFLUX quantities if aprad=0 is passed.
     * Pass the randoms through the "finalize" and "make_mtl" functions:
         * To populate columns needed to run fiberassign on the randoms.
         * Addresses `issue #597`_.
@@ -15,7 +16,7 @@ desitarget Change Log
     * Write out both "resolve" and "noresolve" (North/South) catalogs.
 
 .. _`issue #597`: https://github.com/desihub/desitarget/issues/597
-.. _`PR #605`: https://github.com/desihub/desitarget/pull/605
+.. _`PR #606`: https://github.com/desihub/desitarget/pull/606
 
 0.37.1 (2020-04-07)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,13 +6,14 @@ desitarget Change Log
 -------------------
 
 * Extra columns and features in the random catalogs [`PR #606`_]:
+    * Better error messages and defaults for `bin/supplement_randoms`.
     * Don't calculate APFLUX quantities if aprad=0 is passed.
-    * Pass the randoms through the "finalize" and "make_mtl" functions:
+    * Pass the randoms through the `finalize` and `make_mtl` functions:
         * To populate columns needed to run fiberassign on the randoms.
         * Addresses `issue #597`_.
-    * Add a realistic `TARGETID` (and `RELEASE, OBJID`) to the randoms.
+    * Add the `BRICKID` column to the random catalogs.
+    * Also add a realistic `TARGETID` (and `RELEASE, BRICK_OBJID`).
     * Recognize failure modes more quickly (and fail more quickly).
-    * Add `BRICKID` to the random catalogs.
     * Write out both "resolve" and "noresolve" (North/South) catalogs.
 
 .. _`issue #597`: https://github.com/desihub/desitarget/issues/597

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -398,7 +398,7 @@ def read_data(targfile, mocks=False, downsample=None, header=False):
     truths, objtruths = None, None
 
     if mocks:
-        truthfile = targfile.replace('targets-', 'truth-') # fragile!
+        truthfile = targfile.replace('targets-', 'truth-')  # fragile!
 
         # ADM check that the truth file exists.
         if not os.path.exists(truthfile):

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -803,10 +803,20 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     print("wait")
     print("")
     if gather:
-        print("gather_targets '{}' $CSCRATCH/{}{}.fits {}".format(
-            # ADM prefix2 handles inputs that look like "sv1_targets".
-            ";".join(outfiles), prefix, drstr, prefix2.split("_")[-1]))
-    print("")
+        if prefix == 'randoms':
+            for region in "resolve/", "noresolve/north/", "noresolve/south/":
+                routfiles = [outfile.replace("randoms/", "randoms/{}".format(
+                    region)) for outfile in outfiles]
+                print("")
+                print(
+                    "gather_targets '{}' $CSCRATCH/{}{}.fits {}".format(
+                        ";".join(routfiles), prefix, drstr,
+                        prefix2.split("_")[-1]))
+        else:
+            print("gather_targets '{}' $CSCRATCH/{}{}.fits {}".format(
+                # ADM prefix2 handles inputs that look like "sv1_targets".
+                ";".join(outfiles), prefix, drstr, prefix2.split("_")[-1]))
+        print("")
 
     return
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -535,11 +535,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:
         # ADM hpxlist and nsidefile need to be passed together.
-        if hpxlist is None or nsidefile is None:
-            msg = 'Both hpxlist (={}) and nsidefile (={}) need to be set' \
-                .format(hpxlist, nsidefile)
-            log.critical(msg)
-            raise ValueError(msg)
+        _check_both_set(hpxlist, nsidefile)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
         # ADM warn if we've stored a pixel string that is too long.
@@ -875,11 +871,7 @@ def write_skies(targdir, data, indir=None, indir2=None, supp=False,
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:
         # ADM hpxlist and nsidefile need to be passed together.
-        if hpxlist is None or nsidefile is None:
-            msg = 'Both hpxlist (={}) and nsidefile (={}) need to be set' \
-                .format(hpxlist, nsidefile)
-            log.critical(msg)
-            raise ValueError(msg)
+        _check_both_set(hpxlist, nsidefile)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
         # ADM warn if we've stored a pixel string that is too long.
@@ -979,11 +971,7 @@ def write_gfas(targdir, data, indir=None, indir2=None, nside=None,
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:
         # ADM hpxlist and nsidefile need to be passed together.
-        if hpxlist is None or nsidefile is None:
-            msg = 'Both hpxlist (={}) and nsidefile (={}) need to be set' \
-                .format(hpxlist, nsidefile)
-            log.critical(msg)
-            raise ValueError(msg)
+        _check_both_set(hpxlist, nsidefile)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
         # ADM warn if we've stored a pixel string that is too long.
@@ -1090,11 +1078,7 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:
         # ADM hpxlist and nsidefile need to be passed together.
-        if hpxlist is None or nsidefile is None:
-            msg = 'Both hpxlist (={}) and nsidefile (={}) need to be set' \
-                .format(hpxlist, nsidefile)
-            log.critical(msg)
-            raise ValueError(msg)
+        _check_both_set(hpxlist, nsidefile)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
         # ADM warn if we've stored a pixel string that is too long.
@@ -2226,5 +2210,15 @@ def _check_hpx_length(hpxlist, length=68, warning=False):
         if warning:
             log.warning(msg)
         else:
+            log.critical(msg)
+            raise ValueError(msg)
+
+
+def _check_both_set(hpxlist, nside):
+    """Check that if one of two variables is set, the other is too"""
+    if hpxlist is not None or nside is not None:
+        if hpxlist is None or nside is None:
+            msg = 'Both hpxlist (={}) and nside (={}) need to be set' \
+                .format(hpxlist, nside)
             log.critical(msg)
             raise ValueError(msg)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -535,7 +535,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:
         # ADM hpxlist and nsidefile need to be passed together.
-        _check_both_set(hpxlist, nsidefile)
+        check_both_set(hpxlist, nsidefile)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
         # ADM warn if we've stored a pixel string that is too long.
@@ -871,7 +871,7 @@ def write_skies(targdir, data, indir=None, indir2=None, supp=False,
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:
         # ADM hpxlist and nsidefile need to be passed together.
-        _check_both_set(hpxlist, nsidefile)
+        check_both_set(hpxlist, nsidefile)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
         # ADM warn if we've stored a pixel string that is too long.
@@ -971,7 +971,7 @@ def write_gfas(targdir, data, indir=None, indir2=None, nside=None,
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:
         # ADM hpxlist and nsidefile need to be passed together.
-        _check_both_set(hpxlist, nsidefile)
+        check_both_set(hpxlist, nsidefile)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
         # ADM warn if we've stored a pixel string that is too long.
@@ -1064,7 +1064,7 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
     # ADM record whether this file has been limited to only certain HEALPixels.
     if hpxlist is not None or nsidefile is not None:
         # ADM hpxlist and nsidefile need to be passed together.
-        _check_both_set(hpxlist, nsidefile)
+        check_both_set(hpxlist, nsidefile)
         hdr['FILENSID'] = nsidefile
         hdr['FILENEST'] = True
         # ADM warn if we've stored a pixel string that is too long.
@@ -2219,7 +2219,7 @@ def _check_hpx_length(hpxlist, length=68, warning=False):
             raise ValueError(msg)
 
 
-def _check_both_set(hpxlist, nside):
+def check_both_set(hpxlist, nside):
     """Check that if one of two variables is set, the other is too"""
     if hpxlist is not None or nside is not None:
         if hpxlist is None or nside is None:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1026,11 +1026,11 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
         conjunction with `nsidefile`.
     resolve : :class:`bool`, optional, defaults to ``True``
         Written to the output file header as `RESOLVE`. If ``True``
-        (``False``) output directory includes \resolve\ (\noresolve).
+        (``False``) output directory includes "resolve" ("noresolve").
     north : :class:`bool`, optional
         If passed (and not ``None``), then, if ``True`` (``False``),
         REGION=north (south) is written to the output header and the
-        output directory name is appended by \north\ (\south\).
+        output directory name is appended by "north" ("south").
     extra : :class:`dict`, optional
         If passed (and not ``None``), write these extra dictionary keys
         and values to the output header.
@@ -1056,7 +1056,7 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
             drint = None
 
     # ADM whether this is a north-specific or south-specific file.
-    region=None
+    region = None
     if north is not None:
         region = ["south", "north"][north]
         hdr["REGION"] = region

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -288,7 +288,7 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
     aprad : :class:`float`, optional, defaults to 0.75
         Radii in arcsec of aperture for which to derive sky/fiber fluxes.
         Defaults to the DESI fiber radius. If aprad < 1e-8 is passed,
-        the code to produce these values is skipped, as a speed-up, and 
+        the code to produce these values is skipped, as a speed-up, and
         `apflux_` output values are set to zero.
 
     Returns
@@ -590,7 +590,7 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
     aprad : :class:`float`, optional, defaults to 0.75
         Radii in arcsec of aperture for which to derive sky/fiber fluxes.
         Defaults to the DESI fiber radius. If aprad < 1e-8 is passed,
-        the code to produce these values is skipped, as a speed-up, and 
+        the code to produce these values is skipped, as a speed-up, and
         `apflux_` output values are set to zero.
     zeros : :class:`bool`, optional, defaults to ``False``
         If ``True`` don't look up pixel-level info for the brick, just
@@ -1299,7 +1299,7 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
     aprad : :class:`float`, optional, defaults to 0.75
         Radii in arcsec of aperture for which to derive sky/fiber fluxes.
         Defaults to the DESI fiber radius. If aprad < 1e-8 is passed,
-        the code to produce these values is skipped, as a speed-up, and 
+        the code to produce these values is skipped, as a speed-up, and
         `apflux_` output values are set to zero.
     seed : :class:`int`, optional, defaults to 1
         Random seed to use when shuffling across brick boundaries.

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1158,7 +1158,7 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
         # ADM make every random the highest-priority target.
         dt = np.zeros_like(randoms["RA"]) + bitperprio[np.max(list(bitperprio))]
 
-        return finalize(randoms, dt, dt, dt, randoms=True)
+        return finalize(randoms, dt, dt*0, dt*0, randoms=True)
 
     # ADM this is just to count bricks in _update_status.
     nbrick = np.zeros((), dtype='i8')

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1346,6 +1346,19 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
                                     drdir=drdir, density=density,
                                     dustdir=dustdir, aprad=aprad, seed=seed)
 
+    # ADM add columns that are added by MTL.
+    from desitarget.mtl import make_mtl
+    randoms = np.array(make_mtl(randoms, obscon="DARK"))
+
+    # ADM add OBCONDITIONS that will work for any obscon.
+    from desitarget.targetmask import obsconditions as obscon
+    randoms["OBSCONDITIONS"] = obscon.mask("|".join(obscon.names()))
+
+    # ADM add a random SUBPRIORITY.
+    np.random.seed(616+seed)
+    nrands = len(randoms)
+    randoms["SUBPRIORITY"] = np.random.random(nrands)
+
     # ADM one last shuffle to randomize across brick boundaries.
     np.random.seed(615+seed)
     np.random.shuffle(randoms)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -293,13 +293,14 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
     -------
     :class:`dictionary`
        The number of observations (`nobs_x`), PSF depth (`psfdepth_x`)
-       Galaxy depth (`galdepth_x`), PSF size (`psfsize_x`), sky
+       galaxy depth (`galdepth_x`), PSF size (`psfsize_x`), sky
        background (`apflux_x`) and inverse variance (`apflux_ivar_x`)
        at each passed position in each band x=g,r,z. Plus, the
        `psfdepth_w1` and `_w2` depths and the `maskbits`, `wisemask_w1`
        and `_w2` information at each passed position for the brick.
-       Also adds a unique `objid` for each random, and a `release` if
-       a release number can be determined from the input `drdir`.
+       Also adds a unique `objid` for each random, a `release` if
+       a release number can be determined from the input `drdir`, and
+       the photometric system `photsys` ("N" or "S" for north or south).
 
     Notes
     -----
@@ -621,6 +622,8 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
             WISEMASK_W2: mask info. See header of extension 3 of e.g.
               'coadd/132/1320p317/legacysurvey-1320p317-maskbits.fits.fz'
             EBV: E(B-V) at this location from the SFD dust maps.
+            PHOTSYS: resolved north/south ('N' for an MzLS/BASS location,
+              'S' for a DECaLS location).
     """
     # ADM only intended to work on one brick, so die for larger arrays.
     if not isinstance(brickname, str):
@@ -1125,7 +1128,9 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
     -------
     :class:`~numpy.ndarray`
         a numpy structured array with the same columns as returned by
-        :func:`~desitarget.randoms.get_quantities_in_a_brick`.
+        :func:`~desitarget.randoms.get_quantities_in_a_brick`. If
+        `zeros` is ``False`` additional columns are returned, as added
+        by :func:`~desitarget.targets.finalize`.
 
     Notes
     -----
@@ -1152,6 +1157,8 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
             density=density, dustdir=dustdir, aprad=aprad, zeros=zeros,
             seed=seed)
 
+        if zeros:
+            return randoms
         return _finalize_randoms(randoms)
 
     # ADM add the standard "final" columns that are also added in targeting.

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -32,7 +32,9 @@ from desiutil.log import get_logger
 
 # ADM set up the Legacy Surveys bricks objects.
 bricks = brick.Bricks(bricksize=0.25)
+# ADM make a BRICKNAME->BRICKID look-up table for speed.
 bricktable = bricks.to_table()
+bricklookup = {bt["BRICKNAME"]: bt["BRICKID"] for bt in bricktable}
 
 # ADM set up the default logger from desiutil.
 log = get_logger()
@@ -660,8 +662,7 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
                 qinfo[col.upper()] = qdict[col]
 
     # ADM add the RAs/Decs, brick id and brick name.
-    bricktable = bricks.to_table()
-    brickid = bricktable[bricktable["BRICKNAME"] == brickname]["BRICKID"]
+    brickid = bricklookup[brickname]
     qinfo["RA"], qinfo["DEC"] = ras, decs
     qinfo["BRICKNAME"], qinfo["BRICKID"] = brickname, brickid
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -23,9 +23,6 @@ from desitarget.targets import resolve, main_cmx_or_sv, finalize
 from desitarget.skyfibers import get_brick_info
 from desitarget.io import read_targets_in_box, target_columns_from_header
 from desitarget.targetmask import desi_mask as dMx
-# ADM a look-up dictionary that converts priorities to bit-names.
-bitperprio = {dMx[bn].priorities["UNOBS"]: dMx[bn] for bn in dMx.names()
-              if len(dMx[bn].priorities) > 0}
 
 # ADM the parallelization script.
 from desitarget.internal import sharedmem
@@ -33,6 +30,10 @@ from desitarget.internal import sharedmem
 # ADM set up the DESI default logger.
 from desiutil import brick
 from desiutil.log import get_logger
+
+# ADM a look-up dictionary that converts priorities to bit-names.
+bitperprio = {dMx[bn].priorities["UNOBS"]: dMx[bn] for bn in dMx.names()
+              if len(dMx[bn].priorities) > 0}
 
 # ADM set up the Legacy Surveys bricks objects.
 bricks = brick.Bricks(bricksize=0.25)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -286,8 +286,10 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
        The root directory pointing to a Data Release from the Legacy Surveys
        e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
     aprad : :class:`float`, optional, defaults to 0.75
-        Radii in arcsec of aperture for which to derive sky fluxes
-        defaults to the DESI fiber radius.
+        Radii in arcsec of aperture for which to derive sky/fiber fluxes.
+        Defaults to the DESI fiber radius. If aprad < 1e-8 is passed,
+        the code to produce these values is skipped, as a speed-up, and 
+        `apflux_` output values are set to zero.
 
     Returns
     -------
@@ -338,7 +340,8 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
         for qin, qout, qform in qnames:
             fn = fileform.format(brickname, qin, filt, extn)
             # ADM only process the WCS if there's a file for this filter.
-            if os.path.exists(fn):
+            # ADM also skip calculating aperture fluxes if aprad ~ 0.
+            if os.path.exists(fn) and not (qout == 'apflux' and aprad < 1e-8):
                 img = fits.open(fn)[extn_nb]
                 if not iswcs:
                     # ADM store the instrument name, if it isn't stored.
@@ -585,8 +588,10 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
         The root directory pointing to SFD dust maps. If not
         sent the code will try to use $DUST_DIR+'/maps' before failing.
     aprad : :class:`float`, optional, defaults to 0.75
-        Radii in arcsec of aperture for which to derive sky fluxes
-        defaults to the DESI fiber radius.
+        Radii in arcsec of aperture for which to derive sky/fiber fluxes.
+        Defaults to the DESI fiber radius. If aprad < 1e-8 is passed,
+        the code to produce these values is skipped, as a speed-up, and 
+        `apflux_` output values are set to zero.
     zeros : :class:`bool`, optional, defaults to ``False``
         If ``True`` don't look up pixel-level info for the brick, just
         return zeros. The only quantities populated are those that don't
@@ -614,7 +619,9 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
             PSFDEPTH_W1, W2: (PSF) depth in W1, W2 (AB mag system).
             PSFSIZE_G, R, Z: Weighted average PSF FWHM (arcsec).
             APFLUX_G, R, Z: Sky background extracted in `aprad`.
+                Will be zero if `aprad` < 1e-8 is passed.
             APFLUX_IVAR_G, R, Z: Inverse variance of sky background.
+                Will be zero if `aprad` < 1e-8 is passed.
             MASKBITS: mask information. See header of extension 1 of e.g.
               'coadd/132/1320p317/legacysurvey-1320p317-maskbits.fits.fz'
             WISEMASK_W1: mask info. See header of extension 2 of e.g.
@@ -1290,8 +1297,10 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
         The root directory pointing to SFD dust maps. If None the code
         will try to use $DUST_DIR+'maps') before failing.
     aprad : :class:`float`, optional, defaults to 0.75
-        Radii in arcsec of aperture for which to derive sky fluxes
-        defaults to the DESI fiber radius.
+        Radii in arcsec of aperture for which to derive sky/fiber fluxes.
+        Defaults to the DESI fiber radius. If aprad < 1e-8 is passed,
+        the code to produce these values is skipped, as a speed-up, and 
+        `apflux_` output values are set to zero.
     seed : :class:`int`, optional, defaults to 1
         Random seed to use when shuffling across brick boundaries.
         The actual np.random.seed defaults to 615+`seed`. See also use

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1309,7 +1309,8 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
         bundle_bricks(allpixnum, bundlebricks, nside,
                       brickspersec=brickspersec, prefix='randoms',
                       surveydirs=[drdir], extra=extra, seed=seed)
-        return
+        # ADM because the broader function returns three outputs.
+        return None, None, None
 
     # ADM restrict to only bricks in a set of HEALPixels, if requested.
     if pixlist is not None:

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -950,7 +950,7 @@ def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
 
 
 def select_skies(survey, numproc=16, nskiespersqdeg=None, bands=['g', 'r', 'z'],
-                 apertures_arcsec=[0.75], nside=2, pixlist=None, writebricks=False):
+                 apertures_arcsec=[0.75], nside=None, pixlist=None, writebricks=False):
     """Generate skies in parallel for bricks in a Legacy Surveys DR.
 
     Parameters
@@ -967,7 +967,7 @@ def select_skies(survey, numproc=16, nskiespersqdeg=None, bands=['g', 'r', 'z'],
         List of bands to be used to define good sky locations.
     apertures_arcsec : :class:`list`, optional, defaults to [0.75]
         Radii in arcsec of apertures for which to derive flux at a sky location.
-    nside : :class:`int`, optional, defaults to nside=2 (859.4 sq. deg.)
+    nside : :class:`int`, optional, defaults to ``None``
         The HEALPixel nside number to be used with the `pixlist` input.
     pixlist : :class:`list` or `int`, optional, defaults to None
         Bricks will only be processed if the CENTER of the brick lies within the bounds of

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -335,7 +335,7 @@ def make_skies_for_a_brick(survey, brickname, nskiespersqdeg=None, bands=['g', '
     # ADM add target bit columns to the output array, note that mws_target
     # ADM and bgs_target should be zeros for all sky objects.
     dum = np.zeros_like(desi_target)
-    skies = finalize(skies, desi_target, dum, dum, sky=1)
+    skies = finalize(skies, desi_target, dum, dum, sky=True)
 
     if write:
         outfile = survey.find_file('skies', brick=brickname)
@@ -942,7 +942,7 @@ def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
     desi_target = np.zeros(nskies, dtype='>i8')
     desi_target |= desi_mask.SUPP_SKY
     dum = np.zeros_like(desi_target)
-    supp = finalize(supp, desi_target, dum, dum, sky=1)
+    supp = finalize(supp, desi_target, dum, dum, sky=True)
 
     log.info('Done...t={:.1f}s'.format(time()-start))
 

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -852,7 +852,7 @@ def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
              .format(mindec, time()-start))
     from desitarget.randoms import randoms_in_a_brick_from_edges
     ras, decs = randoms_in_a_brick_from_edges(
-        0., 360., mindec, 90., density=nskiespersqdeg, wrap=False)
+        0., 360., mindec, 90., density=nskiespersqdeg, wrap=False, seed=538)
 
     # ADM limit randoms by HEALPixel, if requested.
     if pixlist is not None:

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -748,12 +748,6 @@ def finalize(targets, desi_target, bgs_target, mws_target,
     # ADM set the OBSCONDITIONS.
     done["OBSCONDITIONS"] = set_obsconditions(done)
 
-    # ADM we only need the DESI_TARGET-like column for randoms.
-    if randoms:
-        colnames = np.array(colnames)[
-            np.array(['BGS_TARGET' in i or 'MWS_TARGET' in i for i in colnames])]
-        done = rfn.drop_fields(done, colnames)
-
     # ADM some final checks that the targets conform to expectations...
     # ADM check that each target has a unique ID.
     if len(done["TARGETID"]) != len(set(done["TARGETID"])):

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -41,8 +41,8 @@ def encode_targetid(objid=None, brickid=None, release=None,
         'data/targetmask.yaml'. Or, if < 1000 and `sky` is not
         ``None``, the HEALPixel processing number for SUPP_SKIES.
     mock : :class:`int` or :class:`~numpy.ndarray`, optional
-        1 if this object is a mock object (generated from
-        mocks, not from real survey data), 0 otherwise
+        1 if this object is a mock object (generated from mocks or from
+        a random catalog, not from real survey data), 0 otherwise
     sky : :class:`int` or :class:`~numpy.ndarray`, optional
         1 if this object is a blank sky object, 0 otherwise
     gaiadr : :class:`int` or :class:`~numpy.ndarray`, optional
@@ -147,8 +147,8 @@ def decode_targetid(targetid):
         'data/targetmask.yaml'. Or, if < 1000 and `sky` is not
         ``None``, the HEALPixel processing number for SUPP_SKIES.
     :class:`int` or :class:`~numpy.ndarray`
-        1 if this object is a mock object (generated from
-        mocks, not from real survey data), 0 otherwise
+        1 if this object is a mock object (generated from mocks or from
+        a random catalog, not from real survey data), 0 otherwise
     :class:`int` or :class:`~numpy.ndarray`
         1 if this object is a blank sky object, 0 otherwise
     :class:`int` or :class:`~numpy.ndarray`
@@ -614,8 +614,8 @@ def resolve(targets):
 
 
 def finalize(targets, desi_target, bgs_target, mws_target,
-             sky=0, survey='main', darkbright=False, gaiadr=None,
-             targetid=None):
+             sky=False, randoms=False, survey='main', darkbright=False,
+             gaiadr=None, targetid=None):
     """Return new targets array with added/renamed columns
 
     Parameters
@@ -628,8 +628,10 @@ def finalize(targets, desi_target, bgs_target, mws_target,
         1D array of target selection bit flags.
     mws_target : :class:`~numpy.ndarray`
         1D array of target selection bit flags.
-    sky : :class:`int`, defaults to 0
-        Pass `1` to indicate these are blank sky targets, `0` otherwise.
+    sky : :class:`bool`, defaults to ``False``
+        Pass ``True`` for sky targets, ``False`` otherwise.
+    randoms : :class:`bool`, defaults to ``False``
+        ``True`` if `targets` is a random catalog, ``False`` otherwise.
     survey : :class:`str`, defaults to `main`
         Specifies which target masks yaml file to use. Options are `main`,
         `cmx` and `svX` (where X = 1, 2, 3 etc.) for the main survey,
@@ -685,13 +687,15 @@ def finalize(targets, desi_target, bgs_target, mws_target,
             targetid = encode_targetid(objid=targets['GAIA_OBJID'],
                                        brickid=targets['GAIA_BRICKID'],
                                        release=0,
-                                       sky=sky,
+                                       mock=int(randoms),
+                                       sky=int(sky),
                                        gaiadr=gaiadr)
         else:
             targetid = encode_targetid(objid=targets['BRICK_OBJID'],
                                        brickid=targets['BRICKID'],
                                        release=targets['RELEASE'],
-                                       sky=sky)
+                                       mock=int(randoms),
+                                       sky=int(sky))
     assert ntargets == len(targetid)
 
     nodata = np.zeros(ntargets, dtype='int')-1
@@ -744,6 +748,12 @@ def finalize(targets, desi_target, bgs_target, mws_target,
     # ADM set the OBSCONDITIONS.
     done["OBSCONDITIONS"] = set_obsconditions(done)
 
+    # ADM we only need the DESI_TARGET-like column for randoms.
+    if randoms:
+        colnames = np.array(colnames)[
+            np.array(['BGS_TARGET' in i or 'MWS_TARGET' in i for i in colnames])]
+        done = rfn.drop_fields(done, colnames)
+
     # ADM some final checks that the targets conform to expectations...
     # ADM check that each target has a unique ID.
     if len(done["TARGETID"]) != len(set(done["TARGETID"])):
@@ -752,7 +762,7 @@ def finalize(targets, desi_target, bgs_target, mws_target,
         raise AssertionError(msg)
 
     # ADM check all LRG targets have LRG_1PASS/2PASS set.
-    # ADM we've moved away from LRG PASSes this so deprecate for now.
+    # ADM we've moved away from LRG PASSes so deprecate this for now.
 #    if survey == 'main':
 #        lrgset = done["DESI_TARGET"] & desi_mask.LRG != 0
 #        pass1lrgset = done["DESI_TARGET"] & desi_mask.LRG_1PASS != 0


### PR DESCRIPTION
This PR adds extra columns and features to the random catalogs. It includes:
- Better error messages and default behavior for `bin/supplement_randoms`.
- Don't calculate the `APFLUX` (and `APFLUX_IVAR`) quantities if `aprad=0` is passed (as a speed-up).
- Pass the randoms through the `desitarget.targets.finalize()` and `desitarget.mtl.make_mtl()` functions to add the extra columns needed to run `fiberassign` on the randoms.
- Add the `BRICKID` column to the random catalogs, for easier indexing on bricks.
- Add a realistic `TARGETID` column to the randoms (and the associated `RELEASE` and `BRICK_OBJID` columns).
- Recognize failure modes more quickly (and fails more quickly), particularly in the `select_randoms` executable.
- Always write out both the `resolve` and the `noresolve` catalogs, so that separate random catalogs are always available for the northern and southern imaging.

Addresses #597.