### PR TITLE
Updates for latest versions of the DR9 imaging (dr9f/dr9g)

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,12 +5,13 @@ desitarget Change Log
 0.37.4 (unreleased)
 -------------------
 
+* Minor updates for latest DR9 imaging versions (dr9f/dr9g) [`PR #607`_].
 * Fixes a typo in the priority of MWS_WD_SV targets [`PR #601`_].
 * Fixes calc_priority logic for MWS CMX targets [`PR #601`_].
-* Separates special case in calc_priority for CMX into a separate function [`PR #601`_].
-* Alter cmx targetmask such taht obsconditionsc can be used to work around MWS/BGS
-  conflicts on MWS CMX tiles [`PR #601`_].
-* Updates test_priorities to deal with new scheme for MWS CMX targets [`PR #601`_].
+* Separate calc_priority() for CMX into a separate function [`PR #601`_].
+* Alter cmx targetmask such that obsconditions can be used to work
+  around MWS/BGS conflicts on MWS CMX tiles [`PR #601`_].
+* Update test_priorities() for new MWS CMX targets scheme [`PR #601`_].
 * Adds SV0_MWS_FAINT bit [`PR #601`_].
 * Extra columns and features in the random catalogs [`PR #606`_]:
     * Better error messages and defaults for `bin/supplement_randoms`.
@@ -26,6 +27,7 @@ desitarget Change Log
 .. _`PR #601`: https://github.com/desihub/desitarget/pull/601
 .. _`issue #597`: https://github.com/desihub/desitarget/issues/597
 .. _`PR #606`: https://github.com/desihub/desitarget/pull/606
+.. _`PR #607`: https://github.com/desihub/desitarget/pull/607
 
 0.37.3 (2020-04-15)
 -------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -35,7 +35,7 @@ log = get_logger()
 # ADM Data Model (e.g. https://desi.lbl.gov/trac/wiki/DecamLegacy/DR4sched).
 # ADM 7999 were the dr8a test reductions, for which only 'S' surveys were processed.
 releasedict = {3000: 'S', 4000: 'N', 5000: 'S', 6000: 'N', 7000: 'S', 7999: 'S',
-               8000: 'S', 8001: 'N', 9000: 'S', 9001: 'N'}
+               8000: 'S', 8001: 'N', 9000: 'S', 9001: 'N', 9002: 'S', 9003: 'N'}
 
 # ADM This is an empty array of most of the TS data model columns and
 # ADM dtypes. Note that other columns are added in read_tractor and
@@ -67,10 +67,10 @@ basetsdatamodel = np.array([], dtype=[
 
 # ADM columns that are new for the DR9 data model.
 dr9addedcols = np.array([], dtype=[
-    ('LC_FLUX_W1', '>f4', (13,)), ('LC_FLUX_W2', '>f4', (13,)),
-    ('LC_FLUX_IVAR_W1', '>f4', (13,)), ('LC_FLUX_IVAR_W2', '>f4', (13,)),
-    ('LC_NOBS_W1', '>i2', (13,)), ('LC_NOBS_W2', '>i2', (13,)),
-    ('LC_MJD_W1', '>f8', (13,)), ('LC_MJD_W2', '>f8', (13,)),
+    ('LC_FLUX_W1', '>f4', (15,)), ('LC_FLUX_W2', '>f4', (15,)),
+    ('LC_FLUX_IVAR_W1', '>f4', (15,)), ('LC_FLUX_IVAR_W2', '>f4', (15,)),
+    ('LC_NOBS_W1', '>i2', (15,)), ('LC_NOBS_W2', '>i2', (15,)),
+    ('LC_MJD_W1', '>f8', (15,)), ('LC_MJD_W2', '>f8', (15,)),
     ('SHAPE_R', '>f4'), ('SHAPE_E1', '>f4'), ('SHAPE_E2', '>f4'),
     ('SHAPE_R_IVAR', '>f4'), ('SHAPE_E1_IVAR', '>f4'), ('SHAPE_E2_IVAR', '>f4'),
     ('SERSIC', '>f4'), ('SERSIC_IVAR', '>f4')

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -228,8 +228,7 @@ def _pre_or_post_dr8(drdir):
     if os.path.exists(os.path.join(drdir, "coadd")):
         drdirs = [drdir]
     else:
-        wcoadd = glob(os.path.join(drdir, '*', "coadd"))
-        drdirs = [os.path.dirname(dd) for dd in wcoadd]
+        drdirs = [os.path.join(drdir, region) for region in ["north", "south"]]
 
     return drdirs
 


### PR DESCRIPTION
This PR makes updates to facilitate running the targets and randoms using the latest versions of the DR9 imaging reductions (`dr9f`/`dr9g`). The updates are minor and reflect small changes to the DR9 imaging data model.

As these updates are minor, I'll merge them once tests pass so I can tag a version of `desitarget` to make targets and randoms for the latest DR9 imaging runs.