### PR TITLE
Maskbits

### DIFF
--- a/bin/mpi_select_mock_targets
+++ b/bin/mpi_select_mock_targets
@@ -92,13 +92,13 @@ if rank == 0:
     keep = list()
     for i, pixnum in enumerate(pixels):
         truthspecfile = mockio.findfile('truth', args.nside, pixnum,
-                                        basedir=args.output_dir)
+                                        basedir=args.output_dir, obscon='dark')
         if not os.path.exists(truthspecfile):
             keep.append(i)
 
     log.info('{}/{} pixels remaining to do'.format(len(keep), len(pixels)))
     pixels = pixels[keep]
-
+    
     #- pre-create output directories
     for pixnum in pixels:
         outdir = os.path.dirname(mockio.findfile('blat', args.nside, pixnum,

--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -69,19 +69,19 @@ if args.healpixels is None:
     healpixels = desimodel.footprint.tiles2pix(args.nside, tiles)
 else:
     healpixels = np.array(args.healpixels)
-
+    
 if args.overwrite:
     log.info('Processing {} pixel(s).'.format(len(healpixels)))
 else:
     keep = list()
     for i, pixnum in enumerate(healpixels):
-        truthfile = mockio.findfile('truth', args.nside, pixnum, basedir=args.output_dir)
+        truthfile = mockio.findfile('truth', args.nside, pixnum, basedir=args.output_dir, obscon='dark')
         if not os.path.exists(truthfile):
             keep.append(i)
 
-    log.info('{}/{} pixels remaining to do'.format(len(keep), len(healpixels)))
+    log.info('{}/{} pixels remaining to do. {}'.format(len(keep), len(healpixels), healpixels[keep]))
     healpixels = healpixels[keep]
-
+    
 if args.join:
     from desitarget.mock.build import join_targets_truth
     join_targets_truth(mockdir=args.output_dir, outdir=args.output_dir, overwrite=args.overwrite)

--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -103,6 +103,14 @@ if 'legacy_dir' in params.keys():
   # wget https://portal.nersc.gov/project/cosmo/data/legacysurvey/dr8/north/coadd/338/3380p295/    
   log.info('Assuming maskbits & depths based on LEGACYDIR={}'.format(params['legacy_dir']))
 
+  # Check the survey bricks file exists.  We'll use this to ensure that the local files are compelte for
+  # the healpixels being requested.  
+  legacy_dir = params['legacy_dir']
+  allbricks  = legacy_dir + '/survey-bricks.fits.gz'
+
+  if not os.path.isfile(allbricks):
+      raise  RuntimeError('survey-bricks.fits.gz is required under legacy_dir.')
+  
 else:
   params['legacy_dir'] = None
     

--- a/bin/select_mock_targets
+++ b/bin/select_mock_targets
@@ -96,6 +96,18 @@ log.info('Reading configuration file {}'.format(args.config))
 with open(args.config, 'r') as pfile:
     params = yaml.safe_load(pfile)
 
+# Set up MASKBITS lookup. Logic check for the necessary files, if not there wget the per brick files for
+# all overlapping pixels. 
+if 'legacy_dir' in params.keys():    
+  # E.g. global/project/projectdirs/cosmo/data/legacysurvey/dr8/
+  # wget https://portal.nersc.gov/project/cosmo/data/legacysurvey/dr8/north/coadd/338/3380p295/    
+  log.info('Assuming maskbits & depths based on LEGACYDIR={}'.format(params['legacy_dir']))
+
+else:
+  params['legacy_dir'] = None
+    
+  log.info('Assuming simple homogeneous depths & no masking.')
+
 log.info('Calling targets_truth with survey={} at {}'.format(args.survey, time.asctime()))
 targets_truth(params, healpixels=healpixels, nside=args.nside, seed=args.seed, 
               output_dir=args.output_dir, nproc=args.nproc, verbose=args.verbose,

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -141,7 +141,7 @@ def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
     magcut = params.get('magcut')
     nside_galaxia = params.get('nside_galaxia')
     calib_only = params.get('calib_only', False)
-
+    
     # QSO/Lya parameters
     nside_lya = params.get('nside_lya')
     zmin_lya = params.get('zmin_lya')
@@ -152,7 +152,7 @@ def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
     add_dla = params.get('add_dla', False)
     add_metals = params.get('add_metals', False)
     add_lyb = params.get('add_lyb', False)
-
+    
     if 'density' in params.keys():
         mock_density = True
     else:
@@ -160,14 +160,17 @@ def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
 
     log.info('Target: {}, type: {}, format: {}, mockfile: {}'.format(
         target_name, target_type, mockformat, mockfile))
-
+    
     if MakeMock is None:
         MakeMock = getattr(mockmaker, '{}Maker'.format(target_name))(
             seed=seed, nside_chunk=nside_chunk, calib_only=calib_only,
             use_simqso=use_simqso, sqmodel=sqmodel, balprob=balprob, add_dla=add_dla,
-            add_metals=add_metals, add_lyb=add_lyb)
+            add_metals=add_metals, add_lyb=add_lyb, legacy_dir=legacy_dir)
+        
     else:
         MakeMock.seed = seed # updated seed
+
+    print(target_name, MakeMock.legacy_dir)
         
     data = MakeMock.read(mockfile=mockfile, mockformat=mockformat,
                          healpixels=healpixels, nside=nside,
@@ -176,7 +179,7 @@ def read_mock(params, log=None, target_name='', seed=None, healpixels=None,
                          nside_galaxia=nside_galaxia, mock_density=mock_density)
     if not bool(data):
         return data, MakeMock
-
+    
     # Add the information we need to incorporate density fluctuations.
     if 'density' in params.keys():
         if 'MOCK_DENSITY' not in data.keys():
@@ -854,11 +857,13 @@ def targets_truth(params, healpixels=None, nside=None, output_dir='.',
         add_dla = params['targets'][target_name].get('add_dla', False)
         add_metals = params['targets'][target_name].get('add_metals', False)
         add_lyb = params['targets'][target_name].get('add_lyb', False)
+        legacy_dir = params['legacy_dir']
+        
         AllMakeMock.append(getattr(mockmaker, '{}Maker'.format(target_name))(
             seed=seed, nside_chunk=nside_chunk, calib_only=calib_only,
             use_simqso=use_simqso, sqmodel=sqmodel, balprob=balprob, add_dla=add_dla,
             add_metals=add_metals, add_lyb=add_lyb, no_spectra=no_spectra,
-            survey=survey))
+            survey=survey, legacy_dir=legacy_dir))
 
     # Are we adding contaminants?  If so, cache the relevant classes here.
     if 'contaminants' in params.keys():
@@ -870,7 +875,7 @@ def targets_truth(params, healpixels=None, nside=None, output_dir='.',
             star_name, _ = list(params['contaminants']['stars'].items())[0]
             ContamStarsMock = getattr(mockmaker, '{}Maker'.format(star_name))(
                 seed=seed, nside_chunk=nside_chunk, no_spectra=no_spectra,
-                survey=survey)
+                survey=survey, legacy_dir=legacy_dir)
         else:
             ContamStarsMock = None
                 
@@ -882,7 +887,7 @@ def targets_truth(params, healpixels=None, nside=None, output_dir='.',
             galaxies_name, _ = list(params['contaminants']['galaxies'].items())[0]
             ContamGalaxiesMock = getattr(mockmaker, '{}Maker'.format(galaxies_name))(
                 seed=seed, nside_chunk=nside_chunk, no_spectra=no_spectra,
-                target_name='CONTAM_GALAXY', survey=survey)
+                target_name='CONTAM_GALAXY', survey=survey, legacy_dir=legacy_dir)
         else:
             ContamGalaxiesMock = None
             

--- a/py/desitarget/mock/data/select-mock-targets-no-contam.yaml
+++ b/py/desitarget/mock/data/select-mock-targets-no-contam.yaml
@@ -1,5 +1,6 @@
 # Parameter file for desitarget/bin/select_mock_targets, including contaminants.
 # legacy_dir: /global/project/projectdirs/cosmo/data/legacysurvey/dr8/
+legacy_dir: /global/homes/m/mjwilson/desi/survey-validation/svdc-spring2020g-onepercent/legacydir
 
 targets:
     BGS: {

--- a/py/desitarget/mock/data/select-mock-targets-no-contam.yaml
+++ b/py/desitarget/mock/data/select-mock-targets-no-contam.yaml
@@ -1,4 +1,6 @@
 # Parameter file for desitarget/bin/select_mock_targets, including contaminants.
+legacy_dir: /global/project/projectdirs/cosmo/data/legacysurvey/dr8/
+
 targets:
     BGS: {
         target_type: BGS,

--- a/py/desitarget/mock/data/select-mock-targets-no-contam.yaml
+++ b/py/desitarget/mock/data/select-mock-targets-no-contam.yaml
@@ -1,0 +1,63 @@
+# Parameter file for desitarget/bin/select_mock_targets, including contaminants.
+targets:
+    BGS: {
+        target_type: BGS,
+        mockfile: '{DESI_ROOT}/mocks/bgs/MXXL/full_sky/v0.0.4/BGS_r20.6.hdf5',
+        format: durham_mxxl_hdf5,
+        magcut: 20.3,
+    }
+    ELG: {
+        target_type: ELG,
+        mockfile: '{DESI_ROOT}/mocks/DarkSky/v1.0.1/elg_0_inpt.fits',
+        format: gaussianfield,
+        density: 2200,
+    }
+    LRG: {
+        target_type: LRG,
+        mockfile: '{DESI_ROOT}/mocks/DarkSky/v1.0.1/lrg_0_inpt.fits',
+        format: gaussianfield,
+        density: 480,
+    }
+    QSO: {
+        target_type: QSO,
+        mockfile: '{DESI_ROOT}/mocks/DarkSky/v1.0.1/qso_0_inpt.fits',
+        format: gaussianfield,
+        zmax_qso: 1.8,
+        use_simqso: True,
+        density: 120,
+    }
+    LYA: {
+        target_type: QSO,
+        mockfile: '{DESI_ROOT}/mocks/lya_forest/london/v9.0/v9.0.0/master.fits',
+        format: CoLoRe,
+        nside_lya: 16,
+        zmin_lya: 1.8,
+        density: 50,
+        use_simqso: True,
+        sqmodel: 'default',  #Other options are 'lya_simqso_model_develop' and 'lya_simqso_model' (same as quickquasars)
+        balprob: 0.0,
+        add_dla: False,
+        add_metals: False,    #If adding metals use 'all', this is to keep the same argument as in quickquasars.
+        add_lyb: False
+        }
+    MWS_MAIN: {
+        target_type: STAR,
+        mockfile: '{DESI_ROOT}/mocks/mws/galaxia/alpha/v0.0.6/healpix',
+        nside_galaxia: 8,
+        format: galaxia,
+    }
+    MWS_NEARBY: {
+        target_type: STAR,
+        mockfile: '{DESI_ROOT}/mocks/mws/100pc/v0.0.4/mock_100pc.fits',
+        format: mws_100pc,
+    }
+    WD: {
+        target_type: WD,
+        mockfile: '{DESI_ROOT}/mocks/mws/wd/v1.0.0/mock_wd.fits',
+        format: mws_wd,
+    }
+    SKY: {
+        target_type: SKY,
+        mockfile: '{DESI_ROOT}/mocks/uniformsky/0.2/uniformsky-2048-0.2.fits',
+        format: uniformsky,
+    }

--- a/py/desitarget/mock/data/select-mock-targets-no-contam.yaml
+++ b/py/desitarget/mock/data/select-mock-targets-no-contam.yaml
@@ -1,5 +1,5 @@
 # Parameter file for desitarget/bin/select_mock_targets, including contaminants.
-legacy_dir: /global/project/projectdirs/cosmo/data/legacysurvey/dr8/
+# legacy_dir: /global/project/projectdirs/cosmo/data/legacysurvey/dr8/
 
 targets:
     BGS: {

--- a/py/desitarget/mock/get_legacy.py
+++ b/py/desitarget/mock/get_legacy.py
@@ -1,0 +1,52 @@
+import  os
+
+from    desitarget.geomask  import  hp_in_box
+from    desitarget.randoms  import  dr_extension, _pre_or_post_dr8
+from    desiutil            import  brick
+
+
+nside      = 8
+bricks     = brick.Bricks(bricksize=0.25)
+bricktable = bricks.to_table()
+lookupdict = {bt["BRICKNAME"]: hp_in_box(nside, [bt["RA1"], bt["RA2"], bt["DEC1"], bt["DEC2"]]) for bt in bricktable}
+
+pixnum     = 6195
+bricknames = [key for key in lookupdict if pixnum in lookupdict[key]]
+
+print(bricknames)
+
+# bricknames  = ['0880p587', '0880p590', '0881p582', '0882p592'] 
+
+# drdir       = '/global/homes/m/mjwilson/desi/survey-validation/svdc-spring2020g-onepercent/legacydir/'
+drdir         = '/global/project/projectdirs/cosmo/data/legacysurvey/dr8/'
+
+drdirs        = _pre_or_post_dr8(drdir)
+
+for drdir in drdirs:
+  # ADM determine whether the coadd files have extension .gz or .fz based on the DR directory.
+  extn, extn_nb = dr_extension(drdir)
+
+  filt          = ['g', 'r', 'z']
+  qnames        = ['nexp', 'depth', 'galdepth', 'psfsize', 'image']
+
+  for brickname in bricknames:
+    brickname   = brickname.replace('m', 'p')
+
+    rootdir     = os.path.join(drdir,   'coadd', brickname[:3], brickname)
+    fileform    = os.path.join(rootdir, 'legacysurvey-{}-{}-{}.fits.{}')
+  
+    # ADM loop through the filters and store the number of observations
+    # ADM etc. at the RA and Dec positions of the passed points.
+    for f in ['g', 'r', 'z']:
+      # ADM the input file labels, and output column names and output
+      # ADM formats for each of the quantities of interest.
+      for q in qnames:
+        fn     = fileform.format(brickname, q, f, extn)
+
+        cmd    = 'cp {} legacydir/'.format(fn)
+        
+        # os.system(cmd)
+
+        print(cmd)
+      
+    break

--- a/py/desitarget/mock/io.py
+++ b/py/desitarget/mock/io.py
@@ -42,10 +42,15 @@ def findfile(filetype, nside, pixnum, basedir='.', ext='fits', obscon=None):
         obscon: (str) e.g. 'dark', 'bright' to add extra dir grouping
     '''
     path = get_healpix_dir(nside, pixnum, basedir=basedir)
+
     if obscon is not None:
         path = os.path.join(path, obscon.lower())
 
-    filename = '{filetype}-{nside}-{pixnum}.{ext}'.format(
-        filetype=filetype, nside=nside, pixnum=pixnum, ext=ext)
+        filename = '{filetype}-{obscon}-{nside}-{pixnum}.{ext}'.format(
+            filetype=filetype, obscon=obscon.lower(), nside=nside, pixnum=pixnum, ext=ext)
+        
+    else:
+        filename = '{filetype}-{nside}-{pixnum}.{ext}'.format(
+            filetype=filetype, nside=nside, pixnum=pixnum, ext=ext)
 
     return os.path.join(path, filename)

--- a/py/desitarget/mock/log.txt
+++ b/py/desitarget/mock/log.txt
@@ -1,0 +1,155 @@
+20:35:22
+INFO:select_mock_targets:44:<module>: Starting select_mock_targets at Wed Apr 15 20:35:25 2020
+INFO:select_mock_targets:74:<module>: Processing 1 pixel(s).
+INFO:select_mock_targets:95:<module>: Reading configuration file data/select-mock-targets-no-contam.yaml
+INFO:select_mock_targets:99:<module>: Calling targets_truth with survey=main at Wed Apr 15 20:35:25 2020
+WARNING:build.py:87:initialize_targets_truth: Output directory /global/cscratch1/sd/mjwilson/trash is not empty.
+INFO:build.py:91:initialize_targets_truth: Writing to output directory /global/cscratch1/sd/mjwilson/trash
+INFO:build.py:95:initialize_targets_truth: Processing 1 healpixel(s) (nside = 64, 0.839 deg2/pixel) spanning 0.839 deg2.
+INFO:build.py:846:targets_truth: Initializing and caching all MockMaker classes.
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/bgs_templates_v2.3.fits
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/elg_templates_v2.2.fits
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/lrg_templates_v2.2.fits
+WARNING:templates.py:2350:__init__: Using default SIMQSO model
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/star_templates_v3.1.fits
+INFO:mockmaker.py:4366:__init__: Caching stellar template photometry.
+WARNING:templates.py:2350:__init__: Using default SIMQSO model
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/wd_templates_v2.2.fits
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/wd_templates_v2.2.fits
+INFO:mockmaker.py:4933:__init__: Caching WD template photometry.
+INFO:build.py:891:targets_truth: Working on healpixel 0
+INFO:build.py:904:targets_truth: Working on target class BGS on healpixel 0
+INFO:build.py:162:read_mock: Target: BGS, type: BGS, format: durham_mxxl_hdf5, mockfile: {DESI_ROOT}/mocks/bgs/MXXL/full_sky/v0.0.4/BGS_r20.6.hdf5
+INFO:mockmaker.py:2545:_read_mockfile: Assigning healpix pixels with nside = 64
+INFO:mockmaker.py:2580:readmock: Trimmed to 2653 BGSs in 1 healpixel(s).
+INFO:mockmaker.py:2608:readmock: Trimmed to 1950 BGSs with r < 20.3.
+INFO:mockmaker.py:2621:readmock: Sampling from BGS Gaussian mixture model.
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 1950).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 1950 BGS targets (2323.38 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1336 BGS targets (1591.81 / deg2).
+INFO:build.py:588:get_spectra: Total time for BGSs = 0.638 minutes (1459.554 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class ELG on healpixel 0
+INFO:build.py:162:read_mock: Target: ELG, type: ELG, format: gaussianfield, mockfile: {DESI_ROOT}/mocks/DarkSky/v1.0.1/elg_0_inpt.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/DarkSky/v1.0.1/elg_0_inpt.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:1480:readmock: Trimmed to 4324 ELGs in 1 healpixel(s)
+INFO:mockmaker.py:1520:readmock: Sampling from ELG Gaussian mixture model.
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 4324).
+INFO:build.py:216:read_mock: Computed median mock density for ELGs of 4863.61 targets/deg2.
+INFO:build.py:218:read_mock: Target density = 2200.00 targets/deg2 (downsampling factor = 0.452).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 1955 ELG targets (2329.34 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1955 ELG targets (2329.34 / deg2).
+INFO:build.py:588:get_spectra: Total time for ELGs = 0.865 minutes (1979.481 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class LRG on healpixel 0
+INFO:build.py:162:read_mock: Target: LRG, type: LRG, format: gaussianfield, mockfile: {DESI_ROOT}/mocks/DarkSky/v1.0.1/lrg_0_inpt.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/DarkSky/v1.0.1/lrg_0_inpt.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:1480:readmock: Trimmed to 575 LRGs in 1 healpixel(s)
+INFO:mockmaker.py:1520:readmock: Sampling from LRG Gaussian mixture model.
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 575).
+INFO:build.py:216:read_mock: Computed median mock density for LRGs of 770.89 targets/deg2.
+INFO:build.py:218:read_mock: Target density = 480.00 targets/deg2 (downsampling factor = 0.623).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 358 LRG targets (426.55 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 358 LRG targets (426.55 / deg2).
+INFO:build.py:588:get_spectra: Total time for LRGs = 0.695 minutes (1590.212 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class LYA on healpixel 0
+INFO:build.py:162:read_mock: Target: LYA, type: QSO, format: CoLoRe, mockfile: {DESI_ROOT}/mocks/lya_forest/london/v9.0/v9.0.0/master.fits
+INFO:mockmaker.py:2309:readmock: Reading /global/cfs/cdirs/desi/mocks/lya_forest/london/v9.0/v9.0.0/master.fits
+INFO:mockmaker.py:2329:readmock: Assigning healpix pixels with nside = 64
+INFO:mockmaker.py:2345:readmock: Trimmed to 167 LYAs in 1 healpixel(s)
+INFO:mockmaker.py:2361:readmock: Trimmed to 167 LYAs with z>=1.800
+INFO:mockmaker.py:2424:readmock: Sampling from LYA Gaussian mixture model.
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 167).
+INFO:build.py:203:read_mock: Density adjustment factor for target type LYA: 1.495.
+INFO:build.py:216:read_mock: Computed median mock density for LYAs of 181.10 targets/deg2.
+INFO:build.py:218:read_mock: Target density = 50.00 targets/deg2 (downsampling factor = 0.413).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 69 LYA targets (82.21 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 69 LYA targets (82.21 / deg2).
+INFO:build.py:588:get_spectra: Total time for LYAs = 0.567 minutes (1297.358 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class MWS_MAIN on healpixel 0
+INFO:build.py:162:read_mock: Target: MWS_MAIN, type: STAR, format: galaxia, mockfile: {DESI_ROOT}/mocks/mws/galaxia/alpha/v0.0.6/healpix
+INFO:mockmaker.py:2053:readmock: Reading /global/cfs/cdirs/desi/mocks/mws/galaxia/alpha/v0.0.6/healpix/8/0/0/mock_allsky_galaxia_desi-8-0.fits
+INFO:mockmaker.py:2074:readmock: Trimmed to 1660 MWS_MAINs in 1 healpixel(s)
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 1660).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 1660 MWS_MAIN targets (1977.85 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1336 MWS_MAIN targets (1591.81 / deg2).
+INFO:build.py:588:get_spectra: Total time for MWS_MAINs = 0.606 minutes (1386.798 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class MWS_NEARBY on healpixel 0
+INFO:build.py:162:read_mock: Target: MWS_NEARBY, type: STAR, format: mws_100pc, mockfile: {DESI_ROOT}/mocks/mws/100pc/v0.0.4/mock_100pc.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/mws/100pc/v0.0.4/mock_100pc.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:3027:readmock: Trimmed to 4 MWS_NEARBYs in 1 healpixel(s).
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 4).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 4 MWS_NEARBY targets (4.77 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 4 MWS_NEARBY targets (4.77 / deg2).
+INFO:build.py:588:get_spectra: Total time for MWS_NEARBYs = 0.600 minutes (1373.207 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class QSO on healpixel 0
+INFO:build.py:162:read_mock: Target: QSO, type: QSO, format: gaussianfield, mockfile: {DESI_ROOT}/mocks/DarkSky/v1.0.1/qso_0_inpt.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/DarkSky/v1.0.1/qso_0_inpt.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:1480:readmock: Trimmed to 272 QSOs in 1 healpixel(s)
+INFO:mockmaker.py:1500:readmock: Trimmed to 220 objects with z<1.800
+INFO:mockmaker.py:1520:readmock: Sampling from QSO Gaussian mixture model.
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 220).
+INFO:build.py:203:read_mock: Density adjustment factor for target type QSO: 0.793.
+INFO:build.py:216:read_mock: Computed median mock density for QSOs of 266.89 targets/deg2.
+INFO:build.py:218:read_mock: Target density = 120.00 targets/deg2 (downsampling factor = 0.356).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 78 QSO targets (92.94 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 78 QSO targets (92.94 / deg2).
+INFO:build.py:588:get_spectra: Total time for QSOs = 0.587 minutes (1342.481 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class SKY on healpixel 0
+INFO:build.py:162:read_mock: Target: SKY, type: SKY, format: uniformsky, mockfile: {DESI_ROOT}/mocks/uniformsky/0.2/uniformsky-2048-0.2.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/uniformsky/0.2/uniformsky-2048-0.2.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:1902:readmock: Trimmed to 1024 SKYs in 1 healpixel(s).
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 1024).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 1024 SKY targets (1220.07 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1024 SKY targets (1220.07 / deg2).
+INFO:build.py:588:get_spectra: Total time for SKYs = 0.689 minutes (1575.107 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class WD on healpixel 0
+INFO:build.py:162:read_mock: Target: WD, type: WD, format: mws_wd, mockfile: {DESI_ROOT}/mocks/mws/wd/v1.0.0/mock_wd.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/mws/wd/v1.0.0/mock_wd.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:2868:readmock: Trimmed to 2 WDs in 1 healpixel(s).
+INFO:mockmaker.py:413:imaging_depth: Setting realistic imaging depths (including MASKBITS).
+INFO:mockmaker.py:489:imaging_depth: Removing 0 targets not in reduced DESI imaging (of 2).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 2 WD targets (2.38 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1 WD targets (1.19 / deg2).
+INFO:build.py:588:get_spectra: Total time for WDs = 0.708 minutes (1619.876 cpu minutes/deg2).
+INFO:build.py:1037:finish_catalog: Summary: ntargets = 5137 (6120.62 targets/deg2), nsky = 1024 (1220.07 targets/deg2) in pixel 0.
+INFO:build.py:982:targets_truth: 2677 targets written to /global/cscratch1/sd/mjwilson/trash/0/0/bright/targets-bright-64-0.fits
+INFO:build.py:982:targets_truth: 4055 targets written to /global/cscratch1/sd/mjwilson/trash/0/0/dark/targets-dark-64-0.fits
+INFO:build.py:987:targets_truth: Writing 1024 SKY targets to /global/cscratch1/sd/mjwilson/trash/0/0/sky-64-0.fits
+INFO:select_mock_targets:103:<module>: All done at Wed Apr 15 20:56:34 2020
+20:56:36

--- a/py/desitarget/mock/log_simple.txt
+++ b/py/desitarget/mock/log_simple.txt
@@ -1,0 +1,147 @@
+21:04:38
+INFO:select_mock_targets:44:<module>: Starting select_mock_targets at Wed Apr 15 21:04:44 2020
+INFO:select_mock_targets:74:<module>: Processing 1 pixel(s).
+INFO:select_mock_targets:95:<module>: Reading configuration file data/select-mock-targets-no-contam.yaml
+INFO:select_mock_targets:99:<module>: Calling targets_truth with survey=main at Wed Apr 15 21:04:44 2020
+WARNING:build.py:87:initialize_targets_truth: Output directory /global/cscratch1/sd/mjwilson/trash is not empty.
+INFO:build.py:91:initialize_targets_truth: Writing to output directory /global/cscratch1/sd/mjwilson/trash
+INFO:build.py:95:initialize_targets_truth: Processing 1 healpixel(s) (nside = 64, 0.839 deg2/pixel) spanning 0.839 deg2.
+INFO:build.py:846:targets_truth: Initializing and caching all MockMaker classes.
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/bgs_templates_v2.3.fits
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/elg_templates_v2.2.fits
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/lrg_templates_v2.2.fits
+WARNING:templates.py:2350:__init__: Using default SIMQSO model
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/star_templates_v3.1.fits
+INFO:mockmaker.py:4366:__init__: Caching stellar template photometry.
+WARNING:templates.py:2350:__init__: Using default SIMQSO model
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/wd_templates_v2.2.fits
+INFO:io.py:959:read_basis_templates: Reading /global/cfs/cdirs/desi/spectro/templates/basis_templates/v3.2/wd_templates_v2.2.fits
+INFO:mockmaker.py:4933:__init__: Caching WD template photometry.
+INFO:build.py:891:targets_truth: Working on healpixel 0
+INFO:build.py:904:targets_truth: Working on target class BGS on healpixel 0
+INFO:build.py:162:read_mock: Target: BGS, type: BGS, format: durham_mxxl_hdf5, mockfile: {DESI_ROOT}/mocks/bgs/MXXL/full_sky/v0.0.4/BGS_r20.6.hdf5
+INFO:mockmaker.py:2545:_read_mockfile: Assigning healpix pixels with nside = 64
+INFO:mockmaker.py:2580:readmock: Trimmed to 2653 BGSs in 1 healpixel(s).
+INFO:mockmaker.py:2608:readmock: Trimmed to 1950 BGSs with r < 20.3.
+INFO:mockmaker.py:2621:readmock: Sampling from BGS Gaussian mixture model.
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 1950 BGS targets (2323.38 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1365 BGS targets (1626.37 / deg2).
+INFO:build.py:588:get_spectra: Total time for BGSs = 0.507 minutes (1160.167 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class ELG on healpixel 0
+INFO:build.py:162:read_mock: Target: ELG, type: ELG, format: gaussianfield, mockfile: {DESI_ROOT}/mocks/DarkSky/v1.0.1/elg_0_inpt.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/DarkSky/v1.0.1/elg_0_inpt.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:1480:readmock: Trimmed to 4324 ELGs in 1 healpixel(s)
+INFO:mockmaker.py:1520:readmock: Sampling from ELG Gaussian mixture model.
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:216:read_mock: Computed median mock density for ELGs of 4863.61 targets/deg2.
+INFO:build.py:218:read_mock: Target density = 2200.00 targets/deg2 (downsampling factor = 0.452).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 1955 ELG targets (2329.34 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1955 ELG targets (2329.34 / deg2).
+INFO:build.py:588:get_spectra: Total time for ELGs = 0.818 minutes (1870.664 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class LRG on healpixel 0
+INFO:build.py:162:read_mock: Target: LRG, type: LRG, format: gaussianfield, mockfile: {DESI_ROOT}/mocks/DarkSky/v1.0.1/lrg_0_inpt.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/DarkSky/v1.0.1/lrg_0_inpt.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:1480:readmock: Trimmed to 575 LRGs in 1 healpixel(s)
+INFO:mockmaker.py:1520:readmock: Sampling from LRG Gaussian mixture model.
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+WARNING:cuts.py:292:isLRG_colors: Setting zfiberflux to zflux!!!
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:216:read_mock: Computed median mock density for LRGs of 770.89 targets/deg2.
+INFO:build.py:218:read_mock: Target density = 480.00 targets/deg2 (downsampling factor = 0.623).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 358 LRG targets (426.55 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 358 LRG targets (426.55 / deg2).
+INFO:build.py:588:get_spectra: Total time for LRGs = 0.645 minutes (1474.886 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class LYA on healpixel 0
+INFO:build.py:162:read_mock: Target: LYA, type: QSO, format: CoLoRe, mockfile: {DESI_ROOT}/mocks/lya_forest/london/v9.0/v9.0.0/master.fits
+INFO:mockmaker.py:2309:readmock: Reading /global/cfs/cdirs/desi/mocks/lya_forest/london/v9.0/v9.0.0/master.fits
+INFO:mockmaker.py:2329:readmock: Assigning healpix pixels with nside = 64
+INFO:mockmaker.py:2345:readmock: Trimmed to 167 LYAs in 1 healpixel(s)
+INFO:mockmaker.py:2361:readmock: Trimmed to 167 LYAs with z>=1.800
+INFO:mockmaker.py:2424:readmock: Sampling from LYA Gaussian mixture model.
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:203:read_mock: Density adjustment factor for target type LYA: 1.495.
+INFO:build.py:216:read_mock: Computed median mock density for LYAs of 181.10 targets/deg2.
+INFO:build.py:218:read_mock: Target density = 50.00 targets/deg2 (downsampling factor = 0.413).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 69 LYA targets (82.21 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 69 LYA targets (82.21 / deg2).
+INFO:build.py:588:get_spectra: Total time for LYAs = 0.602 minutes (1377.425 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class MWS_MAIN on healpixel 0
+INFO:build.py:162:read_mock: Target: MWS_MAIN, type: STAR, format: galaxia, mockfile: {DESI_ROOT}/mocks/mws/galaxia/alpha/v0.0.6/healpix
+INFO:mockmaker.py:2053:readmock: Reading /global/cfs/cdirs/desi/mocks/mws/galaxia/alpha/v0.0.6/healpix/8/0/0/mock_allsky_galaxia_desi-8-0.fits
+INFO:mockmaker.py:2074:readmock: Trimmed to 1660 MWS_MAINs in 1 healpixel(s)
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 1660 MWS_MAIN targets (1977.85 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1338 MWS_MAIN targets (1594.20 / deg2).
+INFO:build.py:588:get_spectra: Total time for MWS_MAINs = 0.549 minutes (1255.991 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class MWS_NEARBY on healpixel 0
+INFO:build.py:162:read_mock: Target: MWS_NEARBY, type: STAR, format: mws_100pc, mockfile: {DESI_ROOT}/mocks/mws/100pc/v0.0.4/mock_100pc.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/mws/100pc/v0.0.4/mock_100pc.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:3027:readmock: Trimmed to 4 MWS_NEARBYs in 1 healpixel(s).
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 4 MWS_NEARBY targets (4.77 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 4 MWS_NEARBY targets (4.77 / deg2).
+INFO:build.py:588:get_spectra: Total time for MWS_NEARBYs = 0.568 minutes (1298.248 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class QSO on healpixel 0
+INFO:build.py:162:read_mock: Target: QSO, type: QSO, format: gaussianfield, mockfile: {DESI_ROOT}/mocks/DarkSky/v1.0.1/qso_0_inpt.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/DarkSky/v1.0.1/qso_0_inpt.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:1480:readmock: Trimmed to 272 QSOs in 1 healpixel(s)
+INFO:mockmaker.py:1500:readmock: Trimmed to 220 objects with z<1.800
+INFO:mockmaker.py:1520:readmock: Sampling from QSO Gaussian mixture model.
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:203:read_mock: Density adjustment factor for target type QSO: 0.793.
+INFO:build.py:216:read_mock: Computed median mock density for QSOs of 266.89 targets/deg2.
+INFO:build.py:218:read_mock: Target density = 120.00 targets/deg2 (downsampling factor = 0.356).
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 78 QSO targets (92.94 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 78 QSO targets (92.94 / deg2).
+INFO:build.py:588:get_spectra: Total time for QSOs = 0.686 minutes (1570.189 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class SKY on healpixel 0
+INFO:build.py:162:read_mock: Target: SKY, type: SKY, format: uniformsky, mockfile: {DESI_ROOT}/mocks/uniformsky/0.2/uniformsky-2048-0.2.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/uniformsky/0.2/uniformsky-2048-0.2.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:1902:readmock: Trimmed to 1024 SKYs in 1 healpixel(s).
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 1024 SKY targets (1220.07 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1024 SKY targets (1220.07 / deg2).
+INFO:build.py:588:get_spectra: Total time for SKYs = 0.633 minutes (1448.551 cpu minutes/deg2).
+INFO:build.py:904:targets_truth: Working on target class WD on healpixel 0
+INFO:build.py:162:read_mock: Target: WD, type: WD, format: mws_wd, mockfile: {DESI_ROOT}/mocks/mws/wd/v1.0.0/mock_wd.fits
+INFO:mockmaker.py:230:_get_radec: Reading /global/cfs/cdirs/desi/mocks/mws/wd/v1.0.0/mock_wd.fits
+INFO:mockmaker.py:235:_get_radec: Assigning healpix pixels with nside = 64.
+INFO:mockmaker.py:2868:readmock: Trimmed to 2 WDs in 1 healpixel(s).
+INFO:mockmaker.py:503:imaging_depth: Setting simple imaging depths.
+INFO:build.py:400:density_fluctuations: Dividing each nside=64 healpixel (0.84 deg2) into 4 nside=128 healpixel(s) (0.21 deg2).
+INFO:build.py:510:get_spectra: Goal: Generate spectra for 2 WD targets (2.38 / deg2).
+INFO:build.py:586:get_spectra: Done: Generated spectra for 1 WD targets (1.19 / deg2).
+INFO:build.py:588:get_spectra: Total time for WDs = 0.627 minutes (1435.281 cpu minutes/deg2).
+INFO:build.py:1037:finish_catalog: Summary: ntargets = 5168 (6157.56 targets/deg2), nsky = 1024 (1220.07 targets/deg2) in pixel 0.
+INFO:build.py:982:targets_truth: 2708 targets written to /global/cscratch1/sd/mjwilson/trash/0/0/bright/targets-bright-64-0.fits
+INFO:build.py:982:targets_truth: 4064 targets written to /global/cscratch1/sd/mjwilson/trash/0/0/dark/targets-dark-64-0.fits
+INFO:build.py:987:targets_truth: Writing 1024 SKY targets to /global/cscratch1/sd/mjwilson/trash/0/0/sky-64-0.fits
+INFO:select_mock_targets:103:<module>: All done at Wed Apr 15 21:14:31 2020
+21:14:35

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -1379,7 +1379,7 @@ class ReadGaussianField(SelectTargets):
         
     def readmock(self, mockfile=None, healpixels=None, nside=None,
                  zmax_qso=None, target_name='', mock_density=False,
-                 only_coords=False, seed=None):
+                 only_coords=False, seed=None, legacy_dir=None):
         """Read the catalog.
 
         Parameters
@@ -1596,7 +1596,7 @@ class ReadGaussianField(SelectTargets):
 
         # Add MW transmission and the imaging depth.
         self.mw_transmission(out)
-        self.imaging_depth(out)
+        self.imaging_depth(out, legacy_dir=legacy_dir)
 
         # Optionally compute the mean mock density.
         if mock_density:
@@ -1612,7 +1612,8 @@ class ReadBuzzard(SelectTargets):
         super(ReadBuzzard, self).__init__(**kwargs)
         
     def readmock(self, mockfile=None, healpixels=[], nside=[], nside_buzzard=8,
-                 target_name='', magcut=None, only_coords=False, seed=None):
+                 target_name='', magcut=None, only_coords=False, seed=None,
+                 legacy_dir=None):
         """Read the catalog.
 
         Parameters
@@ -1793,7 +1794,7 @@ class ReadBuzzard(SelectTargets):
 
         # Add MW transmission and the imaging depth.
         self.mw_transmission(out)
-        self.imaging_depth(out)
+        self.imaging_depth(out, legacy_dir=legacy_dir)
 
         ## Optionally compute the mean mock density.
         #if mock_density:
@@ -1809,7 +1810,8 @@ class ReadUniformSky(SelectTargets):
         super(ReadUniformSky, self).__init__(**kwargs)
 
     def readmock(self, mockfile=None, healpixels=None, nside=None,
-                 target_name='', mock_density=False, only_coords=False):
+                 target_name='', mock_density=False, only_coords=False,
+                 legacy_dir=None):
         """Read the catalog.
 
         Parameters
@@ -1919,7 +1921,7 @@ class ReadUniformSky(SelectTargets):
 
         # Add MW transmission and the imaging depth.
         self.mw_transmission(out)
-        self.imaging_depth(out)
+        self.imaging_depth(out, legacy_dir=legacy_dir)
 
         # Optionally compute the mean mock density.
         if mock_density:
@@ -1936,7 +1938,7 @@ class ReadGalaxia(SelectTargets):
 
     def readmock(self, mockfile=None, healpixels=[], nside=[], nside_galaxia=8, 
                  target_name='MWS_MAIN', magcut=None, faintstar_mockfile=None,
-                 faintstar_magcut=None, seed=None):
+                 faintstar_magcut=None, seed=None, legacy_dir=None):
         """Read the catalog.
 
         Parameters
@@ -2182,7 +2184,7 @@ class ReadGalaxia(SelectTargets):
 
         # Add MW transmission and the imaging depth.
         self.mw_transmission(out)
-        self.imaging_depth(out)
+        self.imaging_depth(out, legacy_dir=legacy_dir)
 
         # Optionally include faint stars.
         if faintstar_mockfile is not None:
@@ -2212,7 +2214,8 @@ class ReadLyaCoLoRe(SelectTargets):
 
     def readmock(self, mockfile=None, healpixels=None, nside=None,
                  target_name='LYA', nside_lya=16, zmin_lya=None,
-                 mock_density=False, sqmodel='default',only_coords=False, seed=None):
+                 mock_density=False, sqmodel='default',only_coords=False, seed=None,
+                 legacy_dir=None):
         """Read the catalog.
 
         Parameters
@@ -2435,7 +2438,7 @@ class ReadLyaCoLoRe(SelectTargets):
 
         # Add MW transmission and the imaging depth.
         self.mw_transmission(out)
-        self.imaging_depth(out)
+        self.imaging_depth(out, legacy_dir=legacy_dir)
 
         # Optionally compute the mean mock density.
         if mock_density:
@@ -2648,7 +2651,8 @@ class ReadGAMA(SelectTargets):
         super(ReadGAMA, self).__init__(**kwargs)
         
     def readmock(self, mockfile=None, healpixels=None, nside=None,
-                 target_name='', magcut=None, only_coords=False):
+                 target_name='', magcut=None, only_coords=False,
+                 legacy_dir=None):
         """Read the catalog.
 
         Parameters
@@ -2764,7 +2768,7 @@ class ReadGAMA(SelectTargets):
 
         # Add MW transmission and the imaging depth.
         self.mw_transmission(out)
-        self.imaging_depth(out)
+        self.imaging_depth(out, legacy_dir=legacy_dir)
 
         return out
 
@@ -2776,7 +2780,7 @@ class ReadMWS_WD(SelectTargets):
         super(ReadMWS_WD, self).__init__(**kwargs)
 
     def readmock(self, mockfile=None, healpixels=None, nside=None,
-                 target_name='WD', mock_density=False):
+                 target_name='WD', mock_density=False, legacy_dir=None):
         """Read the catalog.
 
         Parameters
@@ -2920,7 +2924,7 @@ class ReadMWS_WD(SelectTargets):
 
         # Add MW transmission and the imaging depth.
         self.mw_transmission(out)
-        self.imaging_depth(out)
+        self.imaging_depth(out, legacy_dir=legacy_dir)
 
         # Optionally compute the mean mock density.
         if mock_density:
@@ -2936,7 +2940,8 @@ class ReadMWS_NEARBY(SelectTargets):
         super(ReadMWS_NEARBY, self).__init__(**kwargs)
 
     def readmock(self, mockfile=None, healpixels=None, nside=None,
-                 target_name='MWS_NEARBY', mock_density=False):
+                 target_name='MWS_NEARBY', mock_density=False,
+                 legacy_dir=None):
         """Read the catalog.
 
         Parameters
@@ -3076,7 +3081,7 @@ class ReadMWS_NEARBY(SelectTargets):
 
         # Add MW transmission and the imaging depth.
         self.mw_transmission(out)
-        self.imaging_depth(out)
+        self.imaging_depth(out, legacy_dir=legacy_dir)
 
         # Optionally compute the mean mock density.
         if mock_density:
@@ -3174,7 +3179,8 @@ class QSOMaker(SelectTargets):
         data = MockReader.readmock(mockfile, target_name=self.objtype,
                                    healpixels=healpixels, nside=nside,
                                    only_coords=only_coords, seed=self.seed,
-                                   zmax_qso=zmax_qso, mock_density=mock_density)
+                                   zmax_qso=zmax_qso, mock_density=mock_density,
+                                   legacy_dir=self.legacy_dir)
 
         return data
 
@@ -3398,7 +3404,8 @@ class LYAMaker(SelectTargets):
                                    healpixels=healpixels, nside=nside,
                                    nside_lya=nside_lya, zmin_lya=zmin_lya,
                                    mock_density=mock_density,
-                                   only_coords=only_coords, seed=self.seed)
+                                   only_coords=only_coords, seed=self.seed,
+                                   legacy_dir=self.legacy_dir)
         return data
 
     def make_spectra(self, data=None, indx=None, seed=None,no_spectra=False,add_dlas=None,add_metals=None,add_lyb=None):
@@ -3761,7 +3768,8 @@ class LRGMaker(SelectTargets):
         data = MockReader.readmock(mockfile, target_name=self.objtype,
                                    healpixels=healpixels, nside=nside,
                                    only_coords=only_coords,
-                                   mock_density=mock_density, seed=self.seed)
+                                   mock_density=mock_density, seed=self.seed,
+                                   legacy_dir=self.legacy_dir)
 
         return data
 
@@ -3984,7 +3992,8 @@ class ELGMaker(SelectTargets):
         data = MockReader.readmock(mockfile, target_name=self.objtype,
                                    healpixels=healpixels, nside=nside,
                                    only_coords=only_coords,
-                                   mock_density=mock_density, seed=self.seed)
+                                   mock_density=mock_density, seed=self.seed,
+                                   legacy_dir=self.legacy_dir)
 
         return data
             
@@ -4563,7 +4572,7 @@ class MWS_MAINMaker(STARMaker):
                                    nside_galaxia=nside_galaxia, magcut=magcut,
                                    faintstar_mockfile=faintstar_mockfile,
                                    faintstar_magcut=faintstar_magcut,
-                                   seed=self.seed)
+                                   seed=self.seed, legacy_dir=self.legacy_dir)
 
         return data
     
@@ -4758,7 +4767,7 @@ class MWS_NEARBYMaker(STARMaker):
 
         data = MockReader.readmock(mockfile, target_name='MWS_NEARBY',
                                    healpixels=healpixels, nside=nside,
-                                   mock_density=mock_density)
+                                   mock_density=mock_density, legacy_dir=self.legacy_dir)
 
         return data
     
@@ -5031,7 +5040,7 @@ class WDMaker(SelectTargets):
 
         data = MockReader.readmock(mockfile, target_name=self.objtype,
                                    healpixels=healpixels, nside=nside,
-                                   mock_density=mock_density)
+                                   mock_density=mock_density, legacy_dir=self.legacy_dir)
 
         return data
 
@@ -5283,7 +5292,8 @@ class SKYMaker(SelectTargets):
         data = MockReader.readmock(mockfile, target_name=self.objtype,
                                    healpixels=healpixels, nside=nside,
                                    only_coords=only_coords,
-                                   mock_density=mock_density)
+                                   mock_density=mock_density,
+                                   legacy_dir=self.legacy_dir)
 
         return data
 
@@ -5555,7 +5565,7 @@ class BuzzardMaker(SelectTargets):
                                    healpixels=healpixels, nside=nside,
                                    nside_buzzard=nside_buzzard,
                                    only_coords=only_coords,
-                                   magcut=magcut)
+                                   magcut=magcut, legacy_dir=self.legacy_dir)
 
         return data
 

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -173,7 +173,7 @@ def empty_targets_table(nobj=1):
 
     # Default MASKBITS for all mock targets to non-zero.  If populating with realistic depths
     # these will later be overwritten.
-    targets['MASKBITS'] = 2e10
+    targets['MASKBITS'] = 2**10
     
     return targets
 

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -402,7 +402,6 @@ class SelectTargets(object):
         self.set_wise_depth(data)
 
     def imaging_depth(self, data, release=8, aprad=0.0, simple=False):
-        import  pandas             as     pd 
         import  desitarget.randoms as     randoms
 
         from    desitarget.targets import resolve
@@ -476,8 +475,8 @@ class SelectTargets(object):
 
                     for band in bands:
                         for bk in bandkeep:
-                            key = bk + '_' + band
-                            data[key][indx] = rtn[key]
+                            key               = bk + '_' + band
+                            data[key][indx]   = rtn[key]
 
                     data['PSFDEPTH_W1'][indx] = rtn['PSFDEPTH_W1']
                     data['PSFDEPTH_W2'][indx] = rtn['PSFDEPTH_W2']

--- a/py/desitarget/mock/test.sh
+++ b/py/desitarget/mock/test.sh
@@ -1,0 +1,5 @@
+date +"%T"
+
+select_mock_targets --output_dir /global/cscratch1/sd/mjwilson/trash --nside 64 --config data/select-mock-targets-no-contam.yaml --healpixels 0 --no-spectra --overwrite
+
+date +"%T"

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -334,7 +334,13 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
                     iswcs = True
                 # ADM get the quantity of interest at each location and
                 # ADM store in a dictionary with the filter and quantity.
-                if qout == 'apflux':
+                if (qout == 'apflux'):
+                    if aprad == 0.0:
+                        qdict['apflux_ivar_'+filt] = np.zeros(npts, dtype=qform)
+                        qdict[qout+'_'+filt]       = np.zeros(npts, dtype=qform)
+
+                        continue
+                        
                     # ADM special treatment to photometer sky.
                     # ADM Read in the ivar image.
                     fnivar = fileform.format(brickname, 'invvar', filt, extn)


### PR DESCRIPTION
Opening this as requested.  I can verify it works for my use case, but it may not otherwise be ready for primetime.  

This populates mock targets with MASKBITS and GAL/PSF depths early in the processing.  This is motivated primarily by mock targets inheriting the desi imaging mask.  But, when does this way, naturally allows for inhomogeneity in the mock target catalogue. 

To your points John, I've removed the pandas dependency - just convenient for testing.

On the broader maintainability on a laptop.  There is a look up of legacy coadds, e.g.:
```/global/project/projectdirs/cosmo/data/legacysurvey/dr8/south/coadd/018/0184m117/legacysurvey-{brick}m117-{type}-{filt}.fits```

where type is currently required for all of  'nexp', 'depth', 'galdepth', 'psfsize' & filt is grz.  Image is not required as we're excluding the local sky brightness lookup in this. 

If a local copy of a release, e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr8/ for the required bricks was present in principle this could be supported.  I'm not sure how practical that is.  

I had in mind a --maskbits flag that, if not provided, defaults to the previous "simple" imaging (homogenous) model with no lookup, otherwise assume you're on nersc and proceed.  This would then only exclude laptop debugging of this particular feature. 

If you want to go down the route of local copies, I think I should be able to wire the config such that if you provide a e.g. LEGACYSURVEYDIR that is your local clone of a release, then proceed with the maskbit etc. lookup. 

There are a few other changes in there that I've found useful for debugging the 1% work, but some are probably not essential.  Comments welcome. 