### PR TITLE
Updates to faciliate the mocks run on pixel-level imaging data.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -12,7 +12,7 @@ desitarget Change Log
       `justlist` option to list the (maximal) required input files.
     * Minor bug fixes and documentation updates.
 
-.. _`PR #607`: https://github.com/desihub/desitarget/pull/611
+.. _`PR #611`: https://github.com/desihub/desitarget/pull/611
 
 0.38.0 (2020-04-23)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,8 +5,14 @@ desitarget Change Log
 0.38.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Help the mocks run on pixel-level imaging data [`PR #611`_]. Includes:
+    * New :func:`geomask.get_brick_info()` function to look up the
+      brick names associated with each HEALPixel.
+    * In :func:`randoms.quantities_at_positions_in_a_brick()`, add a
+      `justlist` option to list the (maximal) required input files.
+    * Minor bug fixes and documentation updates.
 
+.. _`PR #607`: https://github.com/desihub/desitarget/pull/611
 
 0.38.0 (2020-04-23)
 -------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -1998,8 +1998,11 @@ def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.'
         # ADM Write out the densest pixels.
         if makeplots:
             html.write('<pre>')
-            html.write('Densest HEALPixels (NSIDE={}; links are to LS viewer):\n'.format(
-                densdict[objtype]["NSIDE"]))
+            resol = 0
+            if isinstance(densdict[objtype]["NSIDE"], int):
+                resol = hp.nside2resol(densdict[objtype]["NSIDE"], arcmin=True)
+            html.write('Densest HEALPixels (NSIDE={}; ~{:.0f} arcmin across; links are to LS viewer):\n'.format(
+                densdict[objtype]["NSIDE"], resol))
             ras, decs, dens = densdict[objtype]["RA"], densdict[objtype]["DEC"], densdict[objtype]["DENSITY"]
             for i in range(len(ras)):
                 ender = "   "
@@ -2226,7 +2229,8 @@ def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.'
                             down = 0.9
                         qasystematics_scatterplot(pixmap, sysname, objtype, qadir=qadir,
                                                   downclip=down, upclip=up, nbins=10, xlabel=plotlabel)
-
+                log.info('Made systematics plots for {}...t ={:.1f}s'.format(
+                    sysname, time()-start))
         log.info('Done with systematics...t = {:.1f}s'.format(time()-start))
 
     # ADM html postamble for main page.

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -883,7 +883,8 @@ def brick_names_touch_hp(nside, numproc=1):
 
     Notes
     -----
-        - Runs in about X (Y) seconds for numproc=1 (32).
+        - Runs in about 65 (10) seconds for numproc=1 (32) at nside=2.
+        - Runs in about 325 (20) seconds for numproc=1 (32) at nside=64.
     """
     t0 = time()
     # ADM grab the standard table of bricks.

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -297,7 +297,7 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
     else:
         # ADM this is critical for, e.g., unit tests for which the
         # ADM Gaia "00000" pixel file might not exist.
-        dummyfile = find_gaia_files_hp(_get_gaia_nside(), pixlist[0],
+        dummyfile = find_gaia_files_hp(nside, pixlist[0],
                                        neighbors=False)[0]
     dummygfas = np.array([], gaia_in_file(dummyfile).dtype)
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -281,7 +281,7 @@ def dr8_quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
 
 
 def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
-                                       aprad=0.75):
+                                       aprad=0.75, justlist=False):
     """Observational quantities (per-band) at positions in a Legacy Surveys brick.
 
     Parameters
@@ -300,6 +300,9 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
         Defaults to the DESI fiber radius. If aprad < 1e-8 is passed,
         the code to produce these values is skipped, as a speed-up, and
         `apflux_` output values are set to zero.
+    justlist : :class:`bool`, optional, defaults to ``False``
+        If ``True``, return a MAXIMAL list of all POSSIBLE files needed
+        to run for `brickname` and `drdir`. Overrides other inputs.
 
     Returns
     -------
@@ -325,7 +328,11 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
         log.critical(msg)
         raise ValueError(msg)
 
-    # ADM determine whether the coadd files have extension .gz or .fz based on the DR directory.
+    # ADM a list to populate with the files required to run the code.
+    fnlist = []
+
+    # ADM determine whether the coadd files have extension .gz or .fz
+    # based on the DR directory.
     extn, extn_nb = dr_extension(drdir)
 
     # ADM the output dictionary.
@@ -349,46 +356,49 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
                      ['i2', 'f4', 'f4', 'f4', 'f4'])
         for qin, qout, qform in qnames:
             fn = fileform.format(brickname, qin, filt, extn)
-            # ADM only process the WCS if there's a file for this filter.
-            # ADM also skip calculating aperture fluxes if aprad ~ 0.
-            if os.path.exists(fn) and not (qout == 'apflux' and aprad < 1e-8):
-                img = fits.open(fn)[extn_nb]
-                if not iswcs:
-                    # ADM store the instrument name, if it isn't stored.
-                    instrum = img.header["INSTRUME"].lower().strip()
-                    w = WCS(img.header)
-                    x, y = w.all_world2pix(ras, decs, 0)
-                    iswcs = True
-                # ADM get the quantity of interest at each location and
-                # ADM store in a dictionary with the filter and quantity.
-                if qout == 'apflux':
-                    # ADM special treatment to photometer sky.
-                    # ADM Read in the ivar image.
-                    fnivar = fileform.format(brickname, 'invvar', filt, extn)
-                    ivar = fits.open(fnivar)[extn_nb].data
-                    with np.errstate(divide='ignore', invalid='ignore'):
-                        # ADM ivars->errors, guard against 1/0.
-                        imsigma = 1./np.sqrt(ivar)
-                        imsigma[ivar == 0] = 0
-                    # ADM aperture photometry at requested radius (aprad).
-                    apxy = np.vstack((x, y)).T
-                    aper = photutils.CircularAperture(apxy, aprad)
-                    p = photutils.aperture_photometry(img.data, aper, error=imsigma)
-                    # ADM store the results.
-                    qdict[qout+'_'+filt] = np.array(p.field('aperture_sum'))
-                    err = p.field('aperture_sum_err')
-                    with np.errstate(divide='ignore', invalid='ignore'):
-                        # ADM errors->ivars, guard against 1/0.
-                        ivar = 1./err**2.
-                        ivar[err == 0] = 0.
-                    qdict[qout+'_ivar_'+filt] = np.array(ivar)
-                else:
-                    qdict[qout+'_'+filt] = img.data[y.astype("int"), x.astype("int")]
-            # ADM if the file doesn't exist, set quantities to zero.
+            if justlist:
+                fnlist.append(fn)
             else:
-                if qout == 'apflux':
-                    qdict['apflux_ivar_'+filt] = np.zeros(npts, dtype=qform)
-                qdict[qout+'_'+filt] = np.zeros(npts, dtype=qform)
+                # ADM only process the WCS if there's a file for this filter.
+                # ADM also skip calculating aperture fluxes if aprad ~ 0.
+                if os.path.exists(fn) and not (qout == 'apflux' and aprad < 1e-8):
+                    img = fits.open(fn)[extn_nb]
+                    if not iswcs:
+                        # ADM store the instrument name, if it isn't stored.
+                        instrum = img.header["INSTRUME"].lower().strip()
+                        w = WCS(img.header)
+                        x, y = w.all_world2pix(ras, decs, 0)
+                        iswcs = True
+                    # ADM get the quantity of interest at each location and
+                    # ADM store in a dictionary with the filter and quantity.
+                    if qout == 'apflux':
+                        # ADM special treatment to photometer sky.
+                        # ADM Read in the ivar image.
+                        fnivar = fileform.format(brickname, 'invvar', filt, extn)
+                        ivar = fits.open(fnivar)[extn_nb].data
+                        with np.errstate(divide='ignore', invalid='ignore'):
+                            # ADM ivars->errors, guard against 1/0.
+                            imsigma = 1./np.sqrt(ivar)
+                            imsigma[ivar == 0] = 0
+                        # ADM aperture photometry at requested radius (aprad).
+                        apxy = np.vstack((x, y)).T
+                        aper = photutils.CircularAperture(apxy, aprad)
+                        p = photutils.aperture_photometry(img.data, aper, error=imsigma)
+                        # ADM store the results.
+                        qdict[qout+'_'+filt] = np.array(p.field('aperture_sum'))
+                        err = p.field('aperture_sum_err')
+                        with np.errstate(divide='ignore', invalid='ignore'):
+                            # ADM errors->ivars, guard against 1/0.
+                            ivar = 1./err**2.
+                            ivar[err == 0] = 0.
+                        qdict[qout+'_ivar_'+filt] = np.array(ivar)
+                    else:
+                        qdict[qout+'_'+filt] = img.data[y.astype("int"), x.astype("int")]
+                # ADM if the file doesn't exist, set quantities to zero.
+                else:
+                    if qout == 'apflux':
+                        qdict['apflux_ivar_'+filt] = np.zeros(npts, dtype=qform)
+                    qdict[qout+'_'+filt] = np.zeros(npts, dtype=qform)
 
     # ADM add the MASKBITS and WISEMASK information.
     fn = os.path.join(rootdir,
@@ -397,35 +407,39 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
     mnames = zip([extn_nb, extn_nb+1, extn_nb+2],
                  ['maskbits', 'wisemask_w1', 'wisemask_w2'],
                  ['>i2', '|u1', '|u1'])
-    for mextn, mout, mform in mnames:
-        if os.path.exists(fn):
-            img = fits.open(fn)[mextn]
-            # ADM use the WCS for the per-filter quantities if it exists.
-            if not iswcs:
-                # ADM store the instrument name, if it isn't yet stored.
-                instrum = img.header["INSTRUME"].lower().strip()
-                w = WCS(img.header)
-                x, y = w.all_world2pix(ras, decs, 0)
-                iswcs = True
-            # ADM add the maskbits to the dictionary.
-            qdict[mout] = img.data[y.astype("int"), x.astype("int")]
-        else:
-            # ADM if no files are found, populate with zeros.
-            qdict[mout] = np.zeros(npts, dtype=mform)
-            # ADM if there was no maskbits file, populate with BAILOUT.
-            if mout == 'maskbits':
-                qdict[mout] |= 2**10
+    if justlist:
+        fnlist.append(fn)
+    else:
+        for mextn, mout, mform in mnames:
+            if os.path.exists(fn):
+                img = fits.open(fn)[mextn]
+                # ADM use the WCS for the per-filter quantities if it exists.
+                if not iswcs:
+                    # ADM store the instrument name, if it isn't yet stored.
+                    instrum = img.header["INSTRUME"].lower().strip()
+                    w = WCS(img.header)
+                    x, y = w.all_world2pix(ras, decs, 0)
+                    iswcs = True
+                # ADM add the maskbits to the dictionary.
+                qdict[mout] = img.data[y.astype("int"), x.astype("int")]
+            else:
+                # ADM if no files are found, populate with zeros.
+                qdict[mout] = np.zeros(npts, dtype=mform)
+                # ADM if there was no maskbits file, populate with BAILOUT.
+                if mout == 'maskbits':
+                    qdict[mout] |= 2**10
 
     # ADM populate the photometric system in the quantity dictionary.
-    if instrum is None:
-        # ADM don't count bricks where we never read a file header.
-        return
-    elif instrum == 'decam':
-        qdict['photsys'] = np.array([b"S" for x in range(npts)], dtype='|S1')
-    else:
-        qdict['photsys'] = np.array([b"N" for x in range(npts)], dtype='|S1')
-#    log.info('Recorded quantities for each point in brick {}...t = {:.1f}s'
-#                  .format(brickname,time()-start))
+    if not justlist:
+        if instrum is None:
+            # ADM don't count bricks where we never read a file header.
+            return
+        elif instrum == 'decam':
+            qdict['photsys'] = np.array([b"S" for x in range(npts)], dtype='|S1')
+        else:
+            qdict['photsys'] = np.array([b"N" for x in range(npts)], dtype='|S1')
+#        log.info('Recorded quantities for each point in brick {}...t = {:.1f}s'
+#                      .format(brickname,time()-start))
 
     # ADM calculate and add WISE depths. The WCS is different for WISE.
     iswcs = False
@@ -439,28 +453,39 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
         qnames = zip(['invvar'], ['psfdepth'], ['f4'])
         for qin, qout, qform in qnames:
             fn = fileform.format(brickname, qin, band, extn)
-            # ADM only process the WCS if there's a file for this band.
-            if os.path.exists(fn):
-                img = fits.open(fn)[extn_nb]
-                # ADM calculate the WCS if it wasn't, already.
-                if not iswcs:
-                    w = WCS(img.header)
-                    x, y = w.all_world2pix(ras, decs, 0)
-                    iswcs = True
-                # ADM get the inverse variance at each location.
-                ivar = img.data[y.astype("int"), x.astype("int")]
-                # ADM convert to WISE depth in AB. From Dustin Lang on the
-                # decam-chatter mailing list on 06/20/19, 1:59PM MST:
-                # psfdepth_Wx_AB = invvar_Wx * norm_Wx**2 / fluxfactor_Wx**2
-                # where fluxfactor = 10.** (dm / -2.5), dm = vega_to_ab[band]
-                ff = 10.**(vega_to_ab[band] / -2.5)
-                # ADM store in a dictionary with the band and quantity.
-                qdict[qout+'_'+band] = ivar * norm[band]**2 / ff**2
-            # ADM if the file doesn't exist, set quantities to zero.
+            if justlist:
+                fnlist.append(fn)
             else:
-                qdict[qout+'_'+band] = np.zeros(npts, dtype=qform)
+                # ADM only process the WCS if there's a file for this band.
+                if os.path.exists(fn):
+                    img = fits.open(fn)[extn_nb]
+                    # ADM calculate the WCS if it wasn't, already.
+                    if not iswcs:
+                        w = WCS(img.header)
+                        x, y = w.all_world2pix(ras, decs, 0)
+                        iswcs = True
+                    # ADM get the inverse variance at each location.
+                    ivar = img.data[y.astype("int"), x.astype("int")]
+                    # ADM convert to WISE depth in AB. From Dustin Lang on the
+                    # decam-chatter mailing list on 06/20/19, 1:59PM MST:
+                    # psfdepth_Wx_AB = invvar_Wx * norm_Wx**2 / fluxfactor_Wx**2
+                    # where fluxfactor = 10.** (dm / -2.5), dm = vega_to_ab[band]
+                    ff = 10.**(vega_to_ab[band] / -2.5)
+                    # ADM store in a dictionary with the band and quantity.
+                    qdict[qout+'_'+band] = ivar * norm[band]**2 / ff**2
+                # ADM if the file doesn't exist, set quantities to zero.
+                else:
+                    qdict[qout+'_'+band] = np.zeros(npts, dtype=qform)
 
     # ADM look up the RELEASE based on "standard" DR directory structure.
+    if justlist:
+        # ADM we need a tractor file. Then we have a list of all needed
+        # ADM files. So, return if justlist was passed as True.
+        tracdir = os.path.join(drdir, 'tractor', brickname[:3])
+        tracfile = os.path.join(tracdir, 'tractor-{}.fits'.format(brickname))
+        fnlist.append(tracfile)
+        return fnlist
+
     gen = iglob(os.path.join(drdir, "tractor", "*", "tractor*fits"))
     try:
         release = fitsio.read(next(gen), columns="release", rows=0)[0]

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -49,29 +49,40 @@ start = time()
 
 
 def dr_extension(drdir):
-    """Determine the extension information for files in a legacy survey coadd directory
+    """Extension information for files in a Legacy Survey coadd directory
 
     Parameters
     ----------
     drdir : :class:`str`
-       The root directory pointing to a Data Release from the Legacy Surveys
-       e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
+        The root directory for a Data Release from the Legacy Surveys
+        e.g. /global/project/projectdirs/cosmo/data/legacysurvey/dr7.
 
     Returns
     -------
     :class:`str`
         Whether the file extension is 'gz' or 'fz'.
     :class:`int`
-        The corresponding FITS extension number that needs to be read (0 or 1).
-    """
-    # ADM for speed, create a generator of all of the nexp files in the coadd directory.
-    gen = iglob(drdir+"/coadd/*/*/*nexp*")
-    # ADM and pop the first one.
-    anexpfile = next(gen)
-    extn = anexpfile[-2:]
+        Corresponding FITS extension number to be read (0 or 1).
 
-    if extn == 'gz':
-        return 'gz', 0
+    Notes
+    -----
+        - If the directory structure seems wrong or can't be found then
+          the post-DR4 convention (.fz files) is returned.
+    """
+    try:
+        # ADM a generator of all of the nexp files in the coadd directory.
+        gen = iglob(drdir+"/coadd/*/*/*nexp*")
+        # ADM pop the first file in the generator.
+        anexpfile = next(gen)
+        extn = anexpfile[-2:]
+        if extn == 'gz':
+            return 'gz', 0
+    # ADM this is triggered if the generator is empty.
+    except StopIteration:
+        msg = "couldn't find any nexp files in {}...".format(
+            os.path.join(drdir, "coadd"))
+        msg += "Defaulting to '.fz' extensions for Legacy Surveys coadd files"
+        log.info(msg)
 
     return 'fz', 1
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -220,7 +220,7 @@ def randoms_in_a_brick_from_name(brickname, drdir, density=100000):
     return ras, decs
 
 
-def _pre_or_post_dr8(drdir):
+def pre_or_post_dr8(drdir):
     """Whether the imaging surveys directory structure is before or after DR8
 
     Parameters
@@ -235,6 +235,11 @@ def _pre_or_post_dr8(drdir):
        For DR8, this just returns the original directory as a list. For DR8
        this returns a list of two directories, one corresponding to DECaLS
        and one corresponding to BASS/MzLS.
+
+    Notes
+    -----
+        - If the directory structure seems wrong or missing then the DR8
+          (and after) convention of a north/south split is assumed.
     """
     if os.path.exists(os.path.join(drdir, "coadd")):
         drdirs = [drdir]
@@ -257,7 +262,7 @@ def dr8_quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
       wrapper also defaults to the behavior for only having one survey.
     """
     # ADM determine if we must traverse two sets of brick directories.
-    drdirs = _pre_or_post_dr8(drdir)
+    drdirs = pre_or_post_dr8(drdir)
 
     # ADM make the dictionary of quantities for one or two directories.
     qall = []
@@ -302,7 +307,8 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
         `apflux_` output values are set to zero.
     justlist : :class:`bool`, optional, defaults to ``False``
         If ``True``, return a MAXIMAL list of all POSSIBLE files needed
-        to run for `brickname` and `drdir`. Overrides other inputs.
+        to run for `brickname` and `drdir`. Overrides other inputs, but
+        ra/dec still have to be passed as *something* (e.g., [1], [1]).
 
     Returns
     -------
@@ -1354,7 +1360,7 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
     """
     # ADM grab brick information for this data release. Depending on whether this
     # ADM is pre-or-post-DR8 we need to find the correct directory or directories.
-    drdirs = _pre_or_post_dr8(drdir)
+    drdirs = pre_or_post_dr8(drdir)
     brickdict = get_brick_info(drdirs, counts=True)
     # ADM this is just the UNIQUE brick names across all surveys.
     bricknames = np.array(list(brickdict.keys()))


### PR DESCRIPTION
This PR updates general utilities and the code that generates randoms for "real" data to help the mocks interface with the pixel-level Legacy Surveys coadd images. It includes:

- A new function `geomask.get_brick_info()` that looks up the brick names associated with HEALPixels at a given `nside`.
- Updates to `randoms.quantities_at_positions_in_a_brick()` to add a `justlist` option to list the required input files for that function. Note that passing `justlist` returns the maximal possible set of files needed to run `quantities_at_positions_in_a_brick()`, which can, in fact, run with few (or zero!) imaging files for any particular brick.
- A few irrelevant and minor bug fixes and documentation updates.