### PR TITLE
New tutorial with background information on how MTL works

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.39.1 (unreleased)
 -------------------
 
-No changes yet.
+* Add a new notebook tutorial about the Merged Target List [`PR #614`_].
+
+.. _`PR #614`: https://github.com/desihub/desitarget/pull/614
 
 0.39.0 (2020-05-01)
 -------------------

--- a/doc/nb/Intro-to-mtl.ipynb
+++ b/doc/nb/Intro-to-mtl.ipynb
@@ -310,7 +310,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK\")\n",
+    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK|GRAY\")\n",
     "# ADM make the observing conditions more human-readable:\n",
     "obscon = []\n",
     "for oc in mtltargets[\"OBSCONDITIONS\"]:\n",
@@ -378,7 +378,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK\")\n",
+    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK|GRAY\")\n",
     "print(mtltargets[\"DESI_TARGET\", \"PRIORITY_INIT\", \"NUMOBS_INIT\", \"NUMOBS_MORE\"])"
    ]
   },
@@ -493,7 +493,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK\", zcat=zcat)\n",
+    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK|GRAY\", zcat=zcat)\n",
     "print(mtltargets['DESI_TARGET', 'TARGETID', 'PRIORITY_INIT', 'NUMOBS_INIT', 'PRIORITY', 'NUMOBS_MORE'])"
    ]
   },
@@ -502,7 +502,7 @@
    "metadata": {},
    "source": [
     "To summarize the output:\n",
-    "- Any target (ELGs, LRGs) for which only one observation was requested has had its priority set to the equivalent of \"DONE\".\n",
+    "- Any target (ELGs, LRGs) for which only one observation was requested has had its priority set to the equivalent of `\"DONE\"`.\n",
     "- Any QSO target that was categorically confirmed to be a (\"tracer\") QSO at z < 2.15 without any warnings has had `NUMOBS_MORE` set to `0` and its priority set to the equivalent of `\"DONE\"`.\n",
     "- Any QSO target that was confirmed to be a (\"Lyman-alpha\") QSO at z > 2.15 without any warnings has had its priority set to the equivalent of `\"MORE_ZGOOD\"` and `NUMOBS_MORE` is set to `3`.\n",
     "- Any QSO target for which the spectrum flagged a redshift warning has had `NUMOBS_MORE` set to `3` but has retained its initial priority of `3400`.        "
@@ -565,7 +565,7 @@
     "    \n",
     "    print(\"...{}...\".format(kind))\n",
     "    print(zcat)\n",
-    "    mtltargets = mtl.make_mtl(targets, obscon=\"DARK\", zcat=zcat)\n",
+    "    mtltargets = mtl.make_mtl(targets, obscon=\"DARK|GRAY\", zcat=zcat)\n",
     "    print(mtltargets['DESI_TARGET', 'TARGETID', 'PRIORITY_INIT', 'NUMOBS_INIT', 'PRIORITY', 'NUMOBS_MORE'])"
    ]
   }

--- a/doc/nb/Intro-to-mtl.ipynb
+++ b/doc/nb/Intro-to-mtl.ipynb
@@ -1,0 +1,592 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction to the Merged Target List #\n",
+    "### Author: Adam D. Myers, University of Wyoming ###\n",
+    "\n",
+    "This Notebook describes how the logic in `mtl.py` (the _Merged Target List_) uses priorities and numbers of observations set by the targeting bitmasks to determine the observational \"state\" of a target.\n",
+    "\n",
+    "If you identify any errors or have requests for additional functionality please create a new issue at https://github.com/desihub/desitarget/issues or send a note to desi-data@desi.lbl.gov.\n",
+    "\n",
+    "Last updated May 2020 using DESI software release:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "release=\"19.12\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting started\n",
+    "\n",
+    "### Using NERSC\n",
+    "\n",
+    "The easiest way to get started is to use the jupyter server at NERSC so that you don't need to\n",
+    "install any code or download any data locally.\n",
+    "\n",
+    "If you need a NERSC account, see https://desi.lbl.gov/trac/wiki/Computing/AccessNersc\n",
+    "\n",
+    "Then do the one-time jupyter configuration described at https://desi.lbl.gov/trac/wiki/Computing/JupyterAtNERSC\n",
+    "\n",
+    "From a NERSC command line, checkout a copy of the tutorial code, *e.g.* from cori.nersc.gov\n",
+    "```console\n",
+    "mkdir -p $HOME/desi/\n",
+    "cd $HOME/desi/\n",
+    "git clone https://github.com/desihub/tutorials\n",
+    "```\n",
+    "And then go to https://jupyter.nersc.gov, login, navigate to where you checked out this package (*e.g.* `$HOME/desi/tutorials`), and double-click on `Intro_to_mtl.ipynb`.\n",
+    "\n",
+    "This tutorial has been tested using the:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"DESI {}\".format(release)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "kernel installed at NERSC.  To get an equivalent environment from a cori command line use the command printed out below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('source /global/common/software/desi/desi_environment.sh {}'.format(release))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import required modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "from astropy.table import Table\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%pylab inline\n",
+    "\n",
+    "# ADM import the mtl code and a function used to initialize target states.\n",
+    "from desitarget import mtl\n",
+    "from desitarget.targets import initial_priority_numobs\n",
+    "\n",
+    "# ADM import the masks that define observing layers and observing states.\n",
+    "from desitarget.targetmask import obsconditions, obsmask\n",
+    "\n",
+    "# ADM import the Main Survey targeting bit mask.\n",
+    "from desitarget.targetmask import desi_mask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we will focus on the Main Survey targeting bit mask for this tutorial. If you instead wanted to study the behavior of MTL for the SV bit-mask, you would use:\n",
+    "```\n",
+    "from desitarget.sv1.sv1_targetmask import desi_mask\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are running locally and any of these fail, \n",
+    "you should go back through the [installation instructions](https://desi.lbl.gov/trac/wiki/Pipeline/GettingStarted/Laptop) and/or email `desi-data@desi.lbl.gov` if you get stuck.\n",
+    "If you are running from jupyter.nersc.gov and have problems, double check that your kernel is as printed below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"DESI {}\".format(release))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preliminaries\n",
+    "\n",
+    "This tutorial will focus on aspects of the targeting bitmasks and coding logic that control the observational state of a target. To understand the more basic aspects of the targeting bitmasks (how we know what is a QSO, or ELG, target, etc.) you might want to try the [bits and bitmasks tutorial.](https://github.com/desihub/desitarget/blob/master/doc/nb/target-selection-bits-and-bitmasks.ipynb)\n",
+    "\n",
+    "How a target is observed (how it is handled by the desitarget `fiberassign` code) depends on three main targeting concepts:\n",
+    "\n",
+    "- The observational layer (conditions) in which a target can be observed. For instance, is a target suitable for bright-time or dark-time obervations?\n",
+    "- The priority of the target. Is this target a highest-priority target, or should we place a fiber on another target first instead?\n",
+    "- The number of observations for the target. Should we place a fiber on this target 1 time? Or maybe 4 times?\n",
+    "\n",
+    "Initially, all of these quantities are set by static information in the [desitarget bitmask yaml file](https://github.com/desihub/desitarget/blob/master/py/desitarget/data/targetmask.yaml) but they can subsequently be altered by the [desitarget mtl code](https://github.com/desihub/desitarget/blob/master/py/desitarget/mtl.py) depending on each target's observational state."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Understanding what information is intially set for each targeting bit\n",
+    "\n",
+    "When a target is initally flagged for DESI observations, the information in the [desitarget bitmask yaml file](https://github.com/desihub/desitarget/blob/master/py/desitarget/data/targetmask.yaml) is used to set an initial observational layer, priority and number of observations. Consider the following example for a quasar target:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bitname=\"QSO\"\n",
+    "print('Bit value associated with a DESI target with bit name \"{}\": {}'.format(bitname, desi_mask.QSO))\n",
+    "print('Conditions (layers) in which a {} is allowed to be observed: {}'.format(bitname, desi_mask.QSO.obsconditions))\n",
+    "print('Initial priorities set for a {}: {}'.format(bitname, desi_mask.QSO.priorities))\n",
+    "print('Initial number of observations set for a {}: {}'.format(bitname, desi_mask.QSO.numobs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or for an ELG or LRG target:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for bitname in [\"ELG\", \"LRG\"]:\n",
+    "    print('Bit value associated with a DESI target with bit name \"{}\": {}'.format(bitname, desi_mask[bitname]))\n",
+    "    print('Conditions (layers) in which a {} is allowed to be observed: {}'.format(bitname, desi_mask[bitname].obsconditions))\n",
+    "    print('Initial priorities set for an {}: {}'.format(bitname, desi_mask[bitname].priorities))\n",
+    "    print('Initial number of observations set for an {}: {}'.format(bitname, desi_mask[bitname].numobs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These quantities define the \"state-of-play\" for a given target before any DESI observations have occurred. So, for example, if an ELG is being observed for the first time, we will request 1 observation of that target at a priority of 3000, if a QSO is being observed for the first time, we will request 4 observations of such a target at a priority of 3400. The actual relative values of the priorites are unimportant, but the target with the highest priority will always be assigned a fiber first.\n",
+    "\n",
+    "The values in the `priorities` dictionary merit some further explanation. As we will see later in this notebook, the priority of a target can change depending on its observational state. The keys in the `priorities` dictionary define what priority to set for a target that has transitioned to that observational state. \n",
+    "\n",
+    "So, for example, an LRG will start with a priority of `3200` (`UNOBS`) but will transition to a priority of `2` (`DONE`) as soon as we have one observation of it. For target classes that request more than one observation, such as Lyman-alpha QSOs, the behavior can be more complex. If we have observed the QSO and request more observations, and the redshift is flagged as problematic, the QSO target will be assigned a priority of 3400 (`MORE_ZWARN`). If we have observed the QSO and request more observations, and the redshift is flagged as good, the QSO target will be assigned a priority of 3500 (`MORE_ZGOOD`). The full suite of allowed observational states for a DESI target can be retrieved using the `obsmask` bitmask (which we imported earlier):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(obsmask)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, the full suite of allowed observational layers (dark-time, bright-time, etc.) can be retrieved using the `obsconditions` bitmask:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(obsconditions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What happens if a target is _both_ an ELG _and_ a QSO?\n",
+    "\n",
+    "No target is an island, and it is certainly possible for a DESI target to satisfy two sets of target selection criteria and be assigned a bit value consistent with two targets. Again, you might want to try the [bits and bitmasks tutorial.](https://github.com/desihub/desitarget/blob/master/doc/nb/target-selection-bits-and-bitmasks.ipynb) for more insight into bit values. For example, though, consider the first 8 possible bit values and what they signify for the various DESI target classes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(8):\n",
+    "    print('{}: {}'.format(i, desi_mask.names(i)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bit value (2 + 4 =) 6, for instance, which corresponds to 2<sup>1</sup> (\"ELG\") + 2<sup>2</sup> (\"QSO\"), denotes a target that satisfies the selection criteria for two different target classes. How do we set priorities and numbers of observations in such a case?\n",
+    "\n",
+    "Clearly, these targets need to have their priorities \"merged\" in some sense. If you've been paying attention, you've probably worked out that this is part of what the desitarget mtl (Merged Target List; henceforth MTL) [code](https://github.com/desihub/desitarget/blob/master/py/desitarget/mtl.py) achieves.\n",
+    "\n",
+    "Let's set up a specific example for a target that is both an ELG and QSO, and see how MTL processes such a target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "targets = Table()\n",
+    "ELGbit, QSObit = desi_mask[\"ELG\"], desi_mask[\"QSO\"]\n",
+    "targets[\"DESI_TARGET\"] = np.array([ELGbit, QSObit, QSObit | ELGbit])\n",
+    "print(targets)\n",
+    "bitnames = []\n",
+    "for dt in targets[\"DESI_TARGET\"]:\n",
+    "    # ADM we'll store these bit names for later use, too!\n",
+    "    bitnames.append(desi_mask.names(dt))\n",
+    "    print(dt, desi_mask.names(dt))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, now we have a simple set of targets defined. We'll also need to add some standard columns, as these are expected by the MTL code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = len(targets)\n",
+    "targets['BITNAMES'] = bitnames\n",
+    "targets['BGS_TARGET'] = np.zeros(n, dtype=np.int64)\n",
+    "targets['MWS_TARGET'] = np.zeros(n, dtype=np.int64)\n",
+    "targets['TARGETID'] = np.arange(n)\n",
+    "targets[\"PRIORITY_INIT\"] = 0\n",
+    "targets[\"NUMOBS_INIT\"] = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what happend to the priorities and observing conditions (layers) for these targets after they were merged by calling the MTL code. Note that as the logic in MTL is different depending on the observing conditions, the MTL code expects to be passed an observing layer to understand what \"flavor\" of survey (dark-time, etc.) it is processing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK\")\n",
+    "# ADM make the observing conditions more human-readable:\n",
+    "obscon = []\n",
+    "for oc in mtltargets[\"OBSCONDITIONS\"]:\n",
+    "    obscon.append(obsconditions.names(oc))\n",
+    "mtltargets[\"LAYERS\"] = np.array(obscon)\n",
+    "print(mtltargets[\"BITNAMES\", \"PRIORITY\", \"OBSCONDITIONS\", \"LAYERS\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some important things to note:\n",
+    "\n",
+    "- The priority for the merged \"ELG/QSO\" target was set to that of the highest priority target.\n",
+    "- The observing conditions for the merged \"ELG/QSO\" target were combined across all targets.\n",
+    "\n",
+    "Note that _this example was purely to show you why a mechanism for merging targets is critical_. In reality, `desitarget` sets initial priorities, observing conditions, and numbers of observations _in advance of running MTL_. This makes the initial values of these parameters more traceable (as they then appear as column names in the `desitarget` initial targeting files). Critically, this step _has_ to be done to _correctly initialize the numbers of observations_ (`NUMOBS_INIT`) for DESI targets. So a more complete example is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "targets = Table()\n",
+    "targets[\"DESI_TARGET\"] = np.array([ELGbit, QSObit, QSObit | ELGbit])\n",
+    "targets['BITNAMES'] = bitnames\n",
+    "n = len(targets)\n",
+    "targets['BGS_TARGET'] = np.zeros(n, dtype=np.int64)\n",
+    "targets['MWS_TARGET'] = np.zeros(n, dtype=np.int64)\n",
+    "targets['TARGETID'] = np.arange(n)\n",
+    "\n",
+    "# ADM use function outside of MTL to more transparental initialize priorities and numobs.\n",
+    "pinit, ninit = initial_priority_numobs(targets)\n",
+    "targets[\"PRIORITY_INIT\"] = pinit\n",
+    "targets[\"NUMOBS_INIT\"] = ninit\n",
+    "\n",
+    "print(targets[\"BITNAMES\", \"DESI_TARGET\", \"PRIORITY_INIT\", \"NUMOBS_INIT\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, for instance, that the merged \"ELG/QSO\" target requires 4 observations (as it is potentially a Lyman-alpha QSO target).\n",
+    "\n",
+    "In \"official\" DESI targeting files, e.g. as stored in the following NERSC directories:\n",
+    "```\n",
+    "/global/cfs/projectdirs/desi/target/catalogs/dr8\n",
+    "/global/cfs/projectdirs/desi/target/catalogs/dr9\n",
+    "```\n",
+    "`PRIORITY_INIT` and `NUMOBS_INIT` have already been set in this manner. \n",
+    "\n",
+    "With reasonable initial values of `PRIORITY_INIT` and `NUMOBS_INIT`, MTL will pass through the number of additional observations required for each target (`NUMOBS_MORE`). For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK\")\n",
+    "print(mtltargets[\"DESI_TARGET\", \"PRIORITY_INIT\", \"NUMOBS_INIT\", \"NUMOBS_MORE\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Updating the status of a target\n",
+    "\n",
+    "The MTL code also contains logic to update the priorities of, and number of observations for, a target based on each target's current observational state. Most of this logic is contained in the [desitarget.targets module](https://github.com/desihub/desitarget/blob/master/py/desitarget/targets.py).\n",
+    "\n",
+    "As the DESI survey progresses, classifications and redshifts of each target will be included in a redshift catalog (henceforth a _zcat_) passed back to MTL from the DESI spectroscopic pipeline. Passing this _zcat_ as an input to MTL, changes the observational state of each target, updating the number of required additional observations and transitioning between the priorites described earlier in this tutorial (`\"UNOBS\"`, `\"DONE\"`, etc.). Let's look at an example. First, let's construct a set of targets in a manner similar to what we did in the previous section of this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "targets = Table()\n",
+    "\n",
+    "# ADM we have 7 targets, two ELGs, an LRG, and four quasars.\n",
+    "classes = np.array(['ELG', 'ELG', 'LRG', 'QSO', 'QSO', 'QSO', 'QSO'])\n",
+    "n = len(classes)\n",
+    "\n",
+    "# ADM pull the appropriate bit value for each target type from the desi_mask.\n",
+    "targets['DESI_TARGET'] = [desi_mask[c].mask for c in classes]\n",
+    "\n",
+    "# ADM the BGS and MWS target bits need to be set, but we'll ignore them (set them to zero) for this tutorial.\n",
+    "targets['BGS_TARGET'] = np.zeros(n, dtype=np.int64)\n",
+    "targets['MWS_TARGET'] = np.zeros(n, dtype=np.int64)\n",
+    "\n",
+    "# ADM this needs to be a unique TARGETID. For this tutorial, we'll just use the integers 0-6.\n",
+    "targets['TARGETID'] = np.arange(n)\n",
+    "\n",
+    "# ADM determine the initial PRIORITY and NUMOBS for the input target classes.\n",
+    "pinit, ninit = initial_priority_numobs(targets)\n",
+    "targets[\"PRIORITY_INIT\"] = pinit\n",
+    "targets[\"NUMOBS_INIT\"] = ninit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's also construct a _zcat_:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zcat = Table()\n",
+    "# ADM MTL matches the targets and the zcat on TARGETID.\n",
+    "# ADM but let's just assume everything matches row-by-row.\n",
+    "zcat['TARGETID'] = targets['TARGETID']\n",
+    "# ADM the spectroscopic pipeline assigned the following redshifts...\n",
+    "zcat['Z'] = [0.0, 1.2, 0.9, 2.16, 2.7, 2.14, 1.4]\n",
+    "# ADM ...and the following classifications.\n",
+    "zcat['SPECTYPE'] = ['STAR', 'GALAXY', 'GALAXY', 'QSO', 'QSO', 'QSO', 'QSO']\n",
+    "# ADM three of the classifications/redshifts were dubious (ZWARN=4).\n",
+    "zcat['ZWARN'] = [4, 0, 0, 0, 4, 0, 4]\n",
+    "# ADM each of our targets has one spectroscopic observation.\n",
+    "zcat['NUMOBS'] = [1, 1, 1, 1, 1, 1, 1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, here's the initial list of target properties (a static set of assignations):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(targets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and here's the spectroscopic information we gleaned from observing these targets once in DESI:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(zcat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what MTL makes of all of this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mtltargets = mtl.make_mtl(targets, obscon=\"DARK\", zcat=zcat)\n",
+    "print(mtltargets['DESI_TARGET', 'TARGETID', 'PRIORITY_INIT', 'NUMOBS_INIT', 'PRIORITY', 'NUMOBS_MORE'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To summarize the output:\n",
+    "- Any target (ELGs, LRGs) for which only one observation was requested has had its priority set to the equivalent of \"DONE\".\n",
+    "- Any QSO target that was categorically confirmed to be a (\"tracer\") QSO at z < 2.15 without any warnings has had `NUMOBS_MORE` set to `0` and its priority set to the equivalent of `\"DONE\"`.\n",
+    "- Any QSO target that was confirmed to be a (\"Lyman-alpha\") QSO at z > 2.15 without any warnings has had its priority set to the equivalent of `\"MORE_ZGOOD\"` and `NUMOBS_MORE` is set to `3`.\n",
+    "- Any QSO target for which the spectrum flagged a redshift warning has had `NUMOBS_MORE` set to `3` but has retained its initial priority of `3400`.        "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How the MTL logic affects every (dark-time) target class\n",
+    "\n",
+    "By extension of the last example, we can test how MTL affects every target class individually, remembering the general precepts that for merged targets (e.g. a target that is both an ELG and a QSO) the highest `PRIORITY` and `NUMOBS` for the individual classes will characterize the behavior, and all observing conditions (layers) will be merged across classes. Here goes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for kind in [\"QSO\", \"LRG\", \"ELG\"]:\n",
+    "    targets = Table()\n",
+    "\n",
+    "    # ADM 4 targets of this kind\n",
+    "    classes = np.array([kind, kind, kind, kind])\n",
+    "    n = len(classes)\n",
+    "    \n",
+    "    # ADM pull the appropriate bit value for each target type from the desi_mask.\n",
+    "    targets['DESI_TARGET'] = [desi_mask[c].mask for c in classes]\n",
+    "\n",
+    "    # ADM the BGS and MWS target bits need to be set, but we'll ignore them (set them to zero) for this tutorial.\n",
+    "    targets['BGS_TARGET'] = np.zeros(n, dtype=np.int64)\n",
+    "    targets['MWS_TARGET'] = np.zeros(n, dtype=np.int64)\n",
+    "\n",
+    "    # ADM this needs to be a unique TARGETID. For this tutorial, we'll just use the integers 0-4.\n",
+    "    targets['TARGETID'] = np.arange(n)\n",
+    "\n",
+    "    # ADM determine the initial PRIORITY and NUMOBS for the input target classes.\n",
+    "    pinit, ninit = initial_priority_numobs(targets)\n",
+    "    targets[\"PRIORITY_INIT\"] = pinit\n",
+    "    targets[\"NUMOBS_INIT\"] = ninit\n",
+    "\n",
+    "    zcat = Table()\n",
+    "    \n",
+    "    # ADM MTL matches the targets and the zcat on TARGETID.\n",
+    "    # ADM but let's just assume everything matches row-by-row.\n",
+    "    zcat['TARGETID'] = targets['TARGETID']\n",
+    "    \n",
+    "    # ADM pick two redshifts above the Lyman-Alpha cutoff and two below.\n",
+    "    zcat['Z'] = [2.5, 2.7, 1.5, 1.2]\n",
+    "    \n",
+    "    # ADM MTL doesn't care about classifications, so everything can be a GALAXY.\n",
+    "    zcat['SPECTYPE'] = ['GALAXY', 'GALAXY', 'GALAXY', 'GALAXY']\n",
+    "    \n",
+    "    # ADM flag warnings in one Lyman-alpha QSO and one tracer.\n",
+    "    zcat['ZWARN'] = [4, 0, 4, 0]\n",
+    "\n",
+    "    # ADM each of our targets has one spectroscopic observation.\n",
+    "    zcat['NUMOBS'] = [1, 1, 1, 1]\n",
+    "    \n",
+    "    print(\"...{}...\".format(kind))\n",
+    "    print(zcat)\n",
+    "    mtltargets = mtl.make_mtl(targets, obscon=\"DARK\", zcat=zcat)\n",
+    "    print(mtltargets['DESI_TARGET', 'TARGETID', 'PRIORITY_INIT', 'NUMOBS_INIT', 'PRIORITY', 'NUMOBS_MORE'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "DESI 19.12",
+   "language": "python",
+   "name": "desi-19.12"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/nb/Intro-to-mtl.ipynb
+++ b/doc/nb/Intro-to-mtl.ipynb
@@ -301,7 +301,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's see what happend to the priorities and observing conditions (layers) for these targets after they were merged by calling the MTL code. Note that as the logic in MTL is different depending on the observing conditions, the MTL code expects to be passed an observing layer to understand what \"flavor\" of survey (dark-time, etc.) it is processing:"
+    "Let's see what happened to the priorities and observing conditions (layers) for these targets after they were merged by calling the MTL code:"
    ]
   },
   {
@@ -327,6 +327,9 @@
     "\n",
     "- The priority for the merged \"ELG/QSO\" target was set to that of the highest priority target.\n",
     "- The observing conditions for the merged \"ELG/QSO\" target were combined across all targets.\n",
+    "- As the logic in MTL is different depending on the observing layer, the MTL code expects to be passed an observing layer to understand what \"flavor\" of survey (dark-time, etc.) it is processing. \n",
+    "    - Currently, this functionality means that users will need to pass either `obscon=\"DARK|GRAY\"` (for the dark-time survey) or `obscon=\"BRIGHT\"` (for the bright-time survey).\n",
+    "    - It's entirely possible, though, that \"special\" layers with unique MTL logic could be created in the future (triggered by, e.g., `obscon=\"SOME_SPECIAL_LAYER\"`).\n",
     "\n",
     "Note that _this example was purely to show you why a mechanism for merging targets is critical_. In reality, `desitarget` sets initial priorities, observing conditions, and numbers of observations _in advance of running MTL_. This makes the initial values of these parameters more traceable (as they then appear as column names in the `desitarget` initial targeting files). Critically, this step _has_ to be done to _correctly initialize the numbers of observations_ (`NUMOBS_INIT`) for DESI targets. So a more complete example is:"
    ]


### PR DESCRIPTION
This PR adds an introductory tutorial about the philosophy of the Merged Target List and how the desitarget.mtl.make_mtl() code works.

It doesn't affect the overall `desitarget` codebase, so I'll merge it fairly quickly.