### PR TITLE
Ensure NUMOBS_MORE=1 for tracer QSOs that are also other targets

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,19 @@ desitarget Change Log
 0.39.1 (unreleased)
 -------------------
 
-* Add a new notebook tutorial about the Merged Target List [`PR #614`_].
+* `NUMOBS_MORE` for tracer QSOs that are also other targets [`PR #617`]:
+    * Separate the calculation of `NUMOBS_MORE` into its own function.
+    * Consistently use `zcut` = 2.1 to define Lyman-Alpha QSOs.
+    * Check tracer QSOs that are other targets drop to `NUMOBS_MORE` = 0.
+    * New unit test to enforce that check on such tracer QSOs.
+    * New unit test to check BGS always gets `NUMOBS_MORE` = 1 in BRIGHT.
+    * Enforce maximum seed in :func:`randoms_in_a_brick_from_edges()`.
 * Update masks for QSO Random Forest selection for DR8 [`PR #615`]
+* Add a new notebook tutorial about the Merged Target List [`PR #614`_].
 
 .. _`PR #614`: https://github.com/desihub/desitarget/pull/614
 .. _`PR #615`: https://github.com/desihub/desitarget/pull/615
+.. _`PR #617`: https://github.com/desihub/desitarget/pull/617
 
 0.39.0 (2020-05-01)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,14 +5,14 @@ desitarget Change Log
 0.39.1 (unreleased)
 -------------------
 
-* `NUMOBS_MORE` for tracer QSOs that are also other targets [`PR #617`]:
+* `NUMOBS_MORE` for tracer QSOs that are also other targets [`PR #617`_]:
     * Separate the calculation of `NUMOBS_MORE` into its own function.
     * Consistently use `zcut` = 2.1 to define Lyman-Alpha QSOs.
     * Check tracer QSOs that are other targets drop to `NUMOBS_MORE` = 0.
     * New unit test to enforce that check on such tracer QSOs.
     * New unit test to check BGS always gets `NUMOBS_MORE` = 1 in BRIGHT.
     * Enforce maximum seed in :func:`randoms_in_a_brick_from_edges()`.
-* Update masks for QSO Random Forest selection for DR8 [`PR #615`]
+* Update masks for QSO Random Forest selection for DR8 [`PR #615`_]
 * Add a new notebook tutorial about the Merged Target List [`PR #614`_].
 
 .. _`PR #614`: https://github.com/desihub/desitarget/pull/614

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1350,7 +1350,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None,
             # Add rf proba test result to "qso" mask
             qso[colorsReducedIndex[tmpReleaseOK]] = tmp_rf_proba >= pcut
 
-        tmpReleaseOK = (releaseReduced >= 5000) & (releaseReduced<8000)
+        tmpReleaseOK = (releaseReduced >= 5000) & (releaseReduced < 8000)
         if np.any(tmpReleaseOK):
             # rf initialization - colors data duplicated within "myRF"
             rf = myRF(colorsReduced[tmpReleaseOK], pathToRF,

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -126,6 +126,12 @@ def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax, density=100000,
     # ADM note this is only unique for bricksize=0.25 for bricks
     # ADM that are more than 0.25 degrees from the poles.
     uniqseed = seed*int(1e7)+int(4*ramin)*1000+int(4*(decmin+90))
+    # ADM np.random only allows seeds < 2**32...
+    maxseed = (2**32-int(4*ramin)*1000-int(4*(decmin+90)))/1e7
+    if seed > maxseed:
+        msg = 'seed must be < {} but you passed {}!!!'.format(maxseed, seed)
+        log.critical(msg)
+        raise ValueError(msg)
     np.random.seed(uniqseed)
 
     # ADM generate random points within the brick at the requested density

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -852,7 +852,7 @@ def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
              .format(mindec, time()-start))
     from desitarget.randoms import randoms_in_a_brick_from_edges
     ras, decs = randoms_in_a_brick_from_edges(
-        0., 360., mindec, 90., density=nskiespersqdeg, wrap=False, seed=538)
+        0., 360., mindec, 90., density=nskiespersqdeg, wrap=False, seed=414)
 
     # ADM limit randoms by HEALPixel, if requested.
     if pixlist is not None:

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -399,12 +399,12 @@ def calc_numobs_more(targets, zcat, obscon):
     targets : :class:`~numpy.ndarray`
         numpy structured array or astropy Table of targets. Must include
         the columns `DESI_TARGET`, `BGS_TARGET`, `MWS_TARGET`
-        (or their SV/cmx equivalents).
+        (or their SV/cmx equivalents) `TARGETID` and `NUMOBS_INIT`.
     zcat : :class:`~numpy.ndarray`
-        numpy structured array or Table of redshift information. Must
-        include 'Z', `ZWARN`, `NUMOBS` and be the same length as
-        `targets`. May also contain `NUMOBS_MORE` if this isn't the
-        first time through MTL and `NUMOBS > 0`.
+        numpy structured array or Table of redshift info. Must include
+        `Z`, `ZWARN`, `NUMOBS` and `TARGETID` and BE SORTED ON TARGETID
+        to match `targets` row-by-row. May also contain `NUMOBS_MORE` if
+        this isn't the first time through MTL and `NUMOBS > 0`.
     obscon : :class:`str`
         A combination of strings that are in the desitarget bitmask yaml
         file (specifically in `desitarget.targetmask.obsconditions`), e.g.
@@ -425,8 +425,8 @@ def calc_numobs_more(targets, zcat, obscon):
           of 1 in bright time and QSO "tracer" targets which always get
           NUMOBS_MORE=0 in dark time.
     """
-    # ADM check the input arrays are the same length.
-    assert len(targets) == len(zcat)
+    # ADM check input arrays are sorted to match row-by-row on TARGETID.
+    assert np.all(targets["TARGETID"] == zcat["TARGETID"])
 
     # ADM determine whether the input targets are main survey, cmx or SV.
     colnames, masks, survey = main_cmx_or_sv(targets, scnd=True)
@@ -483,12 +483,12 @@ def calc_priority(targets, zcat, obscon):
     targets : :class:`~numpy.ndarray`
         numpy structured array or astropy Table of targets. Must include
         the columns `DESI_TARGET`, `BGS_TARGET`, `MWS_TARGET`
-        (or their SV/cmx equivalents).
+        (or their SV/cmx equivalents) and `TARGETID`.
     zcat : :class:`~numpy.ndarray`
-        numpy structured array or Table of redshift information. Must
-        include 'Z', `ZWARN`, `NUMOBS` and be the same length as
-        `targets`. May also contain `NUMOBS_MORE` if this isn't the
-        first time through MTL and `NUMOBS > 0`.
+        numpy structured array or Table of redshift info. Must include
+        `Z`, `ZWARN`, `NUMOBS` and `TARGETID` and BE SORTED ON TARGETID
+        to match `targets` row-by-row. May also contain `NUMOBS_MORE` if
+        this isn't the first time through MTL and `NUMOBS > 0`.
     obscon : :class:`str`
         A combination of strings that are in the desitarget bitmask yaml
         file (specifically in `desitarget.targetmask.obsconditions`), e.g.
@@ -506,8 +506,8 @@ def calc_priority(targets, zcat, obscon):
         - Will automatically detect if the passed targets are main
           survey, commissioning or SV and behave accordingly.
     """
-    # ADM check the input arrays are the same length.
-    assert len(targets) == len(zcat)
+    # ADM check input arrays are sorted to match row-by-row on TARGETID.
+    assert np.all(targets["TARGETID"] == zcat["TARGETID"])
 
     # ADM determine whether the input targets are main survey, cmx or SV.
     colnames, masks, survey = main_cmx_or_sv(targets, scnd=True)

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -485,7 +485,7 @@ def calc_priority(targets, zcat, obscon):
             if (obsconditions.mask(obscon) & pricon) != 0:
                 ii = (targets[desi_target] & desi_mask[name]) != 0
                 # ADM all redshifts require more observations in SV.
-                good_hiz = zgood & (zcat['Z'] >= 2.15) & (zcat['ZWARN'] == 0)
+                good_hiz = zgood & (zcat['Z'] >= 2.1) & (zcat['ZWARN'] == 0)
                 if survey[0:2] == 'sv':
                     good_hiz = zgood & (zcat['ZWARN'] == 0)
                 priority[ii & unobs] = np.maximum(priority[ii & unobs], desi_mask[name].priorities['UNOBS'])

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -23,6 +23,7 @@ log = get_logger()
 # ADM common redshift that defines a Lyman-Alpha QSO.
 zcut = 2.1
 
+
 def encode_targetid(objid=None, brickid=None, release=None,
                     mock=None, sky=None, gaiadr=None):
     """Create the DESI TARGETID from input source and imaging info.

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -20,6 +20,8 @@ from desitarget.targetmask import obsconditions
 from desiutil.log import get_logger
 log = get_logger()
 
+# ADM common redshift that defines a Lyman-Alpha QSO.
+zcut = 2.1
 
 def encode_targetid(objid=None, brickid=None, release=None,
                     mock=None, sky=None, gaiadr=None):
@@ -387,6 +389,90 @@ def initial_priority_numobs(targets, scnd=False,
     return outpriority, outnumobs
 
 
+def calc_numobs_more(targets, zcat, obscon):
+    """
+    Calculate target NUMOBS_MORE from masks, observation/redshift status.
+
+    Parameters
+    ----------
+    targets : :class:`~numpy.ndarray`
+        numpy structured array or astropy Table of targets. Must include
+        the columns `DESI_TARGET`, `BGS_TARGET`, `MWS_TARGET`
+        (or their SV/cmx equivalents).
+    zcat : :class:`~numpy.ndarray`
+        numpy structured array or Table of redshift information. Must
+        include 'Z', `ZWARN`, `NUMOBS` and be the same length as
+        `targets`. May also contain `NUMOBS_MORE` if this isn't the
+        first time through MTL and `NUMOBS > 0`.
+    obscon : :class:`str`
+        A combination of strings that are in the desitarget bitmask yaml
+        file (specifically in `desitarget.targetmask.obsconditions`), e.g.
+        "DARK|GRAY". Governs the behavior of how priorities are set based
+        on "obsconditions" in the desitarget bitmask yaml file.
+
+    Returns
+    -------
+    :class:`~numpy.array`
+        Integer array of number of additional observations (NUMOBS_MORE).
+
+    Notes
+    -----
+        - Will automatically detect if the passed targets are main
+          survey, commissioning or SV and behave accordingly.
+        - Most targets are updated to NUMOBS_MORE = NUMOBS_INIT-NUMOBS.
+          Special cases include BGS targets which always get NUMOBS_MORE
+          of 1 in bright time and QSO "tracer" targets which always get
+          NUMOBS_MORE=0 in dark time.
+    """
+    # ADM check the input arrays are the same length.
+    assert len(targets) == len(zcat)
+
+    # ADM determine whether the input targets are main survey, cmx or SV.
+    colnames, masks, survey = main_cmx_or_sv(targets, scnd=True)
+    # ADM the target bits/names should be shared between main survey and SV.
+    if survey != 'cmx':
+        desi_target, bgs_target, mws_target, scnd_target = colnames
+        desi_mask, bgs_mask, mws_mask, scnd_mask = masks
+    else:
+        cmx_mask = masks[0]
+
+    # ADM Default is 0 , i.e. no more observations.
+    numobs_more = np.zeros(len(targets), dtype='i8')
+
+    # ADM main case, just decrement by NUMOBS.
+    numobs_more = np.maximum(0, targets['NUMOBS_INIT'] - zcat['NUMOBS'])
+
+    if survey != 'cmx':
+        # ADM BGS targets are observed during the BRIGHT survey, regardless
+        # ADM of how often they've previously been observed.
+        if (obsconditions.mask(obscon) & obsconditions.mask("BRIGHT")) != 0:
+            ii = targets[desi_target] & desi_mask.BGS_ANY > 0
+            numobs_more[ii] = 1
+
+    if survey == 'main':
+        # ADM If a DARK layer target is confirmed to have a good redshift
+        # ADM at z < zcut it always needs just one total observation.
+        # ADM (zcut is defined at the top of this module).
+        if (obsconditions.mask(obscon) & obsconditions.mask("DARK")) != 0:
+            ii = (zcat['ZWARN'] == 0)
+            ii &= (zcat['Z'] < zcut)
+            ii &= (zcat['NUMOBS'] > 0)
+            numobs_more[ii] = 0
+
+        # ADM We will have to be more careful if some DARK layer targets
+        # ADM other than QSOs request more than one observation.
+        check = {bit: desi_mask[bit].numobs for bit in desi_mask.names() if
+                 'DARK' in desi_mask[bit].obsconditions and 'QSO' not in bit
+                 and desi_mask[bit].numobs > 1}
+        if len(check) > 1:
+            msg = "logic not programmed for main survey dark-time targets other"
+            msg += " than QSOs having NUMOBS_INIT > 1: {}".format(check)
+            log.critical(msg)
+            raise ValueError(msg)
+
+    return numobs_more
+
+
 def calc_priority(targets, zcat, obscon):
     """
     Calculate target priorities from masks, observation/redshift status.
@@ -485,7 +571,8 @@ def calc_priority(targets, zcat, obscon):
             if (obsconditions.mask(obscon) & pricon) != 0:
                 ii = (targets[desi_target] & desi_mask[name]) != 0
                 # ADM all redshifts require more observations in SV.
-                good_hiz = zgood & (zcat['Z'] >= 2.1) & (zcat['ZWARN'] == 0)
+                # ADM (zcut is defined at the top of this module).
+                good_hiz = zgood & (zcat['Z'] >= zcut) & (zcat['ZWARN'] == 0)
                 if survey[0:2] == 'sv':
                     good_hiz = zgood & (zcat['ZWARN'] == 0)
                 priority[ii & unobs] = np.maximum(priority[ii & unobs], desi_mask[name].priorities['UNOBS'])

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -131,6 +131,8 @@ class TestMTL(unittest.TestCase):
     def test_merged_qso(self):
         """Test QSO tracers that are also other target types get 1 observation.
         """
+        # ADM there are other tests of this kind in test_multiple_mtl.py.
+
         # ADM create a set of targets that are QSOs and
         # ADM (perhaps) also another target class.
         qtargets = self.targets.copy()

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -151,7 +151,7 @@ class TestMTL(unittest.TestCase):
         mtl = make_mtl(qtargets, obscon="DARK|GRAY", zcat=qzcat)
 
         # ADM all confirmed tracer quasars should have NUMOBS_MORE=0.
-        self.assertTrue(np.all(qzcat["NUMOBS_MORE"]==0))
+        self.assertTrue(np.all(qzcat["NUMOBS_MORE"] == 0))
 
     def test_endless_bgs(self):
         """Test BGS targets always get another observation in bright time.
@@ -174,10 +174,12 @@ class TestMTL(unittest.TestCase):
         mtl = make_mtl(bgstargets, obscon="BRIGHT", zcat=bgszcat)
 
         # ADM all BGS targets should always have NUMOBS_MORE=1.
-        self.assertTrue(np.all(bgszcat["NUMOBS_MORE"]==1))
+        self.assertTrue(np.all(bgszcat["NUMOBS_MORE"] == 1))
+
 
 if __name__ == '__main__':
     unittest.main()
+
 
 def test_suite():
     """Allows testing of only this module with the command:


### PR DESCRIPTION
This PR makes (mostly minor) fixes and updates to MTL. 

The major change is to ensure that tracer QSOs that are in both the QSO target class and another target class drop to `NUMOBS_MORE = 0` for the Main Survey. Also:
- Separates out the calculation of `NUMOBS_MORE` into its own function called `desitarget.targets.calc_numobs_more()`.
    - There was enough special logic in `desitarget.mtl.make_mtl()` that I felt a separate function was justified.
- Consistently uses `zcut = 2.1` to define Lyman-Alpha QSOs. 
    - The codebase used two different redshifts in two different places.
- Adds a new unit test to enforce the check that `NUMOBS_MORE` always drops to 0 for tracer QSOs.
- Adds a new unit test to check BGS always gets `NUMOBS_MORE = 1` in the `BRIGHT` layer.
- Enforces a maximum seed in `desitarget.randoms.randoms_in_a_brick_from_edges()`.


