### PR TITLE
Add RELEASE numbers for dr9i and dr9j of the Legacy Surveys

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.39.1 (unreleased)
 -------------------
 
+* Add RELEASE for dr9i, dr9j (etc.) of the Legacy Surveys [`PR #622`_].
 * Various updates to targeting bits and MTL [`PR #619`_]. Includes:
     * Don't select any BGS_WISE targets in the Main Survey.
     * Always set BGS targets with a ZWARN > 0 to a priority of DONE.
@@ -33,6 +34,7 @@ desitarget Change Log
 .. _`PR #615`: https://github.com/desihub/desitarget/pull/615
 .. _`PR #617`: https://github.com/desihub/desitarget/pull/617
 .. _`PR #619`: https://github.com/desihub/desitarget/pull/619
+.. _`PR #622`: https://github.com/desihub/desitarget/pull/622
 
 0.39.0 (2020-05-01)
 -------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -35,7 +35,8 @@ log = get_logger()
 # ADM Data Model (e.g. https://desi.lbl.gov/trac/wiki/DecamLegacy/DR4sched).
 # ADM 7999 were the dr8a test reductions, for which only 'S' surveys were processed.
 releasedict = {3000: 'S', 4000: 'N', 5000: 'S', 6000: 'N', 7000: 'S', 7999: 'S',
-               8000: 'S', 8001: 'N', 9000: 'S', 9001: 'N', 9002: 'S', 9003: 'N'}
+               8000: 'S', 8001: 'N', 9000: 'S', 9001: 'N', 9002: 'S', 9003: 'N',
+               9004: 'S', 9005: 'N', 9006: 'S', 9007: 'N', 9008: 'S', 9009: 'N'}
 
 # ADM This is an empty array of most of the TS data model columns and
 # ADM dtypes. Note that other columns are added in read_tractor and


### PR DESCRIPTION
This PR adds the RELEASE numbers for dr9i and dr9j of the Legacy Surveys imaging:

- `RELEASE=9004` for dr9i south.
- `RELEASE=9005` for dr9i north.
- `RELEASE=9006` for dr9j south.
- `RELEASE=9007` for dr9j north.

I also added `9008` and `9009` under the assumption that we'll have at least one more set of releases (i.e. DR9 proper).