### PR TITLE
 Functionality to allow iterations of SV beyond sv1

### DIFF
--- a/bin/make_new_sv
+++ b/bin/make_new_sv
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+
+#import warnings
+#warnings.simplefilter('error')
+
+from pkg_resources import resource_filename
+from glob import glob
+from time import time
+start = time()
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser("Make a new sv directory, based on the highest existing sv directory (i.e., if sv1 exists, make sv2)")
+
+# ADM the standard root name for a desitarget SV directory.
+svroot = resource_filename('desitarget', 'sv')
+
+# ADM retrieve the highest current sv directory.
+fns = glob(svroot+'*')
+svlist = [int(fn[-1]) for fn in fns if os.path.isdir(fn)]
+maxsv = np.max(svlist)
+
+# ADM copy the highest previous SV directory to make a new one.
+newdir = "{}{}".format(svroot, maxsv+1)
+cmd = 'cp -R {}{} {}'.format(svroot, maxsv, newdir)
+success = os.system(cmd)
+if success != 0:
+    msg = "problem creating new directory (copy command was: '{}')".format(cmd)
+    log.critical(msg)
+    raise OSError
+
+# ADM change into the new directory and remove any caches.
+os.chdir(newdir)
+if len(glob("*cache*")) > 0:
+    _ = os.system('rm -r *cache*')
+
+# ADM update standard file names and references within those files.
+oldsv, newsv = "sv{}".format(maxsv), "sv{}".format(maxsv+1)
+for fn in '{}_cuts.py', '{}_targetmask.py', 'data/{}_targetmask.yaml':
+    os.rename(fn.format(oldsv), fn.format(newsv))
+    # ADM the I on the end makes the search-and-replace case-insensitive.
+    cmd = "sed -i 's/{}/{}/gI' {}".format(oldsv, newsv, fn.format(newsv))
+    success = os.system(cmd)
+    if success != 0:
+        msg = "problem editing new files in {} (command was: '{}')".format(
+            newdir, cmd)
+        log.critical(msg)
+        raise OSError
+
+log.info('Made {}...t={:.1f}s'.format(newdir, time()-start))

--- a/bin/make_new_sv
+++ b/bin/make_new_sv
@@ -16,6 +16,7 @@ log = get_logger()
 
 from argparse import ArgumentParser
 ap = ArgumentParser("Make a new sv directory, based on the highest existing sv directory (i.e., if sv1 exists, make sv2)")
+_ = ap.parse_args()
 
 # ADM the standard root name for a desitarget SV directory.
 svroot = resource_filename('desitarget', 'sv')

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,17 @@ desitarget Change Log
 0.40.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Functionality for iterations of SV beyond sv1 [`PR #624`_]. Includes:
+    * A script to create the necessary files for new iterations of SV.
+    * Generalized mask/cuts handling for survey=svX, X being any integer.
+    * :func:`targets.main_cmx_or_sv` also updated to handle survey=svX.
+    * Alter the automated creation of output SV target directory names:
+        * write svX targets to /targets/svX/ instead of just targets/sv/.
+    * Make TARGETID for secondary targets unique for iterations of SVX:
+        * Schema is RELEASE=(X-1)*100 + SCND_BIT for SVX-like surveys...
+	* ...and RELEASE=5*100 + SCND_BIT for the Main Survey.
+
+.. _`PR #624`: https://github.com/desihub/desitarget/pull/624
 
 0.40.0 (2020-05-26)
 -------------------

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2060,6 +2060,9 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
         primary = np.ones_like(objects, dtype=bool)
         priority_shift = np.zeros_like(objects, dtype=int)
 
+    # ADM default for target classes we WON'T process is all False.
+    tcfalse = primary & False
+
     # ADM determine if an object passes the default logic for cmx stars.
     isgood, istight = passesSTD_logic(
         gfracflux=gfracflux, rfracflux=rfracflux, zfracflux=zfracflux,
@@ -2138,7 +2141,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     # ADM determine if an object is SV0_QSO.
     if noqso:
         # ADM don't run quasar cuts if requested, for speed.
-        sv0_qso, sv0_qso_z5 = ~primary, ~primary
+        sv0_qso, sv0_qso_z5 = tcfalse, tcfalse
     else:
         sv0_qso, sv0_qso_z5 = isSV0_QSO(
             primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
@@ -2179,7 +2182,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     # ADM Main Survey LRGs.
     # ADM initially set everything to arrays of False for the LRGs
     # ADM the zeroth element stores northern targets bits (south=False).
-    lrg_classes = [~primary, ~primary]
+    lrg_classes = [tcfalse, tcfalse]
     for south in south_cuts:
         lrg_classes[int(south)] = isLRG_MS(
             primary=primary,
@@ -2195,7 +2198,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     # ADM Main Survey ELGs.
     # ADM initially set everything to arrays of False for the ELGs
     # ADM the zeroth element stores northern targets bits (south=False).
-    elg_classes = [~primary, ~primary]
+    elg_classes = [tcfalse, tcfalse]
     for south in south_cuts:
         elg_classes[int(south)] = isELG_MS(
             primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
@@ -2210,7 +2213,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     # ADM Main Survey QSOs.
     # ADM initially set everything to arrays of False for the QSOs
     # ADM the zeroth element stores northern targets bits (south=False).
-    qso_classes = [[~primary, ~primary], [~primary, ~primary]]
+    qso_classes = [[tcfalse, tcfalse], [tcfalse, tcfalse]]
     # ADM don't run quasar cuts if requested, for speed.
     if not noqso:
         for south in south_cuts:
@@ -2229,7 +2232,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     # ADM Main Survey BGS (Bright).
     # ADM initially set everything to arrays of False for the BGS
     # ADM the zeroth element stores northern targets bits (south=False).
-    bgs_classes = [~primary, ~primary]
+    bgs_classes = [tcfalse, tcfalse]
     for south in south_cuts:
         bgs_classes[int(south)] = isBGS_MS(
             rfiberflux=rfiberflux, gflux=gflux, rflux=rflux, zflux=zflux,

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1844,9 +1844,12 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         # ADM only northern it will be [False], else it wil be both.
         south_cuts = list(set(np.atleast_1d(photsys_south)))
 
+    # ADM default for target classes we WON'T process is all False.
+    tcfalse = primary & False
+
     # ADM initially set everything to arrays of False for the LRG selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    lrg_classes = [~primary, ~primary]
+    lrg_classes = [tcfalse, tcfalse]
     if "LRG" in tcnames:
         for south in south_cuts:
             lrg_classes[int(south)] = isLRG(
@@ -1863,7 +1866,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the ELG selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    elg_classes = [~primary, ~primary]
+    elg_classes = [tcfalse, tcfalse]
     if "ELG" in tcnames:
         for south in south_cuts:
             elg_classes[int(south)] = isELG(
@@ -1879,7 +1882,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the QSO selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    qso_classes = [[~primary, ~primary], [~primary, ~primary]]
+    qso_classes = [[tcfalse, tcfalse], [tcfalse, tcfalse]]
     if "QSO" in tcnames:
         for south in south_cuts:
             if qso_selection == 'colorcuts':
@@ -1915,7 +1918,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the BGS selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    bgs_classes = [[~primary, ~primary, ~primary], [~primary, ~primary, ~primary]]
+    bgs_classes = [[tcfalse, tcfalse, tcfalse], [tcfalse, tcfalse, tcfalse]]
     # ADM set the BGS bits
     if "BGS" in tcnames:
         for south in south_cuts:
@@ -1955,8 +1958,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the MWS selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    mws_classes = [[~primary, ~primary, ~primary], [~primary, ~primary, ~primary]]
-    mws_nearby = ~primary
+    mws_classes = [[tcfalse, tcfalse, tcfalse], [tcfalse, tcfalse, tcfalse]]
+    mws_nearby = tcfalse
     if "MWS" in tcnames:
         mws_nearby = isMWS_nearby(
             gaia=gaia, gaiagmag=gaiagmag, parallax=parallax,
@@ -1977,7 +1980,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM treat the MWS WD selection specially, as we have to run the
     # ADM white dwarfs for standards and MWS science targets.
-    mws_wd = ~primary
+    mws_wd = tcfalse
     if "MWS" in tcnames or "STD" in tcnames:
         mws_wd = isMWS_WD(
             gaia=gaia, galb=galb, astrometricexcessnoise=gaiaaen,
@@ -1988,7 +1991,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         )
 
     # ADM initially set everything to False for the standards.
-    std_faint, std_bright, std_wd = ~primary, ~primary, ~primary
+    std_faint, std_bright, std_wd = tcfalse, tcfalse, tcfalse
     if "STD" in tcnames:
         # ADM run the MWS_MAIN target types for both faint and bright.
         # ADM Make sure to pass all of the needed columns! At one point we stopped

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -763,7 +763,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     except ValueError:
         drstr = ""
 
-    # ADM to handle inputs that look like "sv1_targets".
+    # ADM to handle inputs that look like "svX_targets".
     prefix2 = prefix
     if prefix[0:2] == "sv":
         prefix2 = "sv_targets"
@@ -789,7 +789,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             # ADM check that we won't overwhelm the pixel scheme.
             _check_hpx_length(goodpix)
             strgoodpix = ",".join([str(pix) for pix in goodpix])
-            # ADM the replace is to handle inputs that look like "sv1_targets".
+            # ADM the replace is to handle inputs that look like "svX_targets".
             outfile = "$CSCRATCH/{}/{}{}-hp-{}.fits".format(
                 prefix2, prefix.replace("_", "-"), drstr, strgoodpix)
             # ADM random catalogs have an additional seed in their file name.
@@ -814,7 +814,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
                         prefix2.split("_")[-1]))
         else:
             print("gather_targets '{}' $CSCRATCH/{}{}.fits {}".format(
-                # ADM prefix2 handles inputs that look like "sv1_targets".
+                # ADM prefix2 handles inputs that look like "svX_targets".
                 ";".join(outfiles), prefix, drstr, prefix2.split("_")[-1]))
         print("")
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1812,9 +1812,9 @@ def find_target_files(targdir, dr=None, flavor="targets", survey="main",
             prefix = "{}-{}".format(survey, prefix)
         if surv in ["main", "sv"]:
             if not supp and obscon is not None:
-                fn = os.path.join(fn, surv, res, obscon)
+                fn = os.path.join(fn, survey, res, obscon)
             elif obscon is None:
-                fn = os.path.join(fn, surv, res)
+                fn = os.path.join(fn, survey, res)
         else:
             fn = os.path.join(fn, surv)
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1036,7 +1036,7 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
               :func:`desitarget.QA._load_targdens()`. Each column
               contains the target density in the pixel.
     :class:`str`
-        Survey to which `targets` corresponds, e.g., 'main', 'sv1', etc.
+        Survey to which `targets` corresponds, e.g., 'main', 'svX', etc.
 
     Notes
     -----

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -35,6 +35,7 @@ In .txt files it should be 1 or 0 instead of True/False, and will be
 loaded from the text file as the corresponding Boolean.
 """
 import os
+import re
 import fitsio
 import itertools
 import numpy as np
@@ -558,7 +559,8 @@ def match_secondary(primtargs, scxdir, scndout, sep=1.,
     return targs
 
 
-def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
+def finalize_secondary(scxtargs, scnd_mask, survey='main', sep=1.,
+                       darkbright=False):
     """Assign secondary targets a realistic TARGETID, finalize columns.
 
     Parameters
@@ -571,6 +573,10 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
         A mask corresponding to a set of secondary targets, e.g, could
         be ``from desitarget.targetmask import scnd_mask`` for the
         main survey mask.
+    survey : :class:`str`, optional, defaults to "main"
+        string indicating whether we are working in the context of the
+        Main Survey (`main`) or SV (e.g. `sv1`, `sv2` etc.). Used to
+        set the `RELEASE` number in the `TARGETID` (see Notes).
     sep : :class:`float`, defaults to 1 arcsecond
         The separation at which to match secondary targets to
         themselves in ARCSECONDS.
@@ -599,8 +605,11 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
         priority, the first one encountered retains its `PRIORITY_INIT`
         - The secondary `TARGETID` is designed to be reproducible. It
         combines `BRICKID` based on location, `OBJID` based on the
-        order of the target in the secondary file (`SCND_ORDER`) and
-        `RELEASE` from the secondary bit number (`SCND_TARGET`).
+        order of the targets in the secondary file (`SCND_ORDER`) and
+        `RELEASE` from the secondary bit number (`SCND_TARGET`) and the
+        input `survey`. `RELEASE` is set to ((X-1)*100)+np.log2(scnd_bit)
+        with X from the `survey` string survey=svX and scnd_bit from
+        `SCND_TARGET`. For the main survey (survey="main") X-1 is 5.
     """
     # ADM assign new TARGETIDs to targets without a primary match.
     nomatch = scxtargs["TARGETID"] == -1
@@ -608,8 +617,25 @@ def finalize_secondary(scxtargs, scnd_mask, sep=1., darkbright=False):
     # ADM get the BRICKIDs for each source.
     brxid = bricks.brickid(scxtargs["RA"], scxtargs["DEC"])
 
+    # ADM ensure unique secondary bits for different iterations of SV
+    # ADM and the Main Survey.
+    if survey == 'main':
+        Xm1 = 5
+    elif survey[0:2] == 'sv':
+        # ADM the re.search just extracts the numbers in the string.
+        Xm1 = int(re.search(r'\d+', survey).group())-1
+        # ADM we've allowed a max of up to sv5 (!). Fail if surpassed.
+        if Xm1 >= 5:
+            msg = "Only coded for up to 'sv5', not {}!!!".format(survey)
+            log.critical(msg)
+            raise ValueError(msg)
+    else:
+        msg = "allowed surveys: 'main', 'svX', not {}!!!".format(survey)
+        log.critical(msg)
+        raise ValueError(msg)
+
     # ADM the RELEASE for each source is the `SCND_TARGET` bit NUMBER.
-    release = np.log2(scxtargs["SCND_TARGET_INIT"]).astype('int')
+    release = (Xm1*100)+np.log2(scxtargs["SCND_TARGET_INIT"]).astype('int')
 
     # ADM build the OBJIDs based on the values of SCND_ORDER.
     t0 = time()
@@ -794,7 +820,7 @@ def select_secondary(priminfodir, sep=1., scxdir=None, darkbright=False):
         if survey == 'sv2':
             from desitarget.sv2.sv2_targetmask import scnd_mask
     elif survey != 'main':
-        msg = "allowed surveys: 'main', 'sv1', 'sv2', not {}!!!".format(survey)
+        msg = "allowed surveys: 'main', 'svX', not {}!!!".format(survey)
         log.critical(msg)
         raise ValueError(msg)
 
@@ -818,7 +844,7 @@ def select_secondary(priminfodir, sep=1., scxdir=None, darkbright=False):
 
     log.info("Finalizing secondaries...t={:.1f}m".format((time()-start)/60.))
     # ADM assign TARGETIDs to secondaries that did not match a primary.
-    scxout = finalize_secondary(scxout, scnd_mask,
+    scxout = finalize_secondary(scxout, scnd_mask, survey=survey,
                                 sep=sep, darkbright=darkbright)
 
     return scxout

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -368,6 +368,9 @@ def add_primary_info(scxtargs, priminfodir):
         am = np.argmax(primtargs[dups]["PRIORITY_INIT"])
         dups = np.delete(dups, am)
         alldups.append(dups)
+    # ADM to catch the case of no duplicates when h-stacking.
+    if len(alldups) == 0:
+        alldups = [alldups]
     alldups = np.hstack(alldups)
     log.debug("Discarding {} primary duplicates".format(len(alldups)))
     primtargs = np.delete(primtargs, alldups)

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1473,10 +1473,13 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         # ADM only northern it will be [False], else it wil be both.
         south_cuts = list(set(photsys_south))
 
+    # ADM default for target classes we WON'T process is all False.
+    tcfalse = primary & False
+
     # ADM initially set everything to arrays of False for the LRG selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    lrg_classes = [[~primary, ~primary, ~primary, ~primary, ~primary],
-                   [~primary, ~primary, ~primary, ~primary, ~primary]]
+    lrg_classes = [[tcfalse, tcfalse, tcfalse, tcfalse, tcfalse],
+                   [tcfalse, tcfalse, tcfalse, tcfalse, tcfalse]]
     if "LRG" in tcnames:
         # ADM run the LRG target types (potentially) for both north and south.
         for south in south_cuts:
@@ -1499,8 +1502,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the ELG selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    elg_classes = [[~primary, ~primary, ~primary, ~primary],
-                   [~primary, ~primary, ~primary, ~primary]]
+    elg_classes = [[tcfalse, tcfalse, tcfalse, tcfalse],
+                   [tcfalse, tcfalse, tcfalse, tcfalse]]
     if "ELG" in tcnames:
         for south in south_cuts:
             elg_classes[int(south)] = isELG(
@@ -1524,8 +1527,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the QSO selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    qso_classes = [[~primary, ~primary, ~primary, ~primary, ~primary],
-                   [~primary, ~primary, ~primary, ~primary, ~primary]]
+    qso_classes = [[tcfalse, tcfalse, tcfalse, tcfalse, tcfalse],
+                   [tcfalse, tcfalse, tcfalse, tcfalse, tcfalse]]
     if "QSO" in tcnames:
         for south in south_cuts:
             qso_store = []
@@ -1542,8 +1545,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
             # ADM SV mock selection needs to apply only the color cuts
             # ADM and ignore the Random Forest selections.
             if qso_selection == 'colorcuts':
-                qso_store.append(~primary)
-                qso_store.append(~primary)
+                qso_store.append(tcfalse)
+                qso_store.append(tcfalse)
             else:
                 qso_store.append(
                     isQSO_randomforest(
@@ -1608,8 +1611,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the BGS selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    bgs_classes = [[~primary, ~primary, ~primary, ~primary, ~primary],
-                   [~primary, ~primary, ~primary, ~primary, ~primary]]
+    bgs_classes = [[tcfalse, tcfalse, tcfalse, tcfalse, tcfalse],
+                   [tcfalse, tcfalse, tcfalse, tcfalse, tcfalse]]
     if "BGS" in tcnames:
         for south in south_cuts:
             bgs_store = []
@@ -1639,8 +1642,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the MWS selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    mws_classes = [[~primary, ~primary], [~primary, ~primary]]
-    mws_nearby = ~primary
+    mws_classes = [[tcfalse, tcfalse], [tcfalse, tcfalse]]
+    mws_nearby = tcfalse
     if "MWS" in tcnames:
         mws_nearby = isMWS_nearby(
             gaia=gaia, gaiagmag=gaiagmag, parallax=parallax,
@@ -1663,7 +1666,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # ADM white dwarfs for standards
     # APC Science WDs now enter as secondary targets, so in principle the
     # APC assignment std_wd = mws_wd could be done here rather than below.
-    mws_wd = ~primary
+    mws_wd = tcfalse
     if "MWS" in tcnames or "STD" in tcnames:
         mws_wd = isMWS_WD(
             gaia=gaia, galb=galb, astrometricexcessnoise=gaiaaen,
@@ -1672,10 +1675,10 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
             gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag
         )
     else:
-        mws_wd = ~primary
+        mws_wd = tcfalse
 
     # ADM initially set everything to False for the standards.
-    std_faint, std_bright, std_wd = ~primary, ~primary, ~primary
+    std_faint, std_bright, std_wd = tcfalse, tcfalse, tcfalse
     if "STD" in tcnames:
         # ADM run the STD target types for both faint and bright.
         # ADM Make sure to pass all of the needed columns! At one point we stopped

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -9,7 +9,6 @@ from astropy.table import Table, join
 
 from desitarget.targetmask import desi_mask as Mx
 from desitarget.targetmask import bgs_mask
-from desitarget.sv1.sv1_targetmask import desi_mask as MxSV
 from desitarget.targetmask import obsconditions
 from desitarget.mtl import make_mtl
 from desitarget.targets import initial_priority_numobs, main_cmx_or_sv
@@ -58,12 +57,6 @@ class TestMTL(unittest.TestCase):
         else:
             for name in main_names:
                 t.rename_column(name, prefix+name)
-
-#        if prefix == "SV1_":
-            # ADM change any occurences of LRG_2PASS to just LRG.
-            # ADM technically not needed as 2PASS no longer exists.
-#            ii = t["SV1_DESI_TARGET"] == Mx.LRG_2PASS
-#            t["SV1_DESI_TARGET"][ii] = MxSV.LRG
 
         return t
 

--- a/py/desitarget/test/test_mtl_multiple.py
+++ b/py/desitarget/test/test_mtl_multiple.py
@@ -8,7 +8,6 @@ import numpy as np
 from astropy.table import Table, join
 
 from desitarget.targetmask import desi_mask as Mx
-from desitarget.sv1.sv1_targetmask import desi_mask as MxSV
 from desitarget.targetmask import obsconditions
 from desitarget.mtl import make_mtl
 from desitarget.targets import initial_priority_numobs, main_cmx_or_sv

--- a/py/desitarget/test/test_sv.py
+++ b/py/desitarget/test/test_sv.py
@@ -7,6 +7,7 @@ import fitsio
 import os
 import numpy as np
 import healpy as hp
+from glob import glob
 
 from pkg_resources import resource_filename
 from desitarget import io, cuts
@@ -44,9 +45,9 @@ class TestSV(unittest.TestCase):
     def test_sv_cuts(self):
         """Test SV cuts work.
         """
-        # ADM increase maxsv if we add more iterations of SV!!!
-        maxsv = 1
-        svlist = ['sv{}'.format(i) for i in range(1, maxsv+1)]
+        # ADM find all svX sub-directories in the desitarget directory.
+        fns = glob(resource_filename('desitarget', 'sv*'))
+        svlist = [os.path.basename(fn) for fn in fns if os.path.isdir(fn)]
 
         for survey in svlist:
             desicol, bgscol, mwscol = ["{}_{}_TARGET".format(survey.upper(), tc)


### PR DESCRIPTION
At some point we will need iterations of SV beyond the "sv1" formalism, if only for the One Percent Survey. This PR makes the necessary updates to generalize to svX (allowing sv2, sv3, sv4 etc.). It includes:

- A script `make_new_sv` to create the necessary files and directories for new iterations of SV. The script will build an `svX` directory from an existing `sv(X-1)` directory (`sv2` from an existing `sv1` directory, `sv3` from an existing `sv2` directory, etc.).
- Generalized handling of `"bitmask.yaml"` and `"cuts.py"` files for all iterations of `svX` (`X` being any integer).
- Updates to `desitarget.targets.main_cmx_or_sv()` to handle any SV file (e.g. that function will automatically return `sv4`-style masks and `SV4_DESI_TARGET`-like column descriptors for a file constructed using `SV4` cuts files and bitmasks).
- Altered output target directory names for SV files. SV targets are written to a directory that begins `/targets/svX/` instead of just `targets/sv/`.
- A new `TARGETID` formalism for secondary targets that will yield unique IDs for different iterations of SV.
    - The schema is `RELEASE=(X-1)*100 + SCND_BIT` for SVX-like surveys...
    - ...and `RELEASE=5*100 + SCND_BIT` for the Main Survey...
    - ...it was previously just `RELEASE=SCND_BIT`, which would have conflicted if we have new secondary target bits for different iterations of SV (and the Main Survey).