### PR TITLE
Minor data model fixes, consistency checks and streamlining.

### DIFF
--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -186,7 +186,9 @@ if ns.bundlefiles is None:
     isgaia = gaiadr > 0
     # ADM write out bright-time and dark-time targets separately.
     # ADM together with the Gaia-only back-up objects.
-    obscons = ["BRIGHT", "DARK", None]
+    # ADM can use DARK for the back-up/supp objects as they never
+    # ADM need merged with another target.
+    obscons = ["BRIGHT", "DARK", "DARK"]
     iis = [~isgaia, ~isgaia, isgaia]
     supps = [False, False, True]
     if ns.writeall:

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -187,7 +187,9 @@ if ns.bundlefiles is None:
     isgaia = gaiadr > 0
     # ADM write out bright-time and dark-time targets separately,
     # ADM together with the Gaia-only back-up objects.
-    obscons = ["BRIGHT", "DARK", None]
+    # ADM can use DARK for the back-up/supp objects as they never
+    # ADM need merged with another target.
+    obscons = ["BRIGHT", "DARK", "DARK"]
     iis = [~isgaia, ~isgaia, isgaia]
     supps = [False, False, True]
     if ns.writeall:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,9 @@ desitarget Change Log
 0.40.1 (unreleased)
 -------------------
 
+* Minor data model fixes, error checks and streamlining [`PR #627`_].
+    * The most important change is that MWS science targets are no
+      longer observed in GRAY or DARK, except for MWS_WDs.
 * Cleanup: Avoid absolute path in resource_filename [`PR #626`_].
 * Update masking to be "all-sky" using Gaia/Tycho/URAT [`PR #625`_]:
     * General desitarget functionality to work with Tycho files.
@@ -36,6 +39,7 @@ desitarget Change Log
 .. _`PR #624`: https://github.com/desihub/desitarget/pull/624
 .. _`PR #625`: https://github.com/desihub/desitarget/pull/625
 .. _`PR #626`: https://github.com/desihub/desitarget/pull/626
+.. _`PR #627`: https://github.com/desihub/desitarget/pull/627
 
 0.40.0 (2020-05-26)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2509,8 +2509,8 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         if nbrick % 50 == 0 and nbrick > 0:
             elapsed = time() - t0
             rate = elapsed / nbrick
-            log.info('{} files; {:.1f} secs/file; {:.1f} total mins elapsed'
-                     .format(nbrick, rate, elapsed/60.))
+            log.info('{}/{} files; {:.1f} secs/file; {:.1f} total mins elapsed'
+                     .format(nbrick, len(infiles), rate, elapsed/60.))
 
         nbrick[...] += 1    # this is an in-place modification
         return result

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -74,9 +74,9 @@ mws_mask:
     # input catalogues. 
 
     #- Bits 0-3 (7 ids)
-    - [MWS_BROAD,           0, "Milky Way Survey magnitude limited bulk sample",         {obsconditions: BRIGHT|GRAY|DARK}]
+    - [MWS_BROAD,           0, "Milky Way Survey magnitude limited bulk sample",         {obsconditions: BRIGHT}]
     - [MWS_WD,              1, "Milky Way Survey White Dwarf",                           {obsconditions: BRIGHT|GRAY|DARK}]
-    - [MWS_NEARBY,          2, "Milky Way Survey volume-complete ~100pc sample",         {obsconditions: BRIGHT|GRAY|DARK}]
+    - [MWS_NEARBY,          2, "Milky Way Survey volume-complete ~100pc sample",         {obsconditions: BRIGHT}]
 
     # Second layer flags additional subclasses that could apply to any
     # of the main classes. These sort targets in each input catalog into
@@ -90,18 +90,18 @@ mws_mask:
     # targeted for reobservation if possible.
 
     #- 4: MWS_BROAD north/south splits
-    - [MWS_BROAD_NORTH,     4, "Milky Way Survey cuts tuned for Bok/Mosaic",               {obsconditions: BRIGHT|GRAY|DARK}]
-    - [MWS_BROAD_SOUTH,     5, "Milky Way Survey cuts tuned for DECam",                    {obsconditions: BRIGHT|GRAY|DARK}]
+    - [MWS_BROAD_NORTH,     4, "Milky Way Survey cuts tuned for Bok/Mosaic",               {obsconditions: BRIGHT}]
+    - [MWS_BROAD_SOUTH,     5, "Milky Way Survey cuts tuned for DECam",                    {obsconditions: BRIGHT}]
 
     #- 8: Sub-classes of MWS_MAIN
-    - [MWS_MAIN_BLUE,       8, "Milky Way Survey magnitude limited blue sample",              {obsconditions: BRIGHT|GRAY|DARK}]
-    - [MWS_MAIN_BLUE_NORTH, 9, "MWS magnitude limited blue sample tuned for Bok/Mosaic",      {obsconditions: BRIGHT|GRAY|DARK}]
-    - [MWS_MAIN_BLUE_SOUTH, 10, "MWS magnitude limited blue sample tuned for DECam",          {obsconditions: BRIGHT|GRAY|DARK}]
-    - [MWS_MAIN_RED,        11, "Milky Way Survey magnitude limited red sample",              {obsconditions: BRIGHT|GRAY|DARK}]
-    - [MWS_MAIN_RED_NORTH,  12, "MWS magnitude limited red sample tuned for Bok/Mosaic",      {obsconditions: BRIGHT|GRAY|DARK}]
-    - [MWS_MAIN_RED_SOUTH,  13, "MWS magnitude limited red sample tuned for DECam",           {obsconditions: BRIGHT|GRAY|DARK}]
+    - [MWS_MAIN_BLUE,       8, "Milky Way Survey magnitude limited blue sample",              {obsconditions: BRIGHT}]
+    - [MWS_MAIN_BLUE_NORTH, 9, "MWS magnitude limited blue sample tuned for Bok/Mosaic",      {obsconditions: BRIGHT}]
+    - [MWS_MAIN_BLUE_SOUTH, 10, "MWS magnitude limited blue sample tuned for DECam",          {obsconditions: BRIGHT}]
+    - [MWS_MAIN_RED,        11, "Milky Way Survey magnitude limited red sample",              {obsconditions: BRIGHT}]
+    - [MWS_MAIN_RED_NORTH,  12, "MWS magnitude limited red sample tuned for Bok/Mosaic",      {obsconditions: BRIGHT}]
+    - [MWS_MAIN_RED_SOUTH,  13, "MWS magnitude limited red sample tuned for DECam",           {obsconditions: BRIGHT}]
 
-    # ADM back-up targets for poor conditions.
+    # ADM back-up targets for poor conditions and as filler.
     - [BACKUP_BRIGHT,       60, "Bright backup Gaia targets",   {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
     - [BACKUP_FAINT,        61, "Fainter backup Gaia targets",  {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]
     - [BACKUP_VERY_FAINT,   62, "Even fainter backup Gaia targets",  {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18}]

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -661,35 +661,8 @@ def find_gaia_files(objs, neighbors=True, radec=False):
     gaiadir = get_gaia_dir()
     hpxdir = os.path.join(gaiadir, 'healpix')
 
-    # ADM which flavor of RA/Dec was passed.
-    if radec:
-        ra, dec = objs
-        dec = np.array(dec)
-    else:
-        ra, dec = objs["RA"], objs["DEC"]
-
-    # ADM convert RA/Dec to co-latitude and longitude in radians.
-    theta, phi = np.radians(90-dec), np.radians(ra)
-
-    # ADM retrieve the pixels in which the locations lie.
-    pixnum = hp.ang2pix(nside, theta, phi, nest=True)
-
-    # ADM retrieve only the UNIQUE pixel numbers. It's possible that only
-    # ADM one pixel was produced, so guard against pixnum being non-iterable.
-    if not isinstance(pixnum, np.integer):
-        pixnum = list(set(pixnum))
-    else:
-        pixnum = [pixnum]
-
-    # ADM if neighbors was sent, then retrieve all pixels that touch each
-    # ADM pixel covered by the provided locations, to prevent edge effects...
-    if neighbors:
-        pixnum = add_hp_neighbors(nside, pixnum)
-
-    # ADM reformat in the Gaia healpix format used by desitarget.
-    gaiafiles = [os.path.join(hpxdir, io.hpx_filename(pn)) for pn in pixnum]
-
-    return gaiafiles
+    return io.find_star_files(objs, hpxdir, nside,
+                              neighbors=neighbors, radec=radec)
 
 
 def find_gaia_files_hp(nside, pixlist, neighbors=True):

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2431,7 +2431,8 @@ def hpx_filename(hpx):
     return 'healpix-{:05d}.fits'.format(hpx)
 
 
-def find_star_files(objs, hpxdir, nside, neighbors=True, radec=False):
+def find_star_files(objs, hpxdir, nside, neighbors=True, radec=False,
+                    strict=False):
     """Full paths to HEALPixel-split star files for objects by RA/Dec.
 
     Parameters
@@ -2450,6 +2451,10 @@ def find_star_files(objs, hpxdir, nside, neighbors=True, radec=False):
     radec : :class:`bool`, optional, defaults to ``False``
         If ``True`` then the passed `objs` is an [RA, Dec] list instead
         of a rec array.
+    strict : :class:`bool`, optional, defaults to ``False``
+        Only return files that actually exist. This is useful for, e.g.,
+        URAT files, which don't cover the whole sky and so don't have
+        files for every HEALPixel.
 
     Returns
     -------
@@ -2488,5 +2493,9 @@ def find_star_files(objs, hpxdir, nside, neighbors=True, radec=False):
 
     # ADM reformat in the general healpix format used by desitarget.
     fns = [os.path.join(hpxdir, hpx_filename(pn)) for pn in pixnum]
+
+    # ADM restrict to only files/HEALPixels actually covered.
+    if strict:
+        fns = [fn for fn in fns if os.path.exists(fn)]
 
     return fns

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -22,7 +22,7 @@ from time import time
 
 from desiutil import depend
 from desitarget.geomask import hp_in_box, box_area, is_in_box
-from desitarget.geomask import hp_in_cap, cap_area, is_in_cap
+from desitarget.geomask import hp_in_cap, cap_area, is_in_cap, add_hp_neighbors
 from desitarget.geomask import is_in_hp, nside2nside, pixarea2nside
 from desitarget.targets import main_cmx_or_sv
 
@@ -2429,3 +2429,65 @@ def hpx_filename(hpx):
     """
 
     return 'healpix-{:05d}.fits'.format(hpx)
+
+
+def find_star_files(objs, hpxdir, nside, neighbors=True, radec=False):
+    """Full paths to HEALPixel-split star files for objects by RA/Dec.
+
+    Parameters
+    ----------
+    objs : :class:`~numpy.ndarray`
+        Array of objects. Must contain at least columns "RA" and "DEC".
+    hpxdir : :class:`str`
+        Name of the directory that hosts the HEALPixel-split files. Most
+        likely this directory ends in "/healpix".
+    nside : :class:`int`
+        The (NESTED) HEALPixel nside integer.
+    neighbors : :class:`bool`, optional, defaults to ``True``
+        Also return all neighboring pixels that touch the files of
+        interest to prevent edge effects (e.g. if a, say, Gaia source is
+        1 arcsec away from a primary source and so in an adjacent pixel).
+    radec : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then the passed `objs` is an [RA, Dec] list instead
+        of a rec array.
+
+    Returns
+    -------
+    :class:`list`
+        A list of all files that need to be read in to account for
+        objects at the passed locations.
+
+    Notes
+    -----
+        - "star" files, here might be Gaia, Tycho or URAT files.
+    """
+    # ADM which flavor of RA/Dec was passed.
+    if radec:
+        ra, dec = objs
+        dec = np.array(dec)
+    else:
+        ra, dec = objs["RA"], objs["DEC"]
+
+    # ADM convert RA/Dec to co-latitude and longitude in radians.
+    theta, phi = np.radians(90-dec), np.radians(ra)
+
+    # ADM retrieve the pixels in which the locations lie.
+    pixnum = hp.ang2pix(nside, theta, phi, nest=True)
+
+    # ADM retrieve only the UNIQUE pixel numbers. It's possible that only
+    # ADM one pixel was produced, so ensure pixnum is iterable.
+    if not isinstance(pixnum, np.integer):
+        pixnum = list(set(pixnum))
+    else:
+        pixnum = [pixnum]
+
+    # ADM if neighbors was sent, then retrieve all pixels that touch each
+    # ADM pixel covered by the passed ras/decs, to prevent edge effects...
+    if neighbors:
+        pixnum = add_hp_neighbors(nside, pixnum)
+
+    # ADM reformat in the general healpix format used by desitarget.
+    fns = [os.path.join(hpxdir, hpx_filename(pn)) for pn in pixnum]
+
+    return fns
+

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2490,4 +2490,3 @@ def find_star_files(objs, hpxdir, nside, neighbors=True, radec=False):
     fns = [os.path.join(hpxdir, hpx_filename(pn)) for pn in pixnum]
 
     return fns
-

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -106,13 +106,17 @@ def encode_targetid(objid=None, brickid=None, release=None,
         else:
             inputs[i] = np.atleast_1d(param)
 
-    # ADM check passed parameters don't exceed their bit-allowance.
+    # ADM check passed parameters don't exceed their bit-allowance
+    # ADM and aren't negative numbers.
     for param, bitname in zip(inputs, bitnames):
-        if not np.all(param < 2**targetid_mask[bitname].nbits):
             msg = 'Invalid range when making targetid: {} '.format(bitname)
-            msg += 'cannot exceed {}'.format(2**targetid_mask[bitname].nbits - 1)
-            log.critical(msg)
-            raise IOError(msg)
+            if not np.all(param < 2**targetid_mask[bitname].nbits):
+                msg += 'cannot exceed {}'.format(2**targetid_mask[bitname].nbits - 1)
+            if not np.all(param >= 0):
+                msg += 'cannot be negative'
+            if 'cannot' in msg:
+                log.critical(msg)
+                raise IOError(msg)
 
     # ADM set up targetid as an array of 64-bit integers.
     targetid = np.zeros(nobjs, ('int64'))

--- a/py/desitarget/tychomatch.py
+++ b/py/desitarget/tychomatch.py
@@ -295,38 +295,8 @@ def find_tycho_files(objs, neighbors=True, radec=False):
     tychodir = get_tycho_dir()
     hpxdir = os.path.join(tychodir, 'healpix')
 
-    # ADM which flavor of RA/Dec was passed.
-    if radec:
-        ra, dec = objs
-        dec = np.array(dec)
-    else:
-        ra, dec = objs["RA"], objs["DEC"]
-
-    # ADM convert RA/Dec to co-latitude and longitude in radians.
-    theta, phi = np.radians(90-dec), np.radians(ra)
-
-    # ADM retrieve the pixels in which the locations lie.
-    pixnum = hp.ang2pix(nside, theta, phi, nest=True)
-
-    # ADM retrieve only the UNIQUE pixel numbers. It's possible that only
-    # ADM one pixel was produced, so guard against pixnum being non-iterable.
-    if not isinstance(pixnum, np.integer):
-        pixnum = list(set(pixnum))
-    else:
-        pixnum = [pixnum]
-
-    # ADM if neighbors was sent, then retrieve all pixels that touch each
-    # ADM pixel covered by the input RA/Dec, to prevent edge effects.
-    if neighbors:
-        pixnum = add_hp_neighbors(nside, pixnum)
-
-    # ADM reformat file names in the Tycho healpix format.
-    tychofiles = [os.path.join(hpxdir, io.hpx_filename(pn)) for pn in pixnum]
-
-    # ADM restrict to only files/HEALPixels actually covered by Tycho.
-    tychofiles = [fn for fn in tychofiles if os.path.exists(fn)]
-
-    return tychofiles
+    return io.find_star_files(objs, hpxdir, nside,
+                              neighbors=neighbors, radec=radec)
 
 
 def find_tycho_files_hp(nside, pixlist, neighbors=True):

--- a/py/desitarget/uratmatch.py
+++ b/py/desitarget/uratmatch.py
@@ -533,38 +533,8 @@ def find_urat_files(objs, neighbors=True, radec=False):
     uratdir = get_urat_dir()
     hpxdir = os.path.join(uratdir, 'healpix')
 
-    # ADM which flavor of RA/Dec was passed.
-    if radec:
-        ra, dec = objs
-        dec = np.array(dec)
-    else:
-        ra, dec = objs["RA"], objs["DEC"]
-
-    # ADM convert RA/Dec to co-latitude and longitude in radians.
-    theta, phi = np.radians(90-dec), np.radians(ra)
-
-    # ADM retrieve the pixels in which the locations lie.
-    pixnum = hp.ang2pix(nside, theta, phi, nest=True)
-
-    # ADM retrieve only the UNIQUE pixel numbers. It's possible that only
-    # ADM one pixel was produced, so guard against pixnum being non-iterable.
-    if not isinstance(pixnum, np.integer):
-        pixnum = list(set(pixnum))
-    else:
-        pixnum = [pixnum]
-
-    # ADM if neighbors was sent, then retrieve all pixels that touch each
-    # ADM pixel covered by the provided locations, to prevent edge effects...
-    if neighbors:
-        pixnum = add_hp_neighbors(nside, pixnum)
-
-    # ADM reformat file names in the URAT healpix format.
-    uratfiles = [os.path.join(hpxdir, io.hpx_filename(pn)) for pn in pixnum]
-
-    # ADM restrict to only files/HEALPixels actually covered by URAT.
-    uratfiles = [fn for fn in uratfiles if os.path.exists(fn)]
-
-    return uratfiles
+    return io.find_star_files(objs, hpxdir, nside,
+                              neighbors=neighbors, radec=radec)
 
 
 def match_to_urat(objs, matchrad=1., radec=False):

--- a/py/desitarget/uratmatch.py
+++ b/py/desitarget/uratmatch.py
@@ -533,7 +533,8 @@ def find_urat_files(objs, neighbors=True, radec=False):
     uratdir = get_urat_dir()
     hpxdir = os.path.join(uratdir, 'healpix')
 
-    return io.find_star_files(objs, hpxdir, nside,
+    # ADM remember to pass "strict", as URAT doesn't cover the whole sky.
+    return io.find_star_files(objs, hpxdir, nside, strict=True,
                               neighbors=neighbors, radec=radec)
 
 


### PR DESCRIPTION
This PR aligns the data model of the supplemental/back-up files with that of the other target files, adds some error checks and merges some (redundant) functions that are used for looking up Tycho, Gaia and URAT files.

Perhaps the most important change is that the Main Survey yaml file is updated so that MWS science targets are no longer observed in the `GRAY` or `DARK` layers (except for the `MWS_WD` class).

This is a relatively small and minor PR, so I'll merge it tomorrow morning.