### PR TITLE
support for py3.8 and np1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ env:
         - NUMPY_VERSION=1.16.5
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=2.0.16
+        #- Old healpy version needed as long as we pin old astropy too
+        - HEALPY_VERSION=1.12.9
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=3.0.0
         - SPECLITE_VERSION=0.8
@@ -190,7 +192,7 @@ install:
     - source ci-helpers/travis/setup_conda.sh
     # egg_info causes the astropy/ci-helpers script to exit before the pip
     # packages are installed, thus desiutil is not installed in that script.
-    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy; fi"
+    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy==${HEALPY_VERSION}; fi"
     - for p in $DESIHUB_PIP_DEPENDENCIES; do r=$(echo $p | cut -d= -f1); v=$(echo $p | cut -d= -f2); pip install git+https://github.com/desihub/${r}.git@${v}#egg=${r}; done
     - export DESIMODEL=${HOME}/desimodel/${DESIMODEL_VERSION}
     - mkdir -p ${DESIMODEL}

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -658,7 +658,14 @@ def qasystematics_scatterplot(pixmap, syscolname, targcolname, qadir='.',
 
     # ADM apply the digitization to the target density values
     # ADM note that the first digitized bin is 1 not zero.
-    meds = [np.median(yy[wbin == bin]) for bin in range(1, nbins+1)]
+    ### meds = [np.median(yy[wbin == bin]) for bin in range(1, nbins+1)]
+    meds = list()
+    for bin in range(1, nbins+1):
+        ii = (wbin == bin)
+        if np.any(ii):
+            meds.append(np.median(yy[ii]))
+        else:
+            meds.append(np.NaN)
 
     # ADM make the plot.
     plt.scatter(xx, yy, marker='.', color='b', alpha=0.8, s=0.8)

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -437,18 +437,26 @@ def isSV0_MWS(rflux=None, obs_rflux=None, objtype=None, paramssolved=None,
     else:
         nans = (np.isnan(gaiagmag) | np.isnan(gaiabmag) | np.isnan(gaiarmag) |
                 np.isnan(parallax))
-    w = np.where(nans)[0]
-    if len(w) > 0:
-        parallax, gaiagmag = parallax.copy(), gaiagmag.copy()
-        gaiabmag, gaiarmag = gaiabmag.copy(), gaiarmag.copy()
-        if photbprpexcessfactor is not None:
-            photbprpexcessfactor = photbprpexcessfactor.copy()
-        # ADM safe to make these zero regardless of cuts as...
-            photbprpexcessfactor[w] = 0.
-        parallax[w] = 0.
-        gaiagmag[w], gaiabmag[w], gaiarmag[w] = 0., 0., 0.
-        # ADM ...we'll turn off all bits here.
-        iswd &= ~nans
+
+    if np.isscalar(nans):
+        if nans:
+            parallax = gaiagmag = gaiabmag = gaiarmag = 0.0
+            if photbprpexcessfactor is not None:
+                photbprpexcessfactor = 0.0
+    else:
+        w = np.where(nans)[0]
+        if len(w) > 0:
+            parallax, gaiagmag = parallax.copy(), gaiagmag.copy()
+            gaiabmag, gaiarmag = gaiabmag.copy(), gaiarmag.copy()
+            if photbprpexcessfactor is not None:
+                photbprpexcessfactor = photbprpexcessfactor.copy()
+            # ADM safe to make these zero regardless of cuts as...
+                photbprpexcessfactor[w] = 0.
+            parallax[w] = 0.
+            gaiagmag[w], gaiabmag[w], gaiarmag[w] = 0., 0., 0.
+
+    # ADM ...we'll turn off all bits here.
+    iswd &= ~nans
 
     # ADM apply the selection for MWS-WD targets.
     # ADM must be a Legacy Surveys object that matches a Gaia source.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1603,9 +1603,12 @@ def _prepare_optical_wise(objects, mask=True):
     deltaChi2 = dchisq[..., 0] - dchisq[..., 1]
 
     # ADM remove handful of NaN values from DCHISQ values and make them unselectable.
-    w = np.where(deltaChi2 != deltaChi2)
-    # ADM this is to catch the single-object case for unit tests.
-    if len(w[0]) > 0:
+    # SJB support py3.8 + np1.18 for both scalars and vectors
+    if np.isscalar(deltaChi2):
+        if np.isnan(deltaChi2):
+            deltaChi2 = -1e6
+    else:
+        w = np.isnan(deltaChi2)
         deltaChi2[w] = -1e6
 
     return (photsys_north, photsys_south, obs_rflux, gflux, rflux, zflux,

--- a/py/desitarget/test/test_cmx.py
+++ b/py/desitarget/test/test_cmx.py
@@ -7,6 +7,7 @@ from pkg_resources import resource_filename
 import os.path
 from uuid import uuid4
 import numbers
+import warnings
 
 from astropy.io import fits
 from astropy.table import Table
@@ -46,6 +47,10 @@ class TestCMX(unittest.TestCase):
         # ADM reset GAIA_DIR environment variable.
         if cls.gaiadir_orig is not None:
             os.environ["GAIA_DIR"] = cls.gaiadir_orig
+
+    def setUp(self):
+        #- Treat a specific warning as an error
+        warnings.filterwarnings('error', '.*Calling nonzero on 0d arrays.*')
 
     def test_cuts_basic(self):
         """Test cuts work with either data or filenames

--- a/py/desitarget/test/test_cmx.py
+++ b/py/desitarget/test/test_cmx.py
@@ -49,7 +49,8 @@ class TestCMX(unittest.TestCase):
             os.environ["GAIA_DIR"] = cls.gaiadir_orig
 
     def setUp(self):
-        #- Treat a specific warning as an error
+        #- Treat a specific warning as an error (could turn off if this
+        #- becomes problematic)
         warnings.filterwarnings('error', '.*Calling nonzero on 0d arrays.*')
 
     def test_cuts_basic(self):

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -50,6 +50,7 @@ class TestCuts(unittest.TestCase):
 
     def setUp(self):
         #- treat some specific warnings as errors so we can find and fix
+        #- (could turn off if this becomes problematic)
         warnings.filterwarnings('error', '.*Calling nonzero on 0d arrays.*')
 
     def test_unextinct_fluxes(self):

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -7,6 +7,7 @@ from pkg_resources import resource_filename
 import os.path
 from uuid import uuid4
 import numbers
+import warnings
 
 from astropy.io import fits
 from astropy.table import Table
@@ -46,6 +47,10 @@ class TestCuts(unittest.TestCase):
         # ADM reset GAIA_DIR environment variable.
         if cls.gaiadir_orig is not None:
             os.environ["GAIA_DIR"] = cls.gaiadir_orig
+
+    def setUp(self):
+        #- treat some specific warnings as errors so we can find and fix
+        warnings.filterwarnings('error', '.*Calling nonzero on 0d arrays.*')
 
     def test_unextinct_fluxes(self):
         """Test function that unextincts fluxes

--- a/py/desitarget/test/test_qa.py
+++ b/py/desitarget/test/test_qa.py
@@ -6,6 +6,7 @@ import unittest
 import os
 import shutil
 import tempfile
+import warnings
 import numpy as np
 import healpy as hp
 from pkg_resources import resource_filename
@@ -35,6 +36,10 @@ class TestQA(unittest.TestCase):
             shutil.rmtree(cls.testdir)
 
     def setUp(self):
+        #- Treat some specific warnings as errors so that we can find and fix
+        # warnings.filterwarnings('error', '.*Mean of empty slice.*')
+        # warnings.filterwarnings('error', '.*Using or importing the ABCs.*')
+        warnings.filterwarnings('error', '.*invalid value encountered.*')
         pass
 
     def tearDown(self):


### PR DESCRIPTION
This PR cleans up some warnings from python 3.8 + numpy 1.18.5:

  * numpy is getting more picky about not using `where` on scalars, thus necessitating
     more verbose `if np.isscalar(x) ... else ...` code.
  * avoid calling `np.median` on empty slices (previously that would return a NaN, so
     still using that if the slice was empty).

Tests pass at NERSC using both the current desi environment with python/3.6 + numpy/1.16.4 and a test python/3.8 + numpy/1.18.5 environment, but I'm not sure if the tests cover the Gaia NaN and QA empty slice cases so please take a look.