### PR TITLE
Add units to all output files

### DIFF
--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -32,6 +32,8 @@ ap.add_argument("--norandomize", action='store_true',
 ap.add_argument("--numchunks", type=int,
                 help='number of chunks in which to write to save memory [defaults to {}]'.format(nchunks),
                 default=nchunks)
+ap.add_argument("--skip", action='store_true',
+                help="Skip input files that don't exist without flagging an error")
 
 ns = ap.parse_args()
 
@@ -42,7 +44,11 @@ if ns.targtype == 'gfas':
 extname = tt.upper()
 
 # ADM convert passed csv strings to lists.
-fns = [ fn for fn in ns.infiles.split(';') ]
+if ns.skip:
+    fns = [ fn for fn in ns.infiles.split(';') if
+            os.path.isfile(os.path.expandvars(fn))]
+else:
+    fns = [ fn for fn in ns.infiles.split(';') ]
 
 # ADM read the header from the first file.
 fx = fitsio.FITS(fns[0])

--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, division
 
+import os
 import fitsio
 from fitsio import FITS
 import numpy as np
@@ -15,6 +16,9 @@ start = time()
 from desiutil.log import get_logger
 log = get_logger()
 
+# ADM the default number of chunks to write in to save memory.
+nchunks = 10
+
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Concatenate multiple FITS files into one large file. Retains the header from the FIRST listed input file')
 ap.add_argument("infiles", 
@@ -23,6 +27,11 @@ ap.add_argument("outfile",
                 help="Output file name")
 ap.add_argument("targtype", choices=['skies', 'randoms', 'targets', 'gfas'],
                 help="Type of target run with parallelization/multiprocessing code to gather")
+ap.add_argument("--norandomize", action='store_true',
+                help="Do NOT randomly shuffle the final file before writing it (using seed 626)")
+ap.add_argument("--numchunks", type=int,
+                help='number of chunks in which to write to save memory [defaults to {}]'.format(nchunks),
+                default=nchunks)
 
 ns = ap.parse_args()
 
@@ -30,6 +39,7 @@ ns = ap.parse_args()
 tt = ns.targtype
 if ns.targtype == 'gfas':
     tt = "GFA_TARGETS"
+extname = tt.upper()
 
 # ADM convert passed csv strings to lists.
 fns = [ fn for fn in ns.infiles.split(';') ]
@@ -38,29 +48,61 @@ fns = [ fn for fn in ns.infiles.split(';') ]
 fx = fitsio.FITS(fns[0])
 hdr = fx[1].read_header()
 
+# ADM if you're combining files, you'll need to
+# ADM combine the HEALPixel coverage.
+hpx = []
+for fn in fns:
+    hpx.append(fitsio.read_header(fn, extname)["FILEHPX"])
+hdr["FILEHPX"] = ",".join(hpx)
+
 # ADM retain a list of the units.
 tunits = ["TUNIT{}".format(i) for i in range(1, hdr["TFIELDS"]+1)]
 units = [hdr[tunit] if tunit in hdr.keys() else "" for tunit in tunits]
 
-[hdr[key] if "UNIT" in key else "" for key in hdr.keys()]
-
 log.info('Begin writing {} to {}...t = {:.1f}s'
          .format(ns.targtype, ns.outfile, time()-start))
 
-# ADM open the file for writing.
-fits = FITS(ns.outfile, 'rw', clobber=True)
+# ADM read the input files.
+data = []
+for fn in fns:
+    log.info('Reading file {}...t = {:.1f}s'.format(fn, time()-start))
+    fndata = fitsio.read(fn)
+    data.append(fndata)
+data = np.concatenate(data)
+ndata = len(data)
 
-# ADM write the first file with the header.
-data = fitsio.read(fns[0])
-log.info('Working on file {}...t = {:.1f}s'.format(fns[0], time()-start))
-fits.write(data, extname=tt.upper(), header=hdr, units=units)
+indexes = np.arange(ndata)
+# ADM shuffle to ensure randomness.
+if not ns.norandomize:
+    log.info("Read in {:.1e} objects. Shuffling indexes...t = {:.1f}s"
+             .format(ndata, time()-start))
+    # ADM the seed for the "final" shuffle."
+    reseed = 626
+    hdr["RESEED"] = reseed
+    np.random.seed(reseed)
+    np.random.shuffle(indexes)
 
-# ADM add the other files.
-for fn in fns[1:]:
-    log.info('Working on file {}...t = {:.1f}s'.format(fn, time()-start))
-    data = fitsio.read(fn)
-    fits[-1].append(data)
+#ADM write in chunks to save memory.
+chunk = ndata//ns.numchunks
+outy = fitsio.FITS(ns.outfile+".tmp", 'rw', clobber=True)
+for i in range(ns.numchunks):
+    log.info("Writing chunk {}/{} from index {} to {}...t = {:.1f}s"
+             .format(i+1, ns.numchunks, i*chunk, (i+1)*chunk-1, time()-start))
+    datachunk = data[indexes[i*chunk:(i+1)*chunk]]
+    # ADM if this is the first chunk, write the data and header...
+    if i == 0:
+        outy.write(datachunk, extname=extname, header=hdr)
+    # ADM ...otherwise just append to the existing file object.
+    else:
+        outy[-1].append(datachunk)
+    # ADM append any remaining data.
+datachunk = data[indexes[ns.numchunks*chunk:]]
+if len(datachunk) > 0:
+    log.info("Writing final partial chunk from index {} to {}...t = {:.1f}s"
+             .format(ns.numchunks*chunk, len(data)-1, time()-start))
+    outy[-1].append(datachunk)
+outy.close()
 
-fits.close()
+os.rename(ns.outfile+'.tmp', ns.outfile)
 
-log.info('Finished writing...t = {:.1f}s'.format(time()-start))
+log.info('Finished writing to {}...t = {:.1f}s'.format(ns.outfile, time()-start))

--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -38,16 +38,22 @@ fns = [ fn for fn in ns.infiles.split(';') ]
 fx = fitsio.FITS(fns[0])
 hdr = fx[1].read_header()
 
+# ADM retain a list of the units.
+tunits = ["TUNIT{}".format(i) for i in range(1, hdr["TFIELDS"]+1)]
+units = [hdr[tunit] if tunit in hdr.keys() else "" for tunit in tunits]
+
+[hdr[key] if "UNIT" in key else "" for key in hdr.keys()]
+
 log.info('Begin writing {} to {}...t = {:.1f}s'
          .format(ns.targtype, ns.outfile, time()-start))
 
 # ADM open the file for writing.
-fits = FITS(ns.outfile, 'rw')
+fits = FITS(ns.outfile, 'rw', clobber=True)
 
 # ADM write the first file with the header.
 data = fitsio.read(fns[0])
 log.info('Working on file {}...t = {:.1f}s'.format(fns[0], time()-start))
-fits.write(data, extname=tt.upper(), header=hdr, clobber=True)
+fits.write(data, extname=tt.upper(), header=hdr, units=units)
 
 # ADM add the other files.
 for fn in fns[1:]:

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -142,7 +142,7 @@ else:
         )
 
     # ADM redact empty output (where there were no bricks in a survey).
-    skies = np.array(skies) 
+    skies = np.array(skies, dtype=object)
     ii = [sk is not None for sk in skies]
     skies = np.concatenate(skies[ii])
 

--- a/bin/split_randoms
+++ b/bin/split_randoms
@@ -33,7 +33,10 @@ nrands = len(rands)
 log.info("Read in {:.1e} randoms. Shuffling indexes...t = {:.1f}s"
          .format(nrands, time()-start))
 indexes = np.arange(nrands)
-np.random.seed(626)
+# ADM the seed for the "extra" shuffles.
+reseed = 626
+hdr["RESEED"] = reseed
+np.random.seed(reseed)
 np.random.shuffle(indexes)
 
 #ADM write in chunks to save memory.
@@ -50,5 +53,3 @@ for i in range(ns.nchunks):
     fitsio.write(outfile, rands[indexes[i*chunk:(i+1)*chunk]], extname='RANDOMS', header=hdr, clobber=True)
 
 print("Done...t = {:.1f}s".format(time()-start))
-
-

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desitarget Change Log
 -------------------
 
 * Add units to all output files (addresses `issue #356`_) [`PR #638`_]:
-    * Units for all output quantities are stored in `data/units.yaml`_.
+    * Units for all output quantities are stored in `data/units.yaml`.
     * Unit tests check that output quantities have associated units.
     * Unit tests also check that all units are valid astropy units.
     * Also some more minor cleanup and speedups.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,14 @@ desitarget Change Log
 0.42.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Add units to all output files (addresses `issue #356`_) [`PR #638`_]:
+    * Units for all output quantities are stored in `data/units.yaml`_.
+    * Unit tests check that output quantities have associated units.
+    * Unit tests also check that all units are valid astropy units.
+    * Also some more minor cleanup and speedups.
+
+.. _`issue #356`: https://github.com/desihub/desitarget/issues/356
+.. _`PR #638`: https://github.com/desihub/desitarget/pull/638
 
 0.42.0 (2020-08-17)
 -------------------

--- a/py/desitarget/data/units.yaml
+++ b/py/desitarget/data/units.yaml
@@ -1,7 +1,7 @@
 # ADM This yaml file stores units for each quantity in the desitarget
 # ADM data model. There are two ways to express a quantity with no unit:
-    - Leave the quantity out of this yaml file completely.
-    - Include the quantity but with no unit after the colon.
+# ADM    - Leave the quantity out of this yaml file completely.
+# ADM    - Include the quantity but with no unit after the colon.
 
 # ADM mostly Legacy Surveys sweeps/tractor files units:
 RA: deg

--- a/py/desitarget/data/units.yaml
+++ b/py/desitarget/data/units.yaml
@@ -1,0 +1,13 @@
+# ADM This yaml file stores units for each quantity in the desitarget
+# ADM data model. There are two ways to express a quantity with no unit:
+    - Leave the quantity out of this yaml file completely.
+    - Include the quantity but with no unit after the colon.
+
+# ADM mostly Legacy Surveys sweeps/tractor files units:
+RA: deg
+DEC: deg
+
+# ADM mostly Gaia units:
+GAIA_PHOT_G_MEAN_MAG: mag
+GAIA_ASTROMETRIC_EXCESS_NOISE:
+REF_EPOCH: yr

--- a/py/desitarget/data/units.yaml
+++ b/py/desitarget/data/units.yaml
@@ -1,7 +1,8 @@
 # ADM This yaml file stores units for each quantity in the desitarget
 # ADM data model. There are two ways to express a quantity with no unit:
-# ADM    - Leave the quantity out of this yaml file completely.
 # ADM    - Include the quantity but with no unit after the colon.
+# ADM    - Leave the quantity out of this yaml file completely.
+# ADM      (note that a unit test *prevents* leaving quantities out!).
 # ADM try to order quantities alphabetically within each sub-section.
 
 # ADM Legacy Surveys sweeps/tractor files units:
@@ -118,9 +119,9 @@ GAIA_ASTROMETRIC_PARAMS_SOLVED:
 PARALLAX: mas
 PARALLAX_IVAR: 1/mas^2
 PMRA: mas / yr
-PMRA_IVAR: 1/(mas/yr)^2
+PMRA_IVAR: yr^2 / mas^2
 PMDEC: mas / yr
-PMDEC_IVAR: 1/(mas/yr)^2
+PMDEC_IVAR: yr^2 / mas^2
 
 # ADM columns specifically added by target selection.
 BGS_TARGET:
@@ -133,6 +134,7 @@ NUMOBS_INIT:
 OBSCONDITIONS:
 PHOTSYS:
 PRIORITY_INIT:
+SCND_TARGET:
 SUBPRIORITY:
 TARGETID:
 
@@ -167,3 +169,11 @@ E2:
 IN_RADIUS: arcsec
 NEAR_RADIUS: arcsec
 REF_MAG: mag
+
+# ADM MTL-related units:
+NUMOBS:
+TARGET_STATE:
+TIMESTAMP: s
+VERSION:
+Z:
+ZWARN:

--- a/py/desitarget/data/units.yaml
+++ b/py/desitarget/data/units.yaml
@@ -2,12 +2,168 @@
 # ADM data model. There are two ways to express a quantity with no unit:
 # ADM    - Leave the quantity out of this yaml file completely.
 # ADM    - Include the quantity but with no unit after the colon.
+# ADM try to order quantities alphabetically within each sub-section.
 
-# ADM mostly Legacy Surveys sweeps/tractor files units:
-RA: deg
+# ADM Legacy Surveys sweeps/tractor files units:
+ALLMASK_G:
+ALLMASK_R:
+ALLMASK_Z:
+BRICKID:
+BRICKNAME:
+DCHISQ:
 DEC: deg
-
-# ADM mostly Gaia units:
-GAIA_PHOT_G_MEAN_MAG: mag
-GAIA_ASTROMETRIC_EXCESS_NOISE:
+DEC_IVAR: 1/deg^2
+EBV: mag
+FIBERFLUX_G: nanomaggy
+FIBERFLUX_R: nanomaggy
+FIBERFLUX_Z: nanomaggy
+FIBERTOTFLUX_G: nanomaggy
+FIBERTOTFLUX_R: nanomaggy
+FIBERTOTFLUX_Z: nanomaggy
+FLUX_G: nanomaggy
+FLUX_IVAR_G: 1/nanomaggy^2
+FLUX_IVAR_R: 1/nanomaggy^2
+FLUX_IVAR_W1: 1/nanomaggy^2
+FLUX_IVAR_W2: 1/nanomaggy^2
+FLUX_IVAR_W3: 1/nanomaggy^2
+FLUX_IVAR_W4: 1/nanomaggy^2
+FLUX_IVAR_Z: 1/nanomaggy^2
+FLUX_R: nanomaggy
+FLUX_W1: nanomaggy
+FLUX_W2: nanomaggy
+FLUX_W3: nanomaggy
+FLUX_W4: nanomaggy
+FLUX_Z: nanomaggy
+FRACDEV:
+FRACDEV_IVAR:
+FRACFLUX_G:
+FRACFLUX_R:
+FRACFLUX_Z:
+FRACIN_G:
+FRACIN_R:
+FRACIN_Z:
+FRACMASKED_G:
+FRACMASKED_R:
+FRACMASKED_Z:
+GALDEPTH_G: 1/nanomaggy^2
+GALDEPTH_R: 1/nanomaggy^2
+GALDEPTH_Z: 1/nanomaggy^2
+LC_FLUX_IVAR_W1: 1/nanomaggy^2
+LC_FLUX_IVAR_W2: 1/nanomaggy^2
+LC_FLUX_W1: nanomaggy
+LC_FLUX_W2: nanomaggy
+LC_MJD_W1:
+LC_MJD_W2:
+LC_NOBS_W1:
+LC_NOBS_W2:
+MASKBITS:
+MW_TRANSMISSION_G:
+MW_TRANSMISSION_R:
+MW_TRANSMISSION_W1:
+MW_TRANSMISSION_W2:
+MW_TRANSMISSION_W3:
+MW_TRANSMISSION_W4:
+MW_TRANSMISSION_Z:
+NOBS_G:
+NOBS_R:
+NOBS_Z:
+OBJID:
+PSFDEPTH_G: 1/nanomaggy^2
+PSFDEPTH_R: 1/nanomaggy^2
+PSFDEPTH_Z: 1/nanomaggy^2
+RA: deg
+RA_IVAR: 1/deg^2
 REF_EPOCH: yr
+RELEASE:
+SERSIC:
+SERSIC_IVAR:
+SHAPEDEV_E1:
+SHAPEDEV_E1_IVAR:
+SHAPEDEV_E2:
+SHAPEDEV_E2_IVAR:
+SHAPEDEV_R: arcsec
+SHAPEDEV_R_IVAR: 1/arcsec^2
+SHAPEEXP_E1:
+SHAPEEXP_E1_IVAR:
+SHAPEEXP_E2:
+SHAPEEXP_E2_IVAR:
+SHAPEEXP_R: arcsec
+SHAPEEXP_R_IVAR: 1/arcsec^2
+SHAPE_E1:
+SHAPE_E1_IVAR:
+SHAPE_E2:
+SHAPE_E2_IVAR:
+SHAPE_R:
+SHAPE_R_IVAR:
+TYPE:
+WISEMASK_W1:
+WISEMASK_W2:
+
+# ADM (desitarget versions of) Gaia-related units:
+REF_ID:
+REF_CAT:
+GAIA_RA: deg
+GAIA_DEC: deg
+GAIA_PHOT_G_MEAN_MAG: mag
+GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR:
+GAIA_PHOT_BP_MEAN_MAG: mag
+GAIA_PHOT_BP_MEAN_FLUX_OVER_ERROR:
+GAIA_PHOT_RP_MEAN_MAG: mag
+GAIA_PHOT_RP_MEAN_FLUX_OVER_ERROR:
+GAIA_PHOT_BP_RP_EXCESS_FACTOR:
+GAIA_ASTROMETRIC_EXCESS_NOISE:
+GAIA_DUPLICATED_SOURCE:
+GAIA_ASTROMETRIC_SIGMA5D_MAX:
+GAIA_ASTROMETRIC_PARAMS_SOLVED:
+PARALLAX: mas
+PARALLAX_IVAR: 1/mas^2
+PMRA: mas / yr
+PMRA_IVAR: 1/(mas/yr)^2
+PMDEC: mas / yr
+PMDEC_IVAR: 1/(mas/yr)^2
+
+# ADM columns specifically added by target selection.
+BGS_TARGET:
+BRICK_OBJID:
+DESI_TARGET:
+HPXPIXEL:
+MORPHTYPE:
+MWS_TARGET:
+NUMOBS_INIT:
+OBSCONDITIONS:
+PHOTSYS:
+PRIORITY_INIT:
+SUBPRIORITY:
+TARGETID:
+
+# ADM sky-related units:
+BLOBDIST: pix
+FIBERFLUX_IVAR_G: 1/nanomaggy^2
+FIBERFLUX_IVAR_R: 1/nanomaggy^2
+FIBERFLUX_IVAR_Z: 1/nanomaggy^2
+
+# ADM GFA-related units:
+URAT_ID:
+URAT_SEP: arcsec
+
+# ADM randoms-related units:
+APFLUX_G: nanomaggy
+APFLUX_IVAR_G: 1/nanomaggy^2
+APFLUX_IVAR_R: 1/nanomaggy^2
+APFLUX_IVAR_Z: 1/nanomaggy^2
+APFLUX_R: nanomaggy
+APFLUX_Z: nanomaggy
+NUMOBS_MORE:
+PRIORITY:
+PSFDEPTH_W1: 1/nanomaggy^2
+PSFDEPTH_W2: 1/nanomaggy^2
+PSFSIZE_G: arcsec
+PSFSIZE_R: arcsec
+PSFSIZE_Z: arcsec
+
+# ADM mask-related units:
+E1:
+E2:
+IN_RADIUS: arcsec
+NEAR_RADIUS: arcsec
+REF_MAG: mag

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -801,7 +801,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     print("wait")
     print("")
     if gather:
-        ddrr = drstr.replace("-","")
+        ddrr = drstr.replace("-", "")
         for resolve, region in zip([True, False, False], [None, "north", "south"]):
             outfiles = []
             for pix in pixtracker:

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -802,7 +802,9 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     print("")
     if gather:
         ddrr = drstr.replace("-", "")
-        for resolve, region in zip([True, False, False], [None, "north", "south"]):
+        for resolve, region, skip in zip([True, False, False],
+                                         [None, "north", "south"],
+                                         ["", "--skip", "--skip"]):
             outfiles = []
             for pix in pixtracker:
                 outfn = find_target_files(
@@ -813,8 +815,8 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
                 "$CSCRATCH", dr=ddrr, flavor=prefix, seed=seed, nohp=True,
                 resolve=resolve, region=region)
             print("")
-            print("gather_targets '{}' {} {}".format(";".join(outfiles), outfn,
-                                                     prefix2.split("_")[-1]))
+            print("gather_targets '{}' {} {} {}".format(
+                ";".join(outfiles), outfn, prefix2.split("_")[-1], skip))
         print("")
 
     return

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -436,8 +436,8 @@ def add_urat_pms(objs, numproc=4):
         refids = urats[0][1]
         urats = urats[0][0]
     else:
-        refids = np.concatenate(np.array(urats)[:, 1])
-        urats = np.concatenate(np.array(urats)[:, 0])
+        refids = np.concatenate(np.array(urats, dtype=object)[:, 1])
+        urats = np.concatenate(np.array(urats, dtype=object)[:, 0])
 
     # ADM sort the output to match the input, on REF_ID.
     ii = np.zeros_like(refids)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1866,10 +1866,14 @@ def check_hp_target_dir(hpdirname):
     for fn in fns:
         hdr = read_targets_header(fn)
         nside.append(hdr["FILENSID"])
-        pixels = int(hdr["FILEHPX"])
-        # ADM if this is a one-pixel file, convert to a list.
-        if isinstance(pixels, int):
-            pixels = [pixels]
+        pixels = hdr["FILEHPX"]
+        # ADM hdr["FILEHPX"] could be a str, depending on fitsio version.
+        if isinstance(pixels, str):
+            pixels = list(map(int, pixels.split(',')))
+        # ADM if this is a one-pixel file, or interpreted as a tuple,
+        # ADM convert to a list.
+        else:
+            pixels = list(np.atleast_1d(pixels))
         # ADM check we haven't stored a pixel string that is too long.
         _check_hpx_length(pixels)
         # ADM create a look-up dictionary of file-for-each-pixel.

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -783,6 +783,7 @@ def write_in_chunks(filename, data, nchunks, extname=None, header=None):
     Notes
     -----
         - Always OVERWRITES existing files!
+        - Mostly deprecated, so was never updated to write units.
     """
     # ADM ensure that files are always overwritten.
     if os.path.isfile(filename):

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2137,6 +2137,8 @@ def find_target_files(targdir, dr='X', flavor="targets", survey="main",
         fn = os.path.join(fn, resdir)
         if region is not None:
             fn = os.path.join(fn, region)
+        if not resolve:
+            prefix = "{}-{}".format(prefix, res)
 
     if flavor == "skies" and supp:
         fn = "{}-supp".format(fn)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -430,7 +430,6 @@ def write_with_units(filename, data, extname=None, header=None, ecsv=False):
                 data[col].unit = unitdict[col]
         except KeyError:
             units.append("")
-            pass
 
     # ADM write the file for either ecsv or fits..
     if ecsv:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1497,7 +1497,7 @@ def list_sweepfiles(root):
 def iter_sweepfiles(root):
     """Iterator over all sweep files found under root directory.
     """
-    ignore = ['metric', 'coadd', 'log', 'pz']
+    ignore = ['metric', 'coadd', 'log', 'pz', 'external', 'tractor']
     return iter_files(root, prefix='sweep', ext='fits', ignore=ignore)
 
 
@@ -1549,7 +1549,8 @@ def iter_tractorfiles(root):
     >>> for brickname, filename in iter_tractor('./'):
     >>>     print(brickname, filename)
     """
-    return iter_files(root, prefix='tractor', ext='fits')
+    ignore = ['metric', 'coadd', 'log', 'pz', 'external', 'sweep']
+    return iter_files(root, prefix='tractor', ext='fits', ignore=ignore)
 
 
 def brickname_from_filename(filename):

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -393,7 +393,7 @@ def write_with_units(filename, data, extname=None, header=None):
     data : :class:`~numpy.ndarray`
         The numpy structured array of data to write.
     extname, header optional
-        Passed through to fitsio.write().
+        Passed through to `fitsio.write()`.
 
     Returns
     -------
@@ -610,8 +610,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
 
     # ADM write in a series of chunks to save memory.
     if nchunks is None:
-        fitsio.write(filename+'.tmp', data, extname='TARGETS', header=hdr, clobber=True)
-        os.rename(filename+'.tmp', filename)
+        write_with_units(filename, data, extname='TARGETS', header=hdr)
     else:
         write_in_chunks(filename, data, nchunks, extname='TARGETS', header=hdr)
 
@@ -621,6 +620,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
         truthdata, trueflux, objtruth = mockdata['truth'], mockdata['trueflux'], mockdata['objtruth']
 
         hdr['SEED'] = (mockdata['seed'], 'initial random seed')
+        # ADM TODO: the mock fitsio.writes could use write_with_units()?
         fitsio.write(truthfile+'.tmp', truthdata.as_array(), extname='TRUTH', header=hdr, clobber=True)
 
         if len(trueflux) > 0 and trueflux.shape[1] > 0:
@@ -924,8 +924,8 @@ def write_secondary(targdir, data, primhdr=None, scxdir=None, obscon=None,
             # ADM to reorder to match the original input order.
             order = np.argsort(scnd_order[ii])
             # ADM write to file.
-            fitsio.write(scxfile, smalldata[ii][order],
-                         extname='TARGETS', header=hdr, clobber=True)
+            write_with_units(scxfile, smalldata[ii][order], extname='TARGETS',
+                             header=hdr)
             log.info('Info for {} secondaries written to {}'
                      .format(np.sum(ii), scxfile))
 
@@ -938,8 +938,7 @@ def write_secondary(targdir, data, primhdr=None, scxdir=None, obscon=None,
     ii = (release < 1000) & (data["PRIORITY_INIT"] > -1)
 
     # ADM ...write them out.
-    fitsio.write(filename, data[ii],
-                 extname='SCND_TARGETS', header=hdr, clobber=True)
+    write_with_units(filename, data[ii], extname='SCND_TARGETS', header=hdr)
 
     return np.sum(ii), filename
 
@@ -1085,8 +1084,7 @@ def write_skies(targdir, data, indir=None, indir2=None, supp=False,
     # ADM create necessary directories, if they don't exist.
     os.makedirs(os.path.dirname(filename), exist_ok=True)
 
-    fitsio.write(filename+'.tmp', data, extname='SKY_TARGETS', header=hdr, clobber=True)
-    os.rename(filename+'.tmp', filename)
+    write_with_units(filename, data, extname='SKY_TARGETS', header=hdr)
 
     return len(data), filename
 
@@ -1187,7 +1185,7 @@ def write_gfas(targdir, data, indir=None, indir2=None, nside=None,
     # ADM create necessary directories, if they don't exist.
     os.makedirs(os.path.dirname(filename), exist_ok=True)
 
-    fitsio.write(filename, data, extname='GFA_TARGETS', header=hdr, clobber=True)
+    write_with_units(filename, data, extname='GFA_TARGETS', header=hdr)
 
     return len(data), filename
 
@@ -1321,7 +1319,7 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
     # ADM create necessary directories, if they don't exist.
     os.makedirs(os.path.dirname(filename), exist_ok=True)
 
-    fitsio.write(filename, data, extname='RANDOMS', header=hdr, clobber=True)
+    write_with_units(filename, data, extname='RANDOMS', header=hdr)
 
     return nrands, filename
 
@@ -1393,16 +1391,14 @@ def write_masks(maskdir, data,
             os.makedirs(os.path.dirname(fn), exist_ok=True)
             # ADM write the output file.
             if len(outdata) > 0:
-                fitsio.write(
-                    fn, outdata, extname='MASKS', header=outhdr, clobber=True)
+                write_with_units(fn, outdata, extname='MASKS', header=outhdr)
                 log.info('wrote {} masks to {}'.format(len(outdata), fn))
     else:
         fn = find_target_files(maskdir, flavor="masks", hp="X",
                                maglim=maglim, epoch=maskepoch)
         os.makedirs(os.path.dirname(fn), exist_ok=True)
         if len(data) > 0:
-            fitsio.write(
-                fn, data, extname='MASKS', header=hdr, clobber=True)
+            write_with_units(fn, data, extname='MASKS', header=hdr)
             log.info('wrote {} masks to {}'.format(len(data), fn))
 
     return nmasks, os.path.dirname(fn)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1383,7 +1383,7 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
         # ADM pixnum only contains unique bricks, need to add duplicates.
         allpixnum = np.concatenate([np.zeros(cnt, dtype=int)+pix for
                                     cnt, pix in zip(cnts.astype(int), pixnum)])
-        bundle_bricks(allpixnum, bundlebricks, nside,
+        bundle_bricks(allpixnum, bundlebricks, nside, gather=True,
                       brickspersec=brickspersec, prefix='randoms',
                       surveydirs=[drdir], extra=extra, seed=seed)
         # ADM because the broader function returns three outputs.

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -259,8 +259,9 @@ def make_skies_for_a_brick(survey, brickname, nskiespersqdeg=None, bands=['g', '
     naps = len(apertures_arcsec)
     apcolindices = np.where(['FIBERFLUX' in colname for colname in dt.names])[0]
     desc = dt.descr
-    for i in apcolindices:
-        desc[i] += (naps,)
+    if naps > 1:
+        for i in apcolindices:
+            desc[i] += (naps,)
 
     # ADM set up a rec array to hold all of the output information.
     skies = np.zeros(nskies, dtype=desc)

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -893,7 +893,8 @@ def get_supp_skies(ras, decs, radius=2.):
     # ADM add the brickid and name.
     supsky["BRICKID"] = bricks.brickid(ras[good], decs[good])
     supsky["BRICKNAME"] = bricks.brickname(ras[good], decs[good])
-    supsky["BLOBDIST"] = 2.
+    # ADM BLOBDIST is in ~Legacy Surveys pixels, with scale 0.262 "/pix.
+    supsky["BLOBDIST"] = radius/0.262
     # ADM set all fluxes and IVARs to -1, so they're ill-defined.
     for name in skydatamodel.dtype.names:
         if "FLUX" in name:

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -374,7 +374,7 @@ def sky_fibers_for_brick(survey, brickname, nskies=144, bands=['g', 'r', 'z'],
         - the brickid
         - the brickname
         - the x and y pixel positions of the fiber location from the blobs file
-        - the distance from the nearest blob of this fiber location
+        - the distance to the nearest blob at this fiber location
         - the RA and Dec positions of the fiber location
         - the aperture flux and ivar at the passed `apertures_arcsec`
 

--- a/py/desitarget/test/test_units.py
+++ b/py/desitarget/test/test_units.py
@@ -1,0 +1,97 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desitarget units.
+"""
+import os
+import unittest
+import yaml
+import astropy.units as u
+import numpy as np
+from astropy.table import Table
+from pkg_resources import resource_filename
+from desitarget.brightmask import maskdatamodel as dma
+from desitarget.gaiamatch import gaiadatamodel as dmb
+from desitarget.gfa import gfadatamodel as dmc
+from desitarget.io import basetsdatamodel as dmd
+from desitarget.io import dr8addedcols as dme
+from desitarget.io import dr9addedcols as dmf
+from desitarget.mtl import mtldatamodel as dmg
+from desitarget.skyfibers import skydatamodel as dmh
+
+
+class TestUNITS(unittest.TestCase):
+
+    def setUp(self):
+        # ADM load the units yaml file.
+        basefn = os.path.join('data', 'units.yaml')
+        self.fn = resource_filename('desitarget', basefn)
+        with open(self.fn) as f:
+            self.units = yaml.safe_load(f)
+
+        # ADM combine the unique quantities from the various data models.
+        dmnames = dma.dtype.names
+        for dm in dmb, dmc, dmd, dme, dmf, dmg, dmh:
+            dmnames += dm.dtype.names
+        self.dmnames = list(set(dmnames))
+
+    def test_fits_units(self):
+        """Test the units meet the FITS standard (via astropy).
+        """
+        # ADM unique units from the yaml file parsed through astropy.
+        uniq = set(self.units.values())
+        parsed = [u.Unit(unit) for unit in uniq if unit is not None]
+
+        # ADM the list of units with None removed
+        uniq = list(uniq)
+        uniq.remove(None)
+
+        # ADM these should be equivalent, even though, formally, parsed
+        # ADM contains items of type astropy.units.core.Unit.
+        self.assertEqual(uniq, parsed)
+
+    def test_quantities(self):
+        """Test all data model quantities in are in the units yaml file.
+        """
+        missing = [dmn for dmn in self.dmnames if dmn not in self.units]
+        msg = 'These quantities are missing in {}'.format(self.fn)
+
+        self.assertEqual([], missing, msg=msg)
+
+    def test_assigning(self):
+        """Test all data model quantities can be assigned units.
+        """
+        # ADM loop through the data model and create a list of units
+        # ADM that would be suitable for writing using fitsio.
+        unitlist = []
+        for col in self.dmnames:
+            if self.units[col] is None:
+                unitlist.append("")
+            else:
+                unitlist.append(self.units[col])
+        unitlist = np.array(unitlist)
+
+        # ADM also test assigning units directly to an astropy Table.
+        data = Table(np.zeros(len(self.dmnames)), names=self.dmnames)
+        for col in data.columns:
+            data[col].unit = self.units[col]
+
+        # ADM recover the units from the Table.
+        tabunits = np.array([data[col].unit for col in data.columns])
+
+        # ADM the only discrepancies should be where "" in the unitlist
+        # ADM correspond to None in the astropy Table.
+        msg = "\n*** Unit list is:\n {} \n*** But Table units are:\n {}".format(
+            unitlist, tabunits)
+        self.assertTrue(np.all(unitlist[tabunits != unitlist] == ""), msg=msg)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+def test_suite():
+    """Allows testing of only this module with the command:
+
+        python setup.py test -m desitarget.test.test_mtl
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_units.py
+++ b/py/desitarget/test/test_units.py
@@ -5,6 +5,7 @@
 import os
 import unittest
 import yaml
+import astropy.version as astropyversion
 import astropy.units as u
 import numpy as np
 from astropy.table import Table
@@ -37,17 +38,20 @@ class TestUNITS(unittest.TestCase):
     def test_fits_units(self):
         """Test the units meet the FITS standard (via astropy).
         """
-        # ADM unique units from the yaml file parsed through astropy.
+        # ADM unique units from the yaml file with NoneType removed.
         uniq = set(self.units.values())
-        parsed = [u.Unit(unit) for unit in uniq if unit is not None]
-
-        # ADM the list of units with None removed
-        uniq = list(uniq)
         uniq.remove(None)
+
+        # ADM nmgy isn't an allowed unit in earlier versions of astropy.
+        if astropyversion.major < 4:
+            uniq = set([i for i in list(uniq) if 'nanomaggy' not in i])
+
+        # ADM parse the units to check they're allowed astropy units.
+        parsed = [u.Unit(unit) for unit in uniq]
 
         # ADM these should be equivalent, even though, formally, parsed
         # ADM contains items of type astropy.units.core.Unit.
-        self.assertEqual(uniq, parsed)
+        self.assertEqual(list(uniq), parsed)
 
     def test_quantities(self):
         """Test all data model quantities in are in the units yaml file.


### PR DESCRIPTION
This PR adds units to all output files, where "all" means targets, mtl ledgers, mask files, GFAs, skies and randoms. New functionality includes:

- Units for all output quantities are stored in a new yaml file named `data/units.yaml`.
- Unit tests check that any new output quantities that are added to the code have associated units.
- Tests also check that all units are valid astropy units using `astropy.units.Unit()`.

This should address #356.

This PR also includes some more minor cleanup and speedups, such as:
- Fixes some Future/Deprecation Warnings associated with environment upgrades.
- Uses the `io.find_target_files()` functionality to write output files in parallelization scripts for randoms.
- Ensures randoms parallelized across HEALPixels on different nodes are re-randomized before they are combined.
- Smarter traversing of imaging directories when searching for sweeps and Tractor files
    * The imaging directories can contain coadd/log/metrics/etc. files that could slow down an `os.walk()`