### PR TITLE
Update Travis for the Python 3.8/Astropy 4.x combination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,8 @@ env:
     matrix:
         #  - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15.4 SETUP_CMD='egg_info'
         #  - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15.4 SETUP_CMD='bdist_egg'
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.6 SETUP_CMD='bdist_egg'
+        - PYTHON_VERSION=3.8 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.8 SETUP_CMD='bdist_egg'
 
 matrix:
     # Don't wait for allowed failures.

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,11 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        # - NUMPY_VERSION='<1.17'
-        - NUMPY_VERSION=1.16.5
+        # - NUMPY_VERSION=1.16.5
+        - NUMPY_VERSION=1.19.1
         # - SCIPY_VERSION=0.16
-        - ASTROPY_VERSION=2.0.16
-        #- Old healpy version needed as long as we pin old astropy too
-        - HEALPY_VERSION=1.12.9
+        - ASTROPY_VERSION=4.0.1
+        - HEALPY_VERSION=1.14.0
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=3.0.0
         - SPECLITE_VERSION=0.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,20 +43,15 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        # ADM I'm leaving the previous (working) version commented out as
-        # ADM it makes it easy to revert (not that we should ever have to).
-        # - NUMPY_VERSION=1.16.5
-        - NUMPY_VERSION=1.19.1
+        # - NUMPY_VERSION='<1.17'
+        - NUMPY_VERSION=1.16.5
         # - SCIPY_VERSION=0.16
-        # - ASTROPY_VERSION=2.0.16
-        - ASTROPY_VERSION=4.0.1
-        #- Old healpy version needed as long as we pin old astropy (2.0.16) too
-        #- HEALPY_VERSION=1.12.9
-        - HEALPY_VERSION=1.14.0
+        - ASTROPY_VERSION=2.0.16
+        #- Old healpy version needed as long as we pin old astropy too
+        - HEALPY_VERSION=1.12.9
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=3.0.0
-        # - SPECLITE_VERSION=0.8
-         - SPECLITE_VERSION=0.9
+        - SPECLITE_VERSION=0.8
         # - SPECTER_VERSION=0.8.3
         - DESIMODEL_VERSION=0.10.2
         - DESIMODEL_DATA=branches/test-0.10
@@ -95,8 +90,8 @@ env:
     matrix:
         #  - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15.4 SETUP_CMD='egg_info'
         #  - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15.4 SETUP_CMD='bdist_egg'
-        - PYTHON_VERSION=3.8 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.8 SETUP_CMD='bdist_egg'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='bdist_egg'
 
 matrix:
     # Don't wait for allowed failures.
@@ -106,13 +101,13 @@ matrix:
     allow_failures:
         - os: osx
         - os: linux
-          env: PYTHON_VERSION=3.8 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
                ASTROPY_VERSION=stable NUMPY_VERSION=stable
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
         - os: linux
-          env: PYTHON_VERSION=3.8 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
+          env: PYTHON_VERSION=3.6 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
 
     include:
 
@@ -120,7 +115,7 @@ matrix:
         # Note: this test is not a perfectly realistic test of ReadTheDocs
         # builds, which operate in a much more bare-bones environment
         - os: linux
-          env: PYTHON_VERSION=3.8 SETUP_CMD='build_sphinx --warning-is-error'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='build_sphinx --warning-is-error'
 
         # Try multiple python versions with the latest numpy
         # - os: linux
@@ -131,13 +126,13 @@ matrix:
         #        DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.8 SETUP_CMD='test --coverage'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.8 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
                ASTROPY_VERSION=stable NUMPY_VERSION=stable
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
@@ -190,7 +185,7 @@ matrix:
 
         # PEP 8 compliance.
         - os: linux
-          env: PYTHON_VERSION=3.8 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
+          env: PYTHON_VERSION=3.6 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
     allow_failures:
         - os: osx
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.8 SETUP_CMD='test'
                ASTROPY_VERSION=stable NUMPY_VERSION=stable
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
@@ -114,7 +114,7 @@ matrix:
         # Note: this test is not a perfectly realistic test of ReadTheDocs
         # builds, which operate in a much more bare-bones environment
         - os: linux
-          env: PYTHON_VERSION=3.8 SETUP_CMD='build_sphinx --warning-is-error'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='build_sphinx --warning-is-error'
 
         # Try multiple python versions with the latest numpy
         # - os: linux
@@ -131,7 +131,7 @@ matrix:
                DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.8 SETUP_CMD='test'
                ASTROPY_VERSION=stable NUMPY_VERSION=stable
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,15 +43,20 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        # - NUMPY_VERSION='<1.17'
-        - NUMPY_VERSION=1.16.5
+        # ADM I'm leaving the previous (working) version commented out as
+        # ADM it makes it easy to revert (not that we should ever have to).
+        # - NUMPY_VERSION=1.16.5
+        - NUMPY_VERSION=1.19.1
         # - SCIPY_VERSION=0.16
-        - ASTROPY_VERSION=2.0.16
-        #- Old healpy version needed as long as we pin old astropy too
-        - HEALPY_VERSION=1.12.9
+        # - ASTROPY_VERSION=2.0.16
+        - ASTROPY_VERSION=4.0.1
+        #- Old healpy version needed as long as we pin old astropy (2.0.16) too
+        #- HEALPY_VERSION=1.12.9
+        - HEALPY_VERSION=1.14.0
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=3.0.0
-        - SPECLITE_VERSION=0.8
+        # - SPECLITE_VERSION=0.8
+         - SPECLITE_VERSION=0.9
         # - SPECTER_VERSION=0.8.3
         - DESIMODEL_VERSION=0.10.2
         - DESIMODEL_DATA=branches/test-0.10
@@ -90,8 +95,8 @@ env:
     matrix:
         #  - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15.4 SETUP_CMD='egg_info'
         #  - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15.4 SETUP_CMD='bdist_egg'
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.6 SETUP_CMD='bdist_egg'
+        - PYTHON_VERSION=3.8 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.8 SETUP_CMD='bdist_egg'
 
 matrix:
     # Don't wait for allowed failures.
@@ -101,13 +106,13 @@ matrix:
     allow_failures:
         - os: osx
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.8 SETUP_CMD='test'
                ASTROPY_VERSION=stable NUMPY_VERSION=stable
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
         - os: linux
-          env: PYTHON_VERSION=3.6 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
+          env: PYTHON_VERSION=3.8 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
 
     include:
 
@@ -115,7 +120,7 @@ matrix:
         # Note: this test is not a perfectly realistic test of ReadTheDocs
         # builds, which operate in a much more bare-bones environment
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='build_sphinx --warning-is-error'
+          env: PYTHON_VERSION=3.8 SETUP_CMD='build_sphinx --warning-is-error'
 
         # Try multiple python versions with the latest numpy
         # - os: linux
@@ -126,13 +131,13 @@ matrix:
         #        DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage'
+          env: PYTHON_VERSION=3.8 SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.8 SETUP_CMD='test'
                ASTROPY_VERSION=stable NUMPY_VERSION=stable
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
@@ -185,7 +190,7 @@ matrix:
 
         # PEP 8 compliance.
         - os: linux
-          env: PYTHON_VERSION=3.6 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
+          env: PYTHON_VERSION=3.8 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,11 +73,12 @@ env:
         # - CONDA_SPHINX_DEPENDENCIES="scipy pyyaml sphinx==1.5"
         # These packages will only be installed if we really need them.
         # - CONDA_ALL_DEPENDENCIES="scipy matplotlib=2.1.2 scikit-learn h5py coverage pyyaml photutils basemap=1.0.7"
-        - CONDA_ALL_DEPENDENCIES="scipy matplotlib scikit-learn h5py coverage pyyaml photutils numba"
+        # - CONDA_ALL_DEPENDENCIES="scipy matplotlib scikit-learn h5py coverage pyyaml photutils numba"
+        - CONDA_ALL_DEPENDENCIES="scipy matplotlib scikit-learn h5py coverage pyyaml numba"
         # These packages will always be installed.
         - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.
-        - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls fitsio"
+        - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls fitsio photutils"
         #- PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls fitsio basemap==1.0.7 "
         # - PIP_ALL_DEPENDENCIES="coveralls fitsio"
         # These pip packages need to be installed in a certain order, so we

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
     allow_failures:
         - os: osx
         - os: linux
-          env: PYTHON_VERSION=3.8 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
                ASTROPY_VERSION=stable NUMPY_VERSION=stable
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
@@ -125,13 +125,13 @@ matrix:
         #        DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage'
+          env: PYTHON_VERSION=3.8 SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.8 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
                ASTROPY_VERSION=stable NUMPY_VERSION=stable
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,8 @@ env:
         # - DESITARGET_VERSION=master
         # - SIMQSO_VERSION=v1.2.3
         # - DESI_LOGLEVEL=DEBUG
-        - PIP_VERSION=19.3.1
+        # - PIP_VERSION=19.3.1
+        - PIP_VERSION=20.2.2
         - MAIN_CMD='python setup.py'
         # Additional conda channels to use.
         - CONDA_CHANNELS="astropy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
         - os: linux
-          env: PYTHON_VERSION=3.6 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
+          env: PYTHON_VERSION=3.8 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
 
     include:
 
@@ -114,7 +114,7 @@ matrix:
         # Note: this test is not a perfectly realistic test of ReadTheDocs
         # builds, which operate in a much more bare-bones environment
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='build_sphinx --warning-is-error'
+          env: PYTHON_VERSION=3.8 SETUP_CMD='build_sphinx --warning-is-error'
 
         # Try multiple python versions with the latest numpy
         # - os: linux
@@ -184,7 +184,7 @@ matrix:
 
         # PEP 8 compliance.
         - os: linux
-          env: PYTHON_VERSION=3.6 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
+          env: PYTHON_VERSION=3.8 MAIN_CMD='pycodestyle' SETUP_CMD='--count py/desitarget'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/bin/write_qso_probs
+++ b/bin/write_qso_probs
@@ -27,9 +27,9 @@ log = get_logger()
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Take a set of target or sweep files and write ')
-ap.add_argument("src", 
+ap.add_argument("src",
                 help="Sweeps or target file or root directory with sweeps or target files")
-ap.add_argument("dest", 
+ap.add_argument("dest",
                 help="Output directory")
 
 ns = ap.parse_args()
@@ -71,7 +71,7 @@ for fn in infiles:
             data[col] = targs[col]
 
     # ADM run targets split by north/south, which have different RFs.
-    norths = _isonnorthphotsys(targs["PHOTSYS"]) 
+    norths = _isonnorthphotsys(targs["PHOTSYS"])
 
     for ii, south in zip([norths, ~norths], [False, True]):
         log.info("south is {}; running on {} targets...t={:.1f}s".format(
@@ -85,7 +85,7 @@ for fn in infiles:
             gfracin, rfracin, zfracin, gallmask, rallmask, zallmask,   \
             gsnr, rsnr, zsnr, w1snr, w2snr,                            \
             dchisq, deltaChi2, maskbits, refcat =                      \
-            _prepare_optical_wise(targs[ii], mask=True) 
+            _prepare_optical_wise(targs[ii], mask=True)
 
         # ADM run the RFs.
         _, _, pqso, pqsohiz = isQSO_randomforest(
@@ -94,7 +94,7 @@ for fn in infiles:
             maskbits=maskbits, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
             objtype=objtype, release=release, south=south,
             return_probs=True)
-        
+
         # ADM add the RFs to the output data.
         data["PQSO"][ii] = pqso
         data["PQSO_HIZ"][ii] = pqsohiz
@@ -103,7 +103,7 @@ for fn in infiles:
     depend.setdep(hdr, 'desitarget-pqso-git', io.gitversion())
     outfn = os.path.join(ns.dest,
                          os.path.basename(fn).replace(".fits", '-pqso.fits'))
-    
+
     log.info("Writing to {}...t={:.1f}s".format(outfn, time()-start))
     io.write_with_units(outfn, data, extname="PQSO", header=hdr)
 

--- a/bin/write_qso_probs
+++ b/bin/write_qso_probs
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import os, sys
+import numpy as np
+import numpy.lib.recfunctions as rfn
+import fitsio
+
+# ADM the columns that are written to the "QSO prob" files.
+datamodel = np.array([], dtype=[
+    ('RELEASE', '>i2'), ('BRICKID', '>i4'),
+    ('BRICKNAME', 'S8'), ('BRICK_OBJID', '>i4'),
+    ('RA', '>f8'), ('DEC', '>f8'),
+    ('PHOTSYS', '<U1'),
+    ('PQSO', '>f4'), ('PQSO_HIZ', '>f4')
+    ])
+
+from desiutil import depend
+from desitarget import io
+from desitarget.cuts import _prepare_optical_wise, isQSO_randomforest, _isonnorthphotsys
+from desitarget.targets import main_cmx_or_sv
+
+from time import time
+start = time()
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Take a set of target or sweep files and write ')
+ap.add_argument("src", 
+                help="Sweeps or target file or root directory with sweeps or target files")
+ap.add_argument("dest", 
+                help="Output directory")
+
+ns = ap.parse_args()
+
+infiles = io.list_sweepfiles(ns.src)
+extname = "SWEEP"
+if len(infiles) == 0:
+    infiles = io.list_targetfiles(ns.src)
+    extname = "TARGETS"
+if len(infiles) == 0:
+    log.critical('no sweep or target files found')
+    sys.exit(1)
+
+# ADM Convert single file to list of files.
+if isinstance(infiles, str):
+    infiles = [infiles, ]
+
+for fn in infiles:
+    log.info("Working on file {}...t={:.1f}s".format(fn, time()-start))
+    # ADM read the file.
+    targs, hdr = fitsio.read(fn, header=True, ext=extname)
+
+    # ADM the input targets may have had some column names changed.
+    targs = rfn.rename_fields(targs, {'MORPHTYPE': 'TYPE'})
+
+    # ADM Add DESI_TARGET to the data model for target files.
+    dt = datamodel.dtype
+    if extname == "TARGETS":
+        tcols, _, _ = main_cmx_or_sv(targs)
+        dt = datamodel.dtype.descr + [(tcols[0], '>i8')]
+    # ADM will need to add PHOTSYS column to sweeps files.
+    else:
+        targs = io.add_photsys(targs)
+
+    # ADM populate the data model.
+    data = np.zeros(len(targs), dtype = dt)
+    for col in data.dtype.names:
+        if col in targs.dtype.names:
+            data[col] = targs[col]
+
+    # ADM run targets split by north/south, which have different RFs.
+    norths = _isonnorthphotsys(targs["PHOTSYS"]) 
+
+    for ii, south in zip([norths, ~norths], [False, True]):
+        log.info("south is {}; running on {} targets...t={:.1f}s".format(
+            south, np.sum(ii), time()-start))
+        # ADM grab the necessary information for running the RF.
+        photsys_north, photsys_south, obs_rflux, gflux, rflux, zflux,  \
+            w1flux, w2flux, gfiberflux, rfiberflux, zfiberflux,        \
+            objtype, release, gfluxivar, rfluxivar, zfluxivar,         \
+            gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,      \
+            gfracmasked, rfracmasked, zfracmasked,                     \
+            gfracin, rfracin, zfracin, gallmask, rallmask, zallmask,   \
+            gsnr, rsnr, zsnr, w1snr, w2snr,                            \
+            dchisq, deltaChi2, maskbits, refcat =                      \
+            _prepare_optical_wise(targs[ii], mask=True) 
+
+        # ADM run the RFs.
+        _, _, pqso, pqsohiz = isQSO_randomforest(
+            primary=None, zflux=zflux, rflux=rflux, gflux=gflux,
+            w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2,
+            maskbits=maskbits, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+            objtype=objtype, release=release, south=south,
+            return_probs=True)
+        
+        # ADM add the RFs to the output data.
+        data["PQSO"][ii] = pqso
+        data["PQSO_HIZ"][ii] = pqsohiz
+
+    # ADM write the file.
+    depend.setdep(hdr, 'desitarget-pqso-git', io.gitversion())
+    outfn = os.path.join(ns.dest,
+                         os.path.basename(fn).replace(".fits", '-pqso.fits'))
+    
+    log.info("Writing to {}...t={:.1f}s".format(outfn, time()-start))
+    io.write_with_units(outfn, data, extname="PQSO", header=hdr)
+
+log.info("Done...t={:.1f}s".format(time()-start))

--- a/bin/write_qso_probs
+++ b/bin/write_qso_probs
@@ -5,7 +5,7 @@ import numpy as np
 import numpy.lib.recfunctions as rfn
 import fitsio
 
-# ADM the columns that are written to the "QSO prob" files.
+# ADM the columns that are to be written to the "QSO prob" files.
 datamodel = np.array([], dtype=[
     ('RELEASE', '>i2'), ('BRICKID', '>i4'),
     ('BRICKNAME', 'S8'), ('BRICK_OBJID', '>i4'),

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 0.42.1 (unreleased)
 -------------------
 
+* Update Travis for Py3.8/Astropy 4.x (fixes `issue #639`_) [`PR #640`_].
+    * Also adds a useful script for recovering the QSO RF probabilities.
 * Add units to all output files (addresses `issue #356`_) [`PR #638`_]:
     * Units for all output quantities are stored in `data/units.yaml`.
     * Unit tests check that output quantities have associated units.
@@ -12,7 +14,9 @@ desitarget Change Log
     * Also some more minor cleanup and speedups.
 
 .. _`issue #356`: https://github.com/desihub/desitarget/issues/356
+.. _`issue #639`: https://github.com/desihub/desitarget/issues/639
 .. _`PR #638`: https://github.com/desihub/desitarget/pull/638
+.. _`PR #640`: https://github.com/desihub/desitarget/pull/640
 
 0.42.0 (2020-08-17)
 -------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -412,7 +412,7 @@ def read_data(targfile, mocks=False, downsample=None, header=False):
         for objtype in set(truths['TEMPLATETYPE']):
             try:
                 oo = objtype.decode('utf-8').strip().upper()
-            except:
+            except AttributeError:
                 oo = objtype
 
             extname = 'TRUTH_{}'.format(oo)

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -846,7 +846,7 @@ def repartition_skies(skydirname, numproc=1):
         with pool:
             skies = pool.map(_write_hp_skies, hpsplit)
     else:
-            _write_hp_skies(hpsplit[0])
+        _write_hp_skies(hpsplit[0])
 
     return
 

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -109,14 +109,14 @@ def encode_targetid(objid=None, brickid=None, release=None,
     # ADM check passed parameters don't exceed their bit-allowance
     # ADM and aren't negative numbers.
     for param, bitname in zip(inputs, bitnames):
-            msg = 'Invalid range when making targetid: {} '.format(bitname)
-            if not np.all(param < 2**targetid_mask[bitname].nbits):
-                msg += 'cannot exceed {}'.format(2**targetid_mask[bitname].nbits - 1)
-            if not np.all(param >= 0):
-                msg += 'cannot be negative'
-            if 'cannot' in msg:
-                log.critical(msg)
-                raise IOError(msg)
+        msg = 'Invalid range when making targetid: {} '.format(bitname)
+        if not np.all(param < 2**targetid_mask[bitname].nbits):
+            msg += 'cannot exceed {}'.format(2**targetid_mask[bitname].nbits - 1)
+        if not np.all(param >= 0):
+            msg += 'cannot be negative'
+        if 'cannot' in msg:
+            log.critical(msg)
+            raise IOError(msg)
 
     # ADM set up targetid as an array of 64-bit integers.
     targetid = np.zeros(nobjs, ('int64'))


### PR DESCRIPTION
This PR updates the online Travis tests to better resemble the `desiconda 20.8` release, which addresses #639.

Basically, we switch the `.travis.yml` file to install `Python 3.8`, `Numpy 1.19.1` and `Astropy 4.0.1` for tests. This also facilitates a few more updates, such as using `healpy 1.14.0` and `pip 20.2.2`.

Although the key tests are updated for the `Python 3.8`/`Astropy 4.0.1` combination, the "stable" test (which is an allowed failure) and the sphinx build still use `Python 3.6`. It didn't seem straightforward to update these tests to use `Python 3.8` (yet), and it isn't as critical that these tests align exactly with the environment at NERSC.

This PR also brought along a useful script that can generate the QSO Random Forest probabilities for a target (or sweeps) file for post-facto analysis.