### PR TITLE
Add the STD_DITHER_GAIA target class for commissioning

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 0.42.1 (unreleased)
 -------------------
 
+* Add the ``STD_DITHER_GAIA`` target class for CMX [`PR #644`_].
+    * For commissioning tests outside the Legacy Surveys footprint.
 * Update Travis for Py3.8/Astropy 4.x (fixes `issue #639`_) [`PR #640`_].
     * Also adds a useful script for recovering the QSO RF probabilities.
 * Add units to all output files (addresses `issue #356`_) [`PR #638`_]:
@@ -17,6 +19,7 @@ desitarget Change Log
 .. _`issue #639`: https://github.com/desihub/desitarget/issues/639
 .. _`PR #638`: https://github.com/desihub/desitarget/pull/638
 .. _`PR #640`: https://github.com/desihub/desitarget/pull/640
+.. _`PR #644`: https://github.com/desihub/desitarget/pull/644
 
 0.42.0 (2020-08-17)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desitarget Change Log
 -------------------
 
 * Add the ``STD_DITHER_GAIA`` target class for CMX [`PR #644`_].
-    * For commissioning tests outside the Legacy Surveys footprint.
+    * For dither tests outside the Legacy Surveys footprint.
 * Update Travis for Py3.8/Astropy 4.x (fixes `issue #639`_) [`PR #640`_].
     * Also adds a useful script for recovering the QSO RF probabilities.
 * Add units to all output files (addresses `issue #356`_) [`PR #638`_]:

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2111,6 +2111,7 @@ def apply_cuts_gaia(numproc=4, cmxdir=None, nside=None, pixlist=None,
     # ADM add in the first light program targets.
     cmx_target = np.concatenate([cmx_target, fl_target])
     gaiaobjs = np.concatenate([gaiaobjs, flobjs])
+    priority_shift = np.concatenate([priority_shift, np.zeros_like(fl_target)])
 
     return cmx_target, gaiaobjs, priority_shift
 

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2629,6 +2629,9 @@ def select_targets(infiles, numproc=4, cmxdir=None, noqso=False,
             # ADM Retain all non-Gaia sources, which have REF_ID of -1 or 0
             # ADM and so are all duplicates on REF_ID.
             ii &= alltargs["REF_ID"] > 0
+            # ADM Always retain the STD_DITHER_GAIA targets, even if they're
+            # ADM duplicated in the Legacy Surveys footprint.
+            ii &= (alltargets["CMX_TARGET"] & cmx_mask.STD_DITHER_GAIA) == 0
             targs = alltargs[ii]
             _, ind = np.unique(targs["REF_ID"], return_index=True)
             targs = targs[ind]

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1643,7 +1643,7 @@ def isSTD_dither_gaia(ra=None, dec=None, gmag=None, rmag=None, aen=None,
 
     Notes
     -----
-    - This version (10/21/20) is version 68 on `the cmx wiki`_.
+    - This version (10/25/20) is version 69 on `the cmx wiki`_.
     """
     if primary is None:
         primary = np.ones_like(gmag, dtype='?')

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1663,9 +1663,9 @@ def isSTD_dither_gaia(ra=None, dec=None, gmag=None, rmag=None, aen=None,
     # ADM Unique Gaia source (not a duplicated source).
     issdg &= ~dupsource
 
-    # ADM CUT TO G < 19 where |b| < 20.
+    # ADM CUT TO G < 18 where |b| < 20.
     blt20 = is_in_gal_box([ra, dec], [0, 360, -20, 20], radec=True)
-    issdg &= (gmag < 19 | ~blt20)
+    issdg &= (gmag < 18 | ~blt20)
 
     # ADM remove any sources that have neighbors within 7"...
     # ADM for speed, run only sources for which issdg is still True.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1679,7 +1679,7 @@ def isSTD_dither_gaia(ra=None, dec=None, gmag=None, rmag=None, aen=None,
         gaiaobjs = []
         gaiacols = ["RA", "DEC", "PHOT_G_MEAN_MAG", "PHOT_RP_MEAN_MAG"]
         for i, fn in enumerate(fns):
-            if i % 10 == 0:
+            if i % 25 == 0:
                 log.info("Read {}/{} files for STD_DITHER_GAIA...t={:.1f}s"
                          .format(i, len(fns), time()-start))
             try:
@@ -2631,7 +2631,7 @@ def select_targets(infiles, numproc=4, cmxdir=None, noqso=False,
             ii &= alltargs["REF_ID"] > 0
             # ADM Always retain the STD_DITHER_GAIA targets, even if they're
             # ADM duplicated in the Legacy Surveys footprint.
-            ii &= (alltargets["CMX_TARGET"] & cmx_mask.STD_DITHER_GAIA) == 0
+            ii &= (alltargs["CMX_TARGET"] & cmx_mask.STD_DITHER_GAIA) == 0
             targs = alltargs[ii]
             _, ind = np.unique(targs["REF_ID"], return_index=True)
             targs = targs[ind]

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -32,7 +32,8 @@ from desitarget.cuts import shift_photo_north
 from desitarget.internal import sharedmem
 from desitarget.targets import finalize, resolve
 from desitarget.cmx.cmx_targetmask import cmx_mask
-from desitarget.geomask import sweep_files_touch_hp, is_in_hp, bundle_bricks
+from desitarget.geomask import sweep_files_touch_hp, bundle_bricks
+from desitarget.geomask import is_in_hp, is_in_gal_box
 from desitarget.gaiamatch import gaia_dr_from_ref_cat, is_in_Galaxy
 from desitarget.gaiamatch import find_gaia_files_hp
 
@@ -1660,7 +1661,9 @@ def isSTD_dither_gaia(ra=None, dec=None, gmag=None, rmag=None, aen=None,
     issdg &= ~dupsource
 
     # ADM CUT TO G < 19 where |b| < 20.
-    
+    blt20 = is_in_gal_box([ra, dec], [0, 360, -20, 20], radec=True)
+    issdg &= (gmag < 19 | ~blt20)
+
     # ADM remove any sources that have neighbors within 7"...
     # ADM for speed, run only sources for which issdg is still True.
     ii_true = np.where(issdg)[0]

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1665,7 +1665,7 @@ def isSTD_dither_gaia(ra=None, dec=None, gmag=None, rmag=None, aen=None,
 
     # ADM CUT TO G < 18 where |b| < 20.
     blt20 = is_in_gal_box([ra, dec], [0, 360, -20, 20], radec=True)
-    issdg &= (gmag < 18 | ~blt20)
+    issdg &= (gmag < 18) | ~blt20
 
     # ADM remove any sources that have neighbors within 7"...
     # ADM for speed, run only sources for which issdg is still True.
@@ -2104,7 +2104,6 @@ def apply_cuts_gaia(numproc=4, cmxdir=None, nside=None, pixlist=None,
     # ADM Construct the target flag bits.
     cmx_target = std_calspec * cmx_mask.STD_CALSPEC
     cmx_target |= backup_bright * cmx_mask.BACKUP_BRIGHT
-    cmx_target |= backup_faint * cmx_mask.BACKUP_FAINT
     cmx_target |= backup_faint * cmx_mask.BACKUP_FAINT
     cmx_target |= sdg * cmx_mask.STD_DITHER_GAIA
 

--- a/py/desitarget/cmx/data/cmx_targetmask.yaml
+++ b/py/desitarget/cmx/data/cmx_targetmask.yaml
@@ -59,7 +59,8 @@ cmx_mask:
     - [MINI_SV_QSO,        55, "QSOs (RF) for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT}]
     - [MINI_SV_BGS_BRIGHT, 56, "BGS (bright) for Mini SV tests (NORTH+SOUTH with noresolve)", {obsconditions: DARK|GRAY|BRIGHT}]
 
-    - [SV0_MWS_FAINT, 57, "Faint stars for Mini SV tests", {obsconditions: POOR|TWILIGHT12|TWILIGHT18}]
+    - [SV0_MWS_FAINT,      57, "Faint stars for Mini SV tests", {obsconditions: POOR|TWILIGHT12|TWILIGHT18}]
+    - [STD_DITHER_GAIA,    58, "Gaia stars for dithering tests outside of the Legacy Surveys footprint", {obsconditions: DARK|GRAY|BRIGHT}]
 
     #- Calibration targets. Shared between main/cmx/sv programs.
     - [SKY,         32, "Blank sky locations",
@@ -146,6 +147,7 @@ priorities:
         MINI_SV_QSO: {UNOBS: 3420, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         MINI_SV_BGS_BRIGHT: {UNOBS: 2101, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         SV0_MWS_FAINT: {UNOBS: 5, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        STD_DITHER_GAIA: {UNOBS: 2400, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FAINT:  -1
@@ -204,6 +206,7 @@ numobs:
         MINI_SV_QSO: 4
         MINI_SV_BGS_BRIGHT: 1
         SV0_MWS_FAINT: 1
+        STD_DITHER_GAIA: 1
         BAD_SKY: 0
         #- Standards and sky are treated specially; NUMOBS doesn't apply
         STD_FAINT: -1

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -161,7 +161,7 @@ def gaia_gfas_from_sweep(filename, maglim=18.):
 
 
 def gaia_in_file(infile, maglim=18, mindec=-30., mingalb=10.,
-                 nside=None, pixlist=None, addobjid=False):
+                 nside=None, pixlist=None, addobjid=False, addparams=False):
     """Retrieve the Gaia objects from a HEALPixel-split Gaia file.
 
     Parameters
@@ -183,6 +183,10 @@ def gaia_in_file(infile, maglim=18, mindec=-30., mingalb=10.,
     addobjid : :class:`bool`, optional, defaults to ``False``
         If ``True``, include, in the output, a column "GAIA_OBJID"
         that is the integer number of each row read from file.
+    addparams : :class:`bool`, optional, defaults to ``False``
+        If ``True``, include some additional Gaia columns:
+        "GAIA_ASTROMETRIC_EXCESS_NOISE", "GAIA_DUPLICATED_SOURCE"
+        and "GAIA_ASTROMETRIC_PARAMS_SOLVED'.
 
     Returns
     -------
@@ -209,6 +213,10 @@ def gaia_in_file(infile, maglim=18, mindec=-30., mingalb=10.,
     dt = gfadatamodel.dtype.descr
     if addobjid:
         for tup in ('GAIA_BRICKID', '>i4'), ('GAIA_OBJID', '>i4'):
+            dt.append(tup)
+    if addparams:
+        for tup in [('GAIA_DUPLICATED_SOURCE', '?'),
+                    ('GAIA_ASTROMETRIC_PARAMS_SOLVED', '>i1')]:
             dt.append(tup)
 
     gfas = np.zeros(len(objs), dtype=dt)
@@ -251,8 +259,8 @@ def gaia_in_file(infile, maglim=18, mindec=-30., mingalb=10.,
 
 
 def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
-                      tiles=None, mindec=-30, mingalb=10,
-                      nside=None, pixlist=None, addobjid=False):
+                      tiles=None, mindec=-30, mingalb=10, nside=None,
+                      pixlist=None, addobjid=False, addparams=False):
     """An array of all Gaia objects in the DESI tiling footprint
 
     Parameters
@@ -279,6 +287,9 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
     addobjid : :class:`bool`, optional, defaults to ``False``
         If ``True``, include, in the output, a column "GAIA_OBJID"
         that is the integer number of each row read from each Gaia file.
+    addparams : :class:`bool`, optional, defaults to ``False``
+        If ``True``, include some additional Gaia columns:
+        "GAIA_DUPLICATED_SOURCE" and "GAIA_ASTROMETRIC_PARAMS_SOLVED'.
 
     Returns
     -------
@@ -317,7 +328,8 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
     def _get_gaia_gfas(fn):
         '''wrapper on gaia_in_file() given a file name'''
         return gaia_in_file(fn, maglim=maglim, mindec=mindec, mingalb=mingalb,
-                            nside=nside, pixlist=pixlist, addobjid=addobjid)
+                            nside=nside, pixlist=pixlist,
+                            addobjid=addobjid, addparams=addparams)
 
     # ADM this is just to count sweeps files in _update_status.
     nfile = np.zeros((), dtype='i8')

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -523,12 +523,18 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
     drint = None
     if supp and len(data) > 0:
         _, _, _, _, _, gaiadr = decode_targetid(data["TARGETID"])
-        if len(set(gaiadr)) != 1:
-            msg = "Targets are based on multiple Gaia DRs:".format(set(gaiadr))
-            log.critical(msg)
-            raise ValueError(msg)
-        gaiadr = gaiadr[0]
+        # ADM cmx targets can have the First Light targets, which
+        # ADM have an invented Gaia DR.
+        if survey != "cmx":
+            if len(set(gaiadr)) != 1:
+                msg = "Targets are based on multiple Gaia DRs:".format(set(gaiadr))
+                log.critical(msg)
+                raise ValueError(msg)
+            gaiadr = gaiadr[0]
+        else:
+            gaiadr = np.max(gaiadr)
         drstring = "gaiadr{}".format(gaiadr)
+        print("HERE", drstring)
     else:
         try:
             drint = int(indir.split("dr")[1][0])

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -534,7 +534,6 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
         else:
             gaiadr = np.max(gaiadr)
         drstring = "gaiadr{}".format(gaiadr)
-        print("HERE", drstring)
     else:
         try:
             drint = int(indir.split("dr")[1][0])

--- a/py/desitarget/test/test_cmx.py
+++ b/py/desitarget/test/test_cmx.py
@@ -117,13 +117,13 @@ class TestCMX(unittest.TestCase):
         for filelist in [self.sweepfiles]:
             # ADM No QSO cuts and limit to pixels for speed.
             # ADM This doesn't affect coverage.
-            targets = cuts.select_targets(filelist, numproc=1,
+            targets = cuts.select_targets(filelist, numproc=1, test=True,
                                           cmxdir=self.cmxdir, noqso=True,
                                           nside=self.nside, pixlist=self.pix)
-            t1 = cuts.select_targets(filelist[0:1], numproc=1,
+            t1 = cuts.select_targets(filelist[0:1], numproc=1, test=True,
                                      cmxdir=self.cmxdir, noqso=True,
                                      nside=self.nside, pixlist=self.pix)
-            t2 = cuts.select_targets(filelist[0], numproc=1,
+            t2 = cuts.select_targets(filelist[0], numproc=1, test=True,
                                      cmxdir=self.cmxdir, noqso=True,
                                      nside=self.nside, pixlist=self.pix)
             for col in t1.dtype.names:
@@ -147,7 +147,7 @@ class TestCMX(unittest.TestCase):
             # ADM parallelization across pixels only works for sweep files.
             for filelist in [self.sweepfiles]:
                 # ADM No QSO cuts for speed. Doesn't affect coverage.
-                targets = cuts.select_targets(filelist, numproc=nproc,
+                targets = cuts.select_targets(filelist, numproc=nproc, test=True,
                                               cmxdir=self.cmxdir, noqso=True,
                                               nside=self.nside, pixlist=self.pix)
                 self.assertTrue('CMX_TARGET' in targets.dtype.names)


### PR DESCRIPTION
This PR adds the `STD_DITHER_GAIA` target class in the `CMX` masks and cuts. These are targets intended for dither tests outside of the Legacy Surveys footprint.

I've asked @schlafly to vet a couple of files produced using this branch. Once he signs off on those I'll merge this, tag, and run new targets for (re-)commissioning.