### PR TITLE
Clean-up targets and randoms for the internal DR9 release.

### DIFF
--- a/bin/alt_split_randoms
+++ b/bin/alt_split_randoms
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import os, sys
+import numpy as np
+import fitsio
+from time import time
+start = time()
+import fitsio
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Split a random catalog into N smaller catalogs. Shuffle the random catalog first to ensure randomness.')
+ap.add_argument("randomcat",
+                help='A random catalog (e.g /project/projectdirs/desi/target/catalogs/randoms-dr4-0.20.0.fits). For an input catalog /X/X.fits N smaller catalogs will be written to /X/X-[0:N-1].fits')
+ap.add_argument("-n", "--nchunks", type=int,
+                help='Number of smaller catalog to split the random catalog into. Defaults to [10].',
+                default="10")
+
+ns = ap.parse_args()
+
+if not os.path.exists(ns.randomcat):
+    log.critical('Input directory does not exist: {}'.format(ns.randomcat))
+    sys.exit(1)
+
+log.info("Read in randoms from {} and split into {} catalogs...t = {:.1f}s"
+         .format(ns.randomcat, ns.nchunks, time()-start))
+
+hdr = fitsio.read_header(ns.randomcat, "RANDOMS")
+nrands = hdr["NAXIS2"]
+
+# ADM shuffle to ensure randomness.
+log.info("Read in {:.1e} randoms. Shuffling indexes...t = {:.1f}s"
+         .format(nrands, time()-start))
+indexes = np.arange(nrands)
+spltseed = 636
+np.random.seed(spltseed)
+hdr["SPLTSEED"] = spltseed
+np.random.shuffle(indexes)
+
+# ADM write in chunks to save memory.
+chunk = nrands//ns.nchunks
+# ADM remember that the density has effectively gone down.
+hdr["DENSITY"] //= ns.nchunks
+
+# ADM write out smaller files one-by-one.
+for i in range(ns.nchunks):
+    # ADM read in the relevant indexes.
+    rands = fitsio.read(ns.randomcat, rows=indexes[i*chunk:(i+1)*chunk])
+    # ADM re-randomize, as fitsio reads in order.
+    write_indexes = np.arange(chunk)
+    np.random.shuffle(write_indexes)
+    # ADM open the file for writing.
+    outfile = "{}-{}.fits".format(os.path.splitext(ns.randomcat)[0], i)
+    log.info("Writing chunk {} from index {} to {}...t = {:.1f}s"
+             .format(i, i*chunk, (i+1)*chunk, time()-start))
+    fitsio.write(outfile, rands[write_indexes], extname='RANDOMS', header=hdr,
+                 clobber=True)
+
+print("Done...t = {:.1f}s".format(time()-start))

--- a/bin/alt_split_randoms
+++ b/bin/alt_split_randoms
@@ -7,6 +7,8 @@ from time import time
 start = time()
 import fitsio
 
+from desitarget.randoms import finalize_randoms, add_default_mtl
+
 from desiutil.log import get_logger
 log = get_logger()
 
@@ -17,6 +19,8 @@ ap.add_argument("randomcat",
 ap.add_argument("-n", "--nchunks", type=int,
                 help='Number of smaller catalog to split the random catalog into. Defaults to [10].',
                 default="10")
+ap.add_argument("--addmtl", action='store_true',
+                help="If passed, then add the columns needed for MTL to the random catalogs after they are split.")
 
 ns = ap.parse_args()
 
@@ -30,6 +34,9 @@ log.info("Read in randoms from {} and split into {} catalogs...t = {:.1f}s"
 hdr = fitsio.read_header(ns.randomcat, "RANDOMS")
 nrands = hdr["NAXIS2"]
 
+# ADM read in the seed used to make the catalog.
+seed = hdr["SEED"]
+
 # ADM shuffle to ensure randomness.
 log.info("Read in {:.1e} randoms. Shuffling indexes...t = {:.1f}s"
          .format(nrands, time()-start))
@@ -39,6 +46,10 @@ np.random.seed(spltseed)
 hdr["SPLTSEED"] = spltseed
 np.random.shuffle(indexes)
 
+# ADM note whether we requested the MTL columns to be added.
+if ns.addmtl:
+    hdr["MTLSPLIT"] = True
+
 # ADM write in chunks to save memory.
 chunk = nrands//ns.nchunks
 # ADM remember that the density has effectively gone down.
@@ -46,8 +57,11 @@ hdr["DENSITY"] //= ns.nchunks
 
 # ADM write out smaller files one-by-one.
 for i in range(ns.nchunks):
-    # ADM read in the relevant indexes.
+    # ADM read in randoms at the relevant indexes.
     rands = fitsio.read(ns.randomcat, rows=indexes[i*chunk:(i+1)*chunk])
+    # ADM if requested, add the MTL-relevant columns.
+    if ns.addmtl:
+        rands = add_default_mtl(finalize_randoms(rands), seed=seed)
     # ADM re-randomize, as fitsio reads in order.
     write_indexes = np.arange(chunk)
     np.random.shuffle(write_indexes)

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -58,18 +58,23 @@ ap.add_argument("--aprad", type=float,
 ap.add_argument("--seed", type=int,
                 help="Random seed passed to desitarget.randoms.select_randoms()",
                 default=1)
+ap.add_argument("--addmtl", action='store_true',
+                help="If passed, then add the columns needed for MTL to the random catalogs.")
 
 ns = ap.parse_args()
 # ADM build the list of command line arguments as
 # ADM bundlebricks potentially needs to know about them.
 extra = " --numproc {}".format(ns.numproc)
 nsdict = vars(ns)
-for nskey in "aprad", "density", "seed":
+for nskey in "aprad", "density", "seed", "addmtl":
     if isinstance(nsdict[nskey], bool):
         if nsdict[nskey]:
             extra += " --{}".format(nskey)
     else:
         extra += " --{} {}".format(nskey, nsdict[nskey])
+
+# ADM whether or not to add the mtl columns.
+nomtl = not ns.addmtl
 
 # ADM parse the list of HEALPixels in which to run.
 pixlist = ns.healpixels
@@ -115,12 +120,12 @@ if not 'dr5' in ns.surveydir and not 'dr6' in ns.surveydir:
 randres, randnorth, randsouth = select_randoms(
     ns.surveydir, density=ns.density, numproc=ns.numproc, nside=ns.nside,
     pixlist=pixlist, aprad=ns.aprad, extra=extra, bundlebricks=ns.bundlebricks,
-    seed=ns.seed, brickspersec=ns.brickspersec, dustdir=ns.dustdir)
+    seed=ns.seed, brickspersec=ns.brickspersec, dustdir=ns.dustdir, nomtl=nomtl)
 
 if ns.bundlebricks is None:
     # ADM extra header keywords for the output fits file.
-    extra = {k: v for k, v in zip(["density", "aprad", "seed"],
-                                  [ns.density, ns.aprad, ns.seed])}
+    extra = {k: v for k, v in zip(["density", "aprad", "seed", "addmtl"],
+                                  [ns.density, ns.aprad, ns.seed, ns.addmtl])}
 
     randoms = [randres, randnorth, randsouth]
     ress = [True, False, False]

--- a/bin/split_randoms
+++ b/bin/split_randoms
@@ -7,6 +7,8 @@ from time import time
 start = time()
 import fitsio
 
+from desitarget.randoms import finalize_randoms, add_default_mtl
+
 from desiutil.log import get_logger
 log = get_logger()
 
@@ -17,6 +19,8 @@ ap.add_argument("randomcat",
 ap.add_argument("-n", "--nchunks", type=int,
                 help='Number of smaller catalog to split the random catalog into. Defaults to [10].',
                 default="10")
+ap.add_argument("--addmtl", action='store_true',
+                help="If passed, then add the columns needed for MTL to the random catalogs after they are split.")
 
 ns = ap.parse_args()
 
@@ -29,6 +33,9 @@ log.info("Read in randoms from {} and split into {} catalogs...t = {:.1f}s"
 rands, hdr = fitsio.read(ns.randomcat, header=True)
 nrands = len(rands)
 
+# ADM read in the seed used to make the catalog.
+seed = hdr["SEED"]
+
 # ADM shuffle to ensure randomness.
 log.info("Read in {:.1e} randoms. Shuffling indexes...t = {:.1f}s"
          .format(nrands, time()-start))
@@ -38,6 +45,10 @@ reseed = 626
 hdr["RESEED"] = reseed
 np.random.seed(reseed)
 np.random.shuffle(indexes)
+
+# ADM note whether we requested the MTL columns to be added.
+if ns.addmtl:
+    hdr["MTLSPLIT"] = True
 
 #ADM write in chunks to save memory.
 chunk = nrands//ns.nchunks
@@ -50,6 +61,10 @@ for i in range(ns.nchunks):
     outfile = "{}-{}.fits".format(os.path.splitext(ns.randomcat)[0], i+1)
     log.info("Writing chunk {} from index {} to {}...t = {:.1f}s"
              .format(i+1, i*chunk, (i+1)*chunk, time()-start))
-    fitsio.write(outfile, rands[indexes[i*chunk:(i+1)*chunk]], extname='RANDOMS', header=hdr, clobber=True)
+    writerands = rands[indexes[i*chunk:(i+1)*chunk]]
+    # ADM if requested, add the MTL-relevant columns.
+    if ns.addmtl:
+        writerands = add_default_mtl(finalize_randoms(writerands), seed=seed)
+    fitsio.write(outfile, writerands, extname='RANDOMS', header=hdr, clobber=True)
 
 print("Done...t = {:.1f}s".format(time()-start))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,16 @@ desitarget Change Log
 0.43.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Clean-up targets and randoms for unofficial DR9 release [`PR #649`_]:
+    * Add function :func:`geomask.imaging_mask()`:
+        * Allows easier parsing of maskbits by string ("BRIGHT", etc.)
+        * Establishes a default set of cuts on maskbits.
+    * New executable ``alt_split_randoms`` (slower but saves memory).
+    * Flexibility when adding MTL columns to randoms, to save memory:
+        * MTL columns can still be added when running the randoms.
+	* Or, can now be added when splitting a larger random catalog.
+
+.. _`PR #649`: https://github.com/desihub/desitarget/pull/649
 
 0.43.0 (2020-10-27)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.43.1 (unreleased)
 -------------------
 
-* Clean-up targets and randoms for unofficial DR9 release [`PR #649`_]:
+* Clean-up targets and randoms for the internal DR9 release [`PR #649`_]:
     * Add function :func:`geomask.imaging_mask()`:
         * Allows easier parsing of maskbits by string ("BRIGHT", etc.)
         * Establishes a default set of cuts on maskbits.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1035,7 +1035,7 @@ def notinBGS_mask(gnobs=None, rnobs=None, znobs=None, primary=None,
     bgs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
     bgs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
 
-    # ADM geometric cuts from the Legacy Surveys.
+    # ADM geometric masking cuts from the Legacy Surveys.
     bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
 
     if targtype == 'bright':
@@ -1127,8 +1127,8 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
             LX = np.array(LX, dtype=bool)
 
     bgs |= LX
-    bgs &= ((maskbits & 2**1) == 0)
-    bgs &= ((maskbits & 2**13) == 0)
+    # ADM geometric masking cuts from the Legacy Surveys.
+    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
 
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -268,12 +268,8 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     # ADM observed in every band.
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
-    # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
-    mb = imaging_mask(maskbits, ["BRIGHT", "MEDIUM" "GALAXY", "CLUSTER",
-                                 "ALLMASK_G", "ALLMASK_R", "ALLMASK_Z"])
-    lrg &= mb
-#    for bit in [1, 5, 6, 7, 11, 12, 13]:
-#        lrg &= ((maskbits & 2**bit) == 0)
+    # ADM default mask bits from the Legacy Surveys not set.
+    lrg &= imaging_mask(maskbits)
 
     return lrg
 
@@ -363,9 +359,8 @@ def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None,
     # ADM observed in every band.
     elg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
-    # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
-    for bit in [1, 5, 6, 7, 11, 12, 13]:
-        elg &= ((maskbits & 2**bit) == 0)
+    # ADM default mask bits from the Legacy Surveys not set.
+    elg &= imaging_mask(maskbits)
 
     return elg
 
@@ -1040,13 +1035,8 @@ def notinBGS_mask(gnobs=None, rnobs=None, znobs=None, primary=None,
     bgs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
     bgs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
 
-    # geometrical cuts (i.e., bright sources)
-    for bit in [1, 12, 13]:
-        bgs &= ((maskbits & 2**bit) == 0)
-
-    # Allmask?
-    # for bit in [5, 6, 7]:
-    #    bgs &= ((maskbits & 2**bit) == 0)
+    # ADM geometric cuts from the Legacy Surveys.
+    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
 
     if targtype == 'bright':
         bgs &= ((Grr > 0.6) | (gaiagmag == 0))
@@ -1206,11 +1196,8 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     if objtype is not None:
         qso &= _psflike(objtype)
 
-    # ADM Reject objects in masks.
-    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
-    if maskbits is not None:
-        for bit in [1, 5, 6, 7, 10, 12, 13]:
-            qso &= ((maskbits & 2**bit) == 0)
+    # ADM default mask bits from the Legacy Surveys not set.
+    qso &= imaging_mask(maskbits)
 
     return qso
 
@@ -1325,8 +1312,8 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
     # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
     # ALLMASK_G	| ALLMASK_R | ALLMASK_Z (5, 6, 7) bits not set.
     if maskbits is not None:
-        for bit in [1, 5, 6, 7, 10, 12, 13]:
-            preSelection &= ((maskbits & 2**bit) == 0)
+        # ADM default mask bits from the Legacy Surveys not set.
+        preSelection &= imaging_mask(maskbits)
 
     # "qso" mask initialized to "preSelection" mask.
     qso = np.copy(preSelection)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -35,7 +35,7 @@ from desitarget.gaiamatch import gaia_dr_from_ref_cat, is_in_Galaxy
 from desitarget.targets import finalize, resolve
 from desitarget.geomask import bundle_bricks, pixarea2nside, sweep_files_touch_hp
 from desitarget.geomask import box_area, hp_in_box, is_in_box, is_in_hp
-from desitarget.geomask import cap_area, hp_in_cap, is_in_cap
+from desitarget.geomask import cap_area, hp_in_cap, is_in_cap, imaging_mask
 
 # ADM set up the DESI default logger
 from desiutil.log import get_logger
@@ -269,8 +269,11 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
-    for bit in [1, 5, 6, 7, 11, 12, 13]:
-        lrg &= ((maskbits & 2**bit) == 0)
+    mb = imaging_mask(maskbits, ["BRIGHT", "MEDIUM" "GALAXY", "CLUSTER",
+                                 "ALLMASK_G", "ALLMASK_R", "ALLMASK_Z"])
+    lrg &= mb
+#    for bit in [1, 5, 6, 7, 11, 12, 13]:
+#        lrg &= ((maskbits & 2**bit) == 0)
 
     return lrg
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -31,6 +31,43 @@ import healpy as hp
 from desiutil.log import get_logger
 log = get_logger()
 
+def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER",
+                                        "ALLMASK_G", "ALLMASK_R", "ALLMASK_Z"]):
+    """Apply the 'geometric' masks from the Legacy Surveys imaging.
+
+    Parameters
+    ----------
+    maskbits : :class:`~numpy.ndarray` or ``None``
+        General array of `Legacy Surveys mask`_ bits.
+    bright : :class:`list`, defaults to ["BRIGHT", "GALAXY", "CLUSTER",
+    "ALLMASK_G", "ALLMASK_R", "ALLMASK_Z"]
+        list of Legacy Surveys mask bits to set to ``False``.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        A boolean array that is the same length as `maskbits` that
+        contains ``False`` where any bits in `bitnamelist` are set.
+
+    Notes
+    -----
+        - For the definitions of the mask bits, see, e.g.,
+             https://www.legacysurvey.org/dr8/bitmasks/#maskbits
+    """
+    # ADM a dictionary of how the bit-names correspond to the bit-values.
+    bitdict = {"BRIGHT":1, "ALLMASK_G":5, "ALLMASK_R":6, "ALLMASK_Z":7,
+               "BAILOUT":10, "MEDIUM":11, "GALAXY":12, "CLUSTER":13}
+
+    # ADM look up the bit value for each passed bit name.
+    bits = [bitdict[bitname] for bitname in bitnamelist]
+
+    # ADM Create array of True and set to False where a mask bit is set.
+    mb = np.ones_like(maskbits, dtype='?')
+    for bit in bits:
+        mb &= ((maskbits & 2**bit) == 0)
+
+    return mb
+
 
 def ellipse_matrix(r, e1, e2):
     """Calculate transformation matrix from half-light-radius to ellipse
@@ -165,7 +202,7 @@ def is_in_ellipse(ras, decs, RAcen, DECcen, r, e1, e2):
     Returns
     -------
     :class:`boolean`
-        An array that is the same length as RA/Dec that is True
+        An array that is the same length as RA/Dec that is ``True``
         for points that are in the mask and False for points that
         are not in the mask
 
@@ -217,7 +254,7 @@ def is_in_ellipse_matrix(ras, decs, RAcen, DECcen, G):
     Returns
     -------
     :class:`boolean`
-        An array that is the same length as ras/decs that is True
+        An array that is the same length as ras/decs that is ``True``
         for points that are in the mask and False for points that
         are not in the mask
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -31,16 +31,15 @@ import healpy as hp
 from desiutil.log import get_logger
 log = get_logger()
 
-def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER",
-                                        "ALLMASK_G", "ALLMASK_R", "ALLMASK_Z"]):
+
+def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"]):
     """Apply the 'geometric' masks from the Legacy Surveys imaging.
 
     Parameters
     ----------
     maskbits : :class:`~numpy.ndarray` or ``None``
         General array of `Legacy Surveys mask`_ bits.
-    bright : :class:`list`, defaults to ["BRIGHT", "GALAXY", "CLUSTER",
-    "ALLMASK_G", "ALLMASK_R", "ALLMASK_Z"]
+    bright : :class:`list`, defaults to ["BRIGHT", "GALAXY", "CLUSTER"]
         list of Legacy Surveys mask bits to set to ``False``.
 
     Returns
@@ -55,8 +54,8 @@ def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER",
              https://www.legacysurvey.org/dr8/bitmasks/#maskbits
     """
     # ADM a dictionary of how the bit-names correspond to the bit-values.
-    bitdict = {"BRIGHT":1, "ALLMASK_G":5, "ALLMASK_R":6, "ALLMASK_Z":7,
-               "BAILOUT":10, "MEDIUM":11, "GALAXY":12, "CLUSTER":13}
+    bitdict = {"BRIGHT": 1, "ALLMASK_G": 5, "ALLMASK_R": 6, "ALLMASK_Z": 7,
+               "BAILOUT": 10, "MEDIUM": 11, "GALAXY": 12, "CLUSTER": 13}
 
     # ADM look up the bit value for each passed bit name.
     bits = [bitdict[bitname] for bitname in bitnamelist]

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -87,6 +87,38 @@ def dr_extension(drdir):
     return 'fz', 1
 
 
+def _add_default_mtl(randoms):
+    """Add default columns that are added by MTL.
+
+    Parameters
+    ----------
+    randoms : :class:`~numpy.ndarray`
+        A random catalog as made by, e.g., :func:`select_randoms()`
+        with `nomtl=True` or `select_randoms_bricks()` with
+        `nomtl=False`. This function adds the default MTL information.
+
+    Returns
+    -------
+    :class:`~numpy.array`
+        Right Ascensions of random points in brick (degrees).
+    :class:`~numpy.array`
+        Declinations of random points in brick (degrees).
+    """
+    from desitarget.mtl import make_mtl
+    randoms = np.array(make_mtl(randoms, obscon="DARK"))
+
+    # ADM add OBCONDITIONS that will work for any obscon.
+    from desitarget.targetmask import obsconditions as obscon
+    randoms["OBSCONDITIONS"] = obscon.mask("|".join(obscon.names()))
+
+    # ADM add a random SUBPRIORITY.
+    np.random.seed(616+seed)
+    nrands = len(randoms)
+    randoms["SUBPRIORITY"] = np.random.random(nrands)
+
+    return randoms
+
+
 def randoms_in_a_brick_from_edges(ramin, ramax, decmin, decmax, density=100000,
                                   poisson=True, wrap=True, seed=1):
     """For brick edges, return random (RA/Dec) positions in the brick.
@@ -1157,7 +1189,7 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
 
 
 def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
-                          zeros=False, cnts=True, density=None,
+                          zeros=False, nomtl=True, cnts=True, density=None,
                           dustdir=None, aprad=None, seed=1):
 
     """Parallel-process a random catalog for a set of brick names.
@@ -1173,6 +1205,8 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
         See :func:`~desitarget.randoms.get_quantities_in_a_brick`.
     zeros : :class:`bool`, optional, defaults to ``False``
         See :func:`~desitarget.randoms.get_quantities_in_a_brick`.
+    nomtl : :class:`bool`, optional, defaults to ``True``
+        If ``True`` then do NOT add MTL quantities to the output array.
     cnts : :class:`bool`, optional, defaults to ``True``
         See :func:`~desitarget.skyfibers.get_brick_info`.
     seed : :class:`int`, optional, defaults to 1
@@ -1183,8 +1217,8 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
     :class:`~numpy.ndarray`
         a numpy structured array with the same columns as returned by
         :func:`~desitarget.randoms.get_quantities_in_a_brick`. If
-        `zeros` is ``False`` additional columns are returned, as added
-        by :func:`~desitarget.targets.finalize`.
+        `zeros` and `nomtl` are both ``False`` additional columns are 
+        returned, as added by :func:`~desitarget.targets.finalize`.
 
     Notes
     -----
@@ -1211,7 +1245,7 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
             density=density, dustdir=dustdir, aprad=aprad, zeros=zeros,
             seed=seed)
 
-        if zeros:
+        if zeros or nomtl:
             return randoms
         return _finalize_randoms(randoms)
 
@@ -1308,7 +1342,7 @@ def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None,
 
 
 def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
-                   bundlebricks=None, brickspersec=2.5, extra=None,
+                   bundlebricks=None, brickspersec=2.5, extra=None, nomtl=True,
                    dustdir=None, aprad=0.75, seed=1):
     """NOBS, DEPTHs (per-band), MASKs for random points in a Legacy Surveys DR.
 
@@ -1340,6 +1374,8 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
     extra : :class:`str`, optional
         Extra command line flags to be passed to the executable lines in
         the output slurm script. Used in conjunction with `bundlefiles`.
+    nomtl : :class:`bool`, optional, defaults to ``True``
+        If ``True`` then do NOT add MTL quantities to the output array.
     dustdir : :class:`str`, optional, defaults to $DUST_DIR+'maps'
         The root directory pointing to SFD dust maps. If None the code
         will try to use $DUST_DIR+'maps') before failing.
@@ -1407,21 +1443,12 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
 
     # ADM recover the pixel-level quantities in the DR bricks.
     randoms = select_randoms_bricks(brickdict, bricknames, numproc=numproc,
-                                    drdir=drdir, density=density,
+                                    drdir=drdir, density=density, nomtl=nomtl,
                                     dustdir=dustdir, aprad=aprad, seed=seed)
 
     # ADM add columns that are added by MTL.
-    from desitarget.mtl import make_mtl
-    randoms = np.array(make_mtl(randoms, obscon="DARK"))
-
-    # ADM add OBCONDITIONS that will work for any obscon.
-    from desitarget.targetmask import obsconditions as obscon
-    randoms["OBSCONDITIONS"] = obscon.mask("|".join(obscon.names()))
-
-    # ADM add a random SUBPRIORITY.
-    np.random.seed(616+seed)
-    nrands = len(randoms)
-    randoms["SUBPRIORITY"] = np.random.random(nrands)
+    if nomtl is False:
+        randoms = _add_default_mtl(randoms)
 
     # ADM one last shuffle to randomize across brick boundaries.
     np.random.seed(615+seed)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1248,7 +1248,7 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
     :class:`~numpy.ndarray`
         a numpy structured array with the same columns as returned by
         :func:`~desitarget.randoms.get_quantities_in_a_brick`. If
-        `zeros` and `nomtl` are both ``False`` additional columns are 
+        `zeros` and `nomtl` are both ``False`` additional columns are
         returned, as added by :func:`~desitarget.targets.finalize`.
 
     Notes

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -169,9 +169,8 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     # ADM observed in every band.
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
-    # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
-    for bit in [1, 5, 6, 7, 11, 12, 13]:
-        lrg &= ((maskbits & 2**bit) == 0)
+    # ADM default mask bits from the Legacy Surveys not set.
+    lrg &= imaging_mask(maskbits)
 
     return lrg
 
@@ -457,11 +456,9 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None,
         primary = np.ones_like(rflux, dtype='?')
     qso = primary.copy()
 
-    # ADM Reject objects in masks.
-    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
+    # ADM default mask bits from the Legacy Surveys not set.
     if maskbits is not None:
-        for bit in [1, 10, 12, 13]:
-            qso &= ((maskbits & 2**bit) == 0)
+            qso &= imaging_mask(maskbits)
 
     # ADM observed in every band.
     qso &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
@@ -637,11 +634,9 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None,
         morph2 = dcs < 0.015
     preSelection &= _psflike(objtype) | morph2
 
-    # ADM Reject objects in masks.
-    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
+    # ADM default mask bits from the Legacy Surveys not set.
     if maskbits is not None:
-        for bit in [1, 10, 12, 13]:
-            preSelection &= ((maskbits & 2**bit) == 0)
+        preSelection &= imaging_mask(maskbits)
 
     # "qso" mask initialized to "preSelection" mask
     qso = np.copy(preSelection)
@@ -756,11 +751,9 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None,
     # Standard morphology cut.
     preSelection &= _psflike(objtype)
 
-    # ADM Reject objects in masks.
-    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
+    # ADM default mask bits from the Legacy Surveys not set.
     if maskbits is not None:
-        for bit in [1, 10, 12, 13]:
-            preSelection &= ((maskbits & 2**bit) == 0)
+        preSelection &= imaging_mask(maskbits)
 
     # "qso" mask initialized to "preSelection" mask.
     qso = np.copy(preSelection)
@@ -839,12 +832,9 @@ def isQSOz5_cuts(gflux=None, rflux=None, zflux=None,
         primary = np.ones_like(rflux, dtype='?')
     qso = primary.copy()
 
-    # ADM Reject objects in masks.
-    # ADM BRIGHT BAILOUT GALAXY CLUSTER (1, 10, 12, 13) bits not set.
+    # ADM default mask bits from the Legacy Surveys not set.
     if maskbits is not None:
-        # for bit in [10, 12, 13]:
-        for bit in [1, 10, 12, 13]:
-            qso &= ((maskbits & 2**bit) == 0)
+        qso &= imaging_mask(maskbits)
 
     # ADM observed in every band.
     qso &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
@@ -1038,8 +1028,8 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
         bgs |= (Grr < 0.6) & (~_psflike(objtype)) & (gaiagmag != 0)
         bgs &= bgs_qcs
 
-    bgs &= (maskbits & 2**1) == 0
-    bgs &= (maskbits & 2**13) == 0
+    # ADM geometric masking cuts from the Legacy Surveys.
+    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
 
     return bgs
 
@@ -1129,9 +1119,8 @@ def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None,
     # ADM observed in every band.
     elg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
-    # ADM ALLMASK (5, 6, 7), BRIGHT OBJECT (1, 11, 12, 13) bits not set.
-    for bit in [1, 5, 6, 7, 11, 12, 13]:
-        elg &= ((maskbits & 2**bit) == 0)
+    # ADM default mask bits from the Legacy Surveys not set.
+    elg &= imaging_mask(maskbits)
 
     return elg
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -21,6 +21,7 @@ from pkg_resources import resource_filename
 from desitarget.cuts import _getColors, _psflike, _check_BGS_targtype_sv
 from desitarget.cuts import shift_photo_north
 from desitarget.gaiamatch import is_in_Galaxy
+from desitarget.geomask import imaging_mask
 
 # ADM set up the DESI default logger
 from desiutil.log import get_logger


### PR DESCRIPTION
Includes:
- A function `geomask.imaging_mask()` that allows easier parsing of maskbits cuts by using a list of strings (such as `["BRIGHT", "CLUSTER"]` etc.
- A default set of cuts on maskbits as a kwarg in the new `geomask.imaging_mask()` function.
- A new executable `alt_split_randoms` that is slower than `split_randoms` but saves memory, so is useful for large files.
- Increased flexibility for adding MTL columns to randoms, which saves memory when making large random catalogs:
    * MTL columns can still be added directly when running the randoms using `select_randoms` (but now must be requested with an `--add_mtl` command-line flag).
    * MTL columns can now _alternatively_ be added when splitting a larger random catalog (again by adding an `--add_mtl` command-line flag to `split_randoms` or `alt_split_randoms`).