### PR TITLE
Prepare for making commissioning targets and skies with DR9

### DIFF
--- a/bin/alt_split_randoms
+++ b/bin/alt_split_randoms
@@ -21,12 +21,18 @@ ap.add_argument("-n", "--nchunks", type=int,
                 default="10")
 ap.add_argument("--addmtl", action='store_true',
                 help="If passed, then add the columns needed for MTL to the random catalogs after they are split.")
+ap.add_argument("--skip", action='store_true',
+                help="Check if the input random catalog exists. If it doesn't, do absolutely nothing (useful for scripting across all possible HEALPixels).")
 
 ns = ap.parse_args()
 
 if not os.path.exists(ns.randomcat):
-    log.critical('Input directory does not exist: {}'.format(ns.randomcat))
-    sys.exit(1)
+    if ns.skip:
+        log.info('Input catalog does not exist: {}'.format(ns.randomcat))
+        sys.exit(0)
+    else:
+        log.critical('Input catalog does not exist: {}'.format(ns.randomcat))
+        sys.exit(1)
 
 log.info("Read in randoms from {} and split into {} catalogs...t = {:.1f}s"
          .format(ns.randomcat, ns.nchunks, time()-start))

--- a/bin/alt_split_randoms
+++ b/bin/alt_split_randoms
@@ -17,7 +17,7 @@ ap = ArgumentParser(description='Split a random catalog into N smaller catalogs.
 ap.add_argument("randomcat",
                 help='A random catalog (e.g /project/projectdirs/desi/target/catalogs/randoms-dr4-0.20.0.fits). For an input catalog /X/X.fits N smaller catalogs will be written to /X/X-[0:N-1].fits')
 ap.add_argument("-n", "--nchunks", type=int,
-                help='Number of smaller catalog to split the random catalog into. Defaults to [10].',
+                help='Number of smaller catalogs to split the random catalog into. Defaults to [10].',
                 default="10")
 ap.add_argument("--addmtl", action='store_true',
                 help="If passed, then add the columns needed for MTL to the random catalogs after they are split.")

--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -68,12 +68,21 @@ else:
 fx = fitsio.FITS(fns[0])
 hdr = fx[1].read_header()
 
-# ADM if you're combining files, you'll need to
-# ADM combine the HEALPixel coverage.
-hpx = []
-for fn in fns:
-    hpx.append(fitsio.read_header(fn, extname)["FILEHPX"])
+# ADM if combining files, combine the HEALPixel coverage. If the
+# ADM HEALPixel coverage is the same in each file, increase the density.
+hpx0 = fitsio.read_header(fns[0], extname)["FILEHPX"]
+hpx = [hpx0]
+if ns.targtype == 'randoms':
+    dens = fitsio.read_header(fns[0], extname)["DENSITY"]
+for fn in fns[1:]:
+    hpxfn = fitsio.read_header(fn, extname)["FILEHPX"]
+    if hpxfn != hpx0:
+        hpx.append(hpxfn)
+    elif ns.targtype == 'randoms':
+        dens += fitsio.read_header(fn, extname)["DENSITY"]
 hdr["FILEHPX"] = ",".join(hpx)
+if ns.targtype == 'randoms':
+    hdr["DENSITY"] = dens
 
 # ADM retain a list of the units.
 tunits = ["TUNIT{}".format(i) for i in range(1, hdr["TFIELDS"]+1)]
@@ -86,7 +95,7 @@ log.info('Begin writing {} to {}...t = {:.1f}s'
 data = []
 for fn in fns:
     log.info('Reading file {}...t = {:.1f}s'.format(fn, time()-start))
-    fndata = fitsio.read(fn, columns=columns)
+    fndata = fitsio.read(fn, columns=columns, rows=[0,1])
     data.append(fndata)
 data = np.concatenate(data)
 ndata = len(data)

--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -95,7 +95,7 @@ log.info('Begin writing {} to {}...t = {:.1f}s'
 data = []
 for fn in fns:
     log.info('Reading file {}...t = {:.1f}s'.format(fn, time()-start))
-    fndata = fitsio.read(fn, columns=columns, rows=[0,1])
+    fndata = fitsio.read(fn, columns=columns)
     data.append(fndata)
 data = np.concatenate(data)
 ndata = len(data)

--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -28,12 +28,16 @@ ap.add_argument("outfile",
 ap.add_argument("targtype", choices=['skies', 'randoms', 'targets', 'gfas'],
                 help="Type of target run with parallelization/multiprocessing code to gather")
 ap.add_argument("--norandomize", action='store_true',
-                help="Do NOT randomly shuffle the final file before writing it (using seed 626)")
+                help="Do NOT randomly shuffle the output file before writing it (using seed 626)")
 ap.add_argument("--numchunks", type=int,
                 help='number of chunks in which to write to save memory [defaults to {}]'.format(nchunks),
                 default=nchunks)
 ap.add_argument("--skip", action='store_true',
                 help="Skip input files that don't exist without flagging an error")
+ap.add_argument("--columns",
+                help='Limit the output file to just this set of columns (comma-separated without spaces, e.g., "RA,DEC"). \
+                Pass the string "pixweight" to limit to just columns needed for making the pixweight files',
+                default=None)
 
 ns = ap.parse_args()
 
@@ -42,6 +46,16 @@ tt = ns.targtype
 if ns.targtype == 'gfas':
     tt = "GFA_TARGETS"
 extname = tt.upper()
+
+# ADM the columns to limit to, if requested.
+if ns.columns is None:
+    columns = None
+elif ns.columns=="pixweight":
+    obsval = ['PSFDEPTH', 'NOBS', 'GALDEPTH', 'PSFSIZE']
+    columns = ['RA', 'DEC', 'EBV', 'MASKBITS', 'PSFDEPTH_W1', 'PSFDEPTH_W2'] + \
+    ['{}_{}'.format(val, b) for val in obsval for b in 'GRZ']
+else:
+    columns = [ col for col in ns.columns.split(',') ]
 
 # ADM convert passed csv strings to lists.
 if ns.skip:
@@ -72,7 +86,7 @@ log.info('Begin writing {} to {}...t = {:.1f}s'
 data = []
 for fn in fns:
     log.info('Reading file {}...t = {:.1f}s'.format(fn, time()-start))
-    fndata = fitsio.read(fn)
+    fndata = fitsio.read(fn, columns=columns, rows =[0,1])
     data.append(fndata)
 data = np.concatenate(data)
 ndata = len(data)

--- a/bin/gather_targets
+++ b/bin/gather_targets
@@ -86,7 +86,7 @@ log.info('Begin writing {} to {}...t = {:.1f}s'
 data = []
 for fn in fns:
     log.info('Reading file {}...t = {:.1f}s'.format(fn, time()-start))
-    fndata = fitsio.read(fn, columns=columns, rows =[0,1])
+    fndata = fitsio.read(fn, columns=columns)
     data.append(fndata)
 data = np.concatenate(data)
 ndata = len(data)

--- a/bin/select_randoms
+++ b/bin/select_randoms
@@ -46,6 +46,9 @@ ap.add_argument('--healpixels',
 ap.add_argument("--bundlebricks", type=int,
                 help="(overrides all options but surveydir) Print a slurm script to parallelize, with about this many bricks per HEALPixel (e.g. 10000)",
                 default=None)
+ap.add_argument("-n", "--nchunks", type=int,
+                help='Number of smaller catalogs to split the random catalog into inside the `bundlebricks` slurm script. Defaults to [10].',
+                default="10")
 ap.add_argument("--brickspersec", type=float,
                 help="estimate of bricks completed per second by the (parallelized) code. Used with `bundlebricks` to guess run times (defaults to 2.5)",
                 default=2.5)
@@ -119,8 +122,9 @@ if not 'dr5' in ns.surveydir and not 'dr6' in ns.surveydir:
 
 randres, randnorth, randsouth = select_randoms(
     ns.surveydir, density=ns.density, numproc=ns.numproc, nside=ns.nside,
-    pixlist=pixlist, aprad=ns.aprad, extra=extra, bundlebricks=ns.bundlebricks,
-    seed=ns.seed, brickspersec=ns.brickspersec, dustdir=ns.dustdir, nomtl=nomtl)
+    pixlist=pixlist, aprad=ns.aprad, extra=extra, nchunks=ns.nchunks,
+    bundlebricks=ns.bundlebricks, seed=ns.seed,
+    brickspersec=ns.brickspersec, dustdir=ns.dustdir, nomtl=nomtl)
 
 if ns.bundlebricks is None:
     # ADM extra header keywords for the output fits file.

--- a/bin/split_randoms
+++ b/bin/split_randoms
@@ -17,7 +17,7 @@ ap = ArgumentParser(description='Split a random catalog into N smaller catalogs.
 ap.add_argument("randomcat",
                 help='A random catalog (e.g /project/projectdirs/desi/target/catalogs/randoms-dr4-0.20.0.fits). For an input catalog /X/X.fits N smaller catalogs will be written to /X/X-[1:N].fits')
 ap.add_argument("-n", "--nchunks", type=int,
-                help='Number of smaller catalog to split the random catalog into. Defaults to [10].',
+                help='Number of smaller catalogs to split the random catalog into. Defaults to [10].',
                 default="10")
 ap.add_argument("--addmtl", action='store_true',
                 help="If passed, then add the columns needed for MTL to the random catalogs after they are split.")

--- a/bin/split_randoms
+++ b/bin/split_randoms
@@ -21,12 +21,18 @@ ap.add_argument("-n", "--nchunks", type=int,
                 default="10")
 ap.add_argument("--addmtl", action='store_true',
                 help="If passed, then add the columns needed for MTL to the random catalogs after they are split.")
+ap.add_argument("--skip", action='store_true',
+                help="Check if the input random catalog exists. If it doesn't, do absolutely nothing (useful for scripting across all possible HEALPixels).")
 
 ns = ap.parse_args()
 
 if not os.path.exists(ns.randomcat):
-    log.critical('Input directory does not exist: {}'.format(ns.randomcat))
-    sys.exit(1)
+    if ns.skip:
+        log.info('Input catalog does not exist: {}'.format(ns.randomcat))
+        sys.exit(0)
+    else:
+        log.critical('Input directory does not exist: {}'.format(ns.randomcat))
+        sys.exit(1)
 
 log.info("Read in randoms from {} and split into {} catalogs...t = {:.1f}s"
          .format(ns.randomcat, ns.nchunks, time()-start))
@@ -58,9 +64,9 @@ hdr["DENSITY"] //= ns.nchunks
 #ADM write out smaller files one-by-one.
 for i in range(ns.nchunks):
     #ADM open the file for writing.
-    outfile = "{}-{}.fits".format(os.path.splitext(ns.randomcat)[0], i+1)
+    outfile = "{}-{}.fits".format(os.path.splitext(ns.randomcat)[0], i)
     log.info("Writing chunk {} from index {} to {}...t = {:.1f}s"
-             .format(i+1, i*chunk, (i+1)*chunk, time()-start))
+             .format(i, i*chunk, (i+1)*chunk, time()-start))
     writerands = rands[indexes[i*chunk:(i+1)*chunk]]
     # ADM if requested, add the MTL-relevant columns.
     if ns.addmtl:

--- a/bin/supplement_skies
+++ b/bin/supplement_skies
@@ -75,15 +75,6 @@ if not official:
     log.critical(msg)
     raise ValueError
 
-if ns.bundlefiles is not None:
-    # ADM a check that nside isn't too large for RELEASE numbers < 1000.
-    if hp.nside2npix(ns.nside) >= 1000:
-        msg = "At nside ({}), pixels > 1000 exist. Pixel numbers set ".format(
-            ns.nside)
-        msg += "RELEASE for SUPP_SKIES. > 1000 may duplicate TARGETID for SKIES!"
-        log.critical(msg)
-        raise IOError
-
 # ADM if the GAIA directory was passed, set it...
 gaiadir = ns.gaiadir
 if gaiadir is None:
@@ -116,13 +107,6 @@ if ns.bundlefiles is None:
     pixlist = ns.healpixels
     if pixlist is not None:
         pixlist = [int(pix) for pix in pixlist.split(',')]
-        # ADM if splitting by HEALPixels they will be used to set
-        # ADM RELEASE. Check this won't produce duplicate TARGETIDs.
-        if pixlist[0] >= 1000:
-            msg = "First entry in pixlist ({}) > 1000. This sets ".format(pixlist[0])
-            msg += "RELEASE for SUPP_SKIES. > 1000 may duplicate TARGETID for SKIES!"
-            log.critical(msg)
-            raise ValueError
 
     # ADM read the locations and the header for skies in this healpixel.
     skies, hdr = io.read_targets_in_hp(ns.skydir, ns.nside, pixlist,
@@ -149,8 +133,8 @@ if ns.bundlefiles is None:
     # ADM mask the supplemental sky locations using a bright star mask.
     if do_mask:
         maskdir = get_recent_mask_dir(ns.maskdir)
-        supp_skies = mask_targets(supp_skies, maskdir,
-                                  nside=ns.nside, pixlist=pixlist)
+        supp_skies = mask_targets(supp_skies, maskdir, nside=ns.nside,
+                                  pixlist=pixlist, bricks_are_hpx=True)
 
     # ADM a compact version of the maskdir name.
     md = maskdir.split("/")

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,22 @@ desitarget Change Log
 0.44.1 (unreleased)
 -------------------
 
+* Clean-up for DR9-based commissioning [`PR #653`_]. Includes:
+    * Use HEALPixels instead of ``BRICKIDs`` for supp_skies.
+        * This avoids duplicated ``TARGETIDs`` where bricks span pixels.
+        * Addresses `issue #647`_.
+    * G < 19 for ``STD_DITHER_GAIA`` cmx targets near the Galaxy.
+    * Allow ``gather_targets`` to restrict to a subset of columns.
+    * Ignore new "light-curve" and "extra" flavors when finding sweeps.
+    * Smarter processing of randoms when writing "bundled" slurm file.
+        * Split pixelized files into N smaller files first...
+        * ...then combine across pixels to make N random catalogs.
+        * Never requires memory to write a very large random catalog.
 * Tune the RF selection for QSOs in SV using DR9 imaging [`PR #652`_].
 
+.. _`issue #647`: https://github.com/desihub/desitarget/issues/647
 .. _`PR #652`: https://github.com/desihub/desitarget/pull/652
-
+.. _`PR #653`: https://github.com/desihub/desitarget/pull/653
 
 0.44.0 (2020-11-12)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desitarget Change Log
 0.44.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Tune the RF selection for QSOs in SV using DR9 imaging [`PR #652`_].
+
+.. _`PR #652`: https://github.com/desihub/desitarget/pull/652
+
 
 0.44.0 (2020-11-12)
 -------------------

--- a/py/desitarget/brightmask.py
+++ b/py/desitarget/brightmask.py
@@ -30,7 +30,7 @@ from desitarget.internal import sharedmem
 from desitarget.targetmask import desi_mask, targetid_mask
 from desitarget.targets import encode_targetid, decode_targetid
 from desitarget.gaiamatch import find_gaia_files, get_gaia_nside_brick
-from desitarget.geomask import circles, cap_area, circle_boundaries
+from desitarget.geomask import circles, cap_area, circle_boundaries, is_in_hp
 from desitarget.geomask import ellipses, ellipse_boundary, is_in_ellipse
 from desitarget.geomask import radec_match_to, rewind_coords, add_hp_neighbors
 from desitarget.cuts import _psflike
@@ -985,6 +985,11 @@ def mask_targets(targs, inmaskdir, nside=2, pixlist=None, bricks_are_hpx=False):
     # ADM update the bits for the safe locations depending on whether
     # ADM they're in a mask.
     safes["DESI_TARGET"] = set_target_bits(safes, sourcemask)
+    # ADM it's possible that a safe location was generated outside of
+    # ADM the requested HEALPixels.
+    inhp = is_in_hp(safes, nside, pixlist)
+    safes = safes[inhp]
+
     # ADM combine the targets and safe locations.
     done = np.concatenate([targs, safes])
 

--- a/py/desitarget/brightmask.py
+++ b/py/desitarget/brightmask.py
@@ -963,10 +963,10 @@ def mask_targets(targs, inmaskdir, nside=2, pixlist=None, bricks_are_hpx=False):
         pixlist = np.atleast_1d(pixlist)
     log.info("Masking using masks in {} at nside={} in HEALPixels={}".format(
         inmaskdir, nside, pixlist))
-    pixlist = add_hp_neighbors(nside, pixlist)
+    pixlistwneigh = add_hp_neighbors(nside, pixlist)
 
     # ADM read in the (potentially HEALPixel-split) mask.
-    sourcemask = io.read_targets_in_hp(inmaskdir, nside, pixlist)
+    sourcemask = io.read_targets_in_hp(inmaskdir, nside, pixlistwneigh)
 
     ntargs = len(targs)
     log.info('Total number of masks {}'.format(len(sourcemask)))

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -1643,7 +1643,7 @@ def isSTD_dither_gaia(ra=None, dec=None, gmag=None, rmag=None, aen=None,
 
     Notes
     -----
-    - This version (10/25/20) is version 69 on `the cmx wiki`_.
+    - This version (11/17/20) is version 70 on `the cmx wiki`_.
     """
     if primary is None:
         primary = np.ones_like(gmag, dtype='?')
@@ -1663,9 +1663,9 @@ def isSTD_dither_gaia(ra=None, dec=None, gmag=None, rmag=None, aen=None,
     # ADM Unique Gaia source (not a duplicated source).
     issdg &= ~dupsource
 
-    # ADM CUT TO G < 18 where |b| < 20.
+    # ADM CUT TO G < 19 where |b| < 20.
     blt20 = is_in_gal_box([ra, dec], [0, 360, -20, 20], radec=True)
-    issdg &= (gmag < 18) | ~blt20
+    issdg &= (gmag < 19) | ~blt20
 
     # ADM remove any sources that have neighbors within 7"...
     # ADM for speed, run only sources for which issdg is still True.

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -21,7 +21,7 @@ from os.path import basename
 from desitarget import io
 from desitarget.io import check_fitsio_version
 from desitarget.internal import sharedmem
-from desitarget.geomask import hp_in_box, add_hp_neighbors
+from desitarget.geomask import hp_in_box, add_hp_neighbors, pixarea2nside
 from desitarget.geomask import hp_beyond_gal_b, nside2nside
 from desimodel.footprint import radec2pix
 from astropy.coordinates import SkyCoord
@@ -93,6 +93,23 @@ def _get_gaia_nside():
     nside = 32
 
     return nside
+
+
+def get_gaia_nside_brick(bricksize=0.25):
+    """Grab the HEALPixel nside that corresponds to a brick.
+
+    Parameters
+    ----------
+    bricksize : :class:`float`, optional, defaults to 0.25
+        Size of the brick, default is the Legacy Surveys standard.
+
+    Returns
+    -------
+    :class:`int`
+        The HEALPixel nside number that corresponds to a brick.
+    """
+
+    return pixarea2nside(bricksize*bricksize)
 
 
 def is_in_Galaxy(objs, radec=False):

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -7,6 +7,7 @@ desitarget.geomask
 
 Utility functions for geometry on the sky, masking, etc.
 
+.. _`this post on Stack Overflow`: https://stackoverflow.com/questions/7392143/python-implementations-of-packing-algorithm
 """
 from __future__ import (absolute_import, division)
 #
@@ -30,7 +31,6 @@ import healpy as hp
 # ADM set up the DESI default logger.
 from desiutil.log import get_logger
 log = get_logger()
-
 
 def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"]):
     """Apply the 'geometric' masks from the Legacy Surveys imaging.
@@ -642,7 +642,8 @@ def circle_boundaries(RAcens, DECcens, r, nloc):
 
 
 def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
-                  gather=False, surveydirs=None, extra=None, seed=None):
+                  gather=False, surveydirs=None, extra=None, seed=None,
+                  nchunks=10):
     """Determine the optimal packing for bricks collected by HEALpixel integer.
 
     Parameters
@@ -678,6 +679,9 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
         the output slurm script.
     seed : :class:`int`, optional, defaults to 1
         Random seed for file name. Only relevant for `prefix='randoms'`.
+    nchunks : :class:`int`, optional, defaults to 10
+        Number of smaller catalogs to split the random catalog into. Only
+        relevant for `prefix='randoms'`.
 
     Returns
     -------
@@ -687,7 +691,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
 
     Notes
     -----
-    h/t https://stackoverflow.com/questions/7392143/python-implementations-of-packing-algorithm
+        - For the packing algorithm see `this post on Stack Overflow`_.
     """
     # ADM interpret the passed directories.
     surveydir = os.path.normpath(surveydirs[0])
@@ -851,7 +855,6 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
                 "$CSCRATCH", dr=ddrr, flavor=prefix, seed=seed, nohp=True,
                 resolve=resolve, region=region)
             print("")
-            n = 10
             # ADM split each pixel-file into 10 smaller catalogs.
             for fn in outfiles:
                 adder = ""
@@ -860,11 +863,11 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
                 if not "addmtl" in extra:
                     adder = "--addmtl"
                     print("srun -N 1 split_randoms {} -n {} {} {} &".format(
-                        fn, n, adder, skip))
+                        fn, nchunks, adder, skip))
             print("")
             print("wait")
             print("")
-            for nchunk in range(n):
+            for nchunk in range(nchunks):
                 ofs = [fn.replace(".fits", "-{}.fits".format(nchunk))
                        for fn in outfiles]
                 ofn = outfn.replace(".fits", "-{}.fits".format(nchunk))

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -871,6 +871,8 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
                 print("srun -N 1 gather_targets '{}' {} {} {} &".format(
                     ";".join(ofs), ofn, prefix2.split("_")[-1], skip))
         print("")
+        print("wait")
+        print("")
 
     return
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -32,6 +32,7 @@ import healpy as hp
 from desiutil.log import get_logger
 log = get_logger()
 
+
 def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"]):
     """Apply the 'geometric' masks from the Legacy Surveys imaging.
 
@@ -860,7 +861,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
                 adder = ""
                 # ADM we'll need to add the MTL columns if they aren't
                 # ADM added when the randoms are initially constructed.
-                if not "addmtl" in extra:
+                if "addmtl" not in extra:
                     adder = "--addmtl"
                     print("srun -N 1 split_randoms {} -n {} {} {} &".format(
                         fn, nchunks, adder, skip))

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1502,7 +1502,9 @@ def list_sweepfiles(root):
 def iter_sweepfiles(root):
     """Iterator over all sweep files found under root directory.
     """
-    ignore = ['metric', 'coadd', 'log', 'pz', 'external', 'tractor']
+    ignoredirs = ['metric', 'coadd', 'log', 'pz', 'external', 'tractor']
+    ignorefiles = ['ex.fits', 'lc.fits']
+    ignore = ignoredirs + ignorefiles
     return iter_files(root, prefix='sweep', ext='fits', ignore=ignore)
 
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1366,8 +1366,8 @@ def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None,
 
 
 def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
-                   bundlebricks=None, brickspersec=2.5, extra=None, nomtl=True,
-                   dustdir=None, aprad=0.75, seed=1):
+                   bundlebricks=None, nchunks=10, brickspersec=2.5, extra=None,
+                   nomtl=True, dustdir=None, aprad=0.75, seed=1):
     """NOBS, DEPTHs (per-band), MASKs for random points in a Legacy Surveys DR.
 
     Parameters
@@ -1391,6 +1391,9 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
     bundlebricks : :class:`int`, defaults to ``None``
         If not ``None``, then instead of selecting randoms, print a slurm
         script to balance the bricks at `bundlebricks` bricks per node.
+    nchunks : :class:`int`, optional, defaults to 10
+        Number of smaller catalogs to split the random catalog into
+        inside the `bundlebricks` slurm script.
     brickspersec : :class:`float`, optional, defaults to 2.5
         The rough number of bricks processed per second (parallelized
         across a chosen number of nodes). Used with `bundlebricks` to
@@ -1443,9 +1446,9 @@ def select_randoms(drdir, density=100000, numproc=32, nside=None, pixlist=None,
         # ADM pixnum only contains unique bricks, need to add duplicates.
         allpixnum = np.concatenate([np.zeros(cnt, dtype=int)+pix for
                                     cnt, pix in zip(cnts.astype(int), pixnum)])
-        bundle_bricks(allpixnum, bundlebricks, nside, gather=True,
+        bundle_bricks(allpixnum, bundlebricks, nside, gather=True, seed=seed,
                       brickspersec=brickspersec, prefix='randoms',
-                      surveydirs=[drdir], extra=extra, seed=seed)
+                      surveydirs=[drdir], extra=extra, nchunks=nchunks)
         # ADM because the broader function returns three outputs.
         return None, None, None
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1055,7 +1055,9 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
     ----------
     randoms : :class:`~numpy.ndarray` or `str`
         Catalog or file of randoms as made by :func:`select_randoms()` or
-        :func:`quantities_at_positions_in_a_brick()`.
+        :func:`quantities_at_positions_in_a_brick()`. Must contain the
+        columns 'RA', 'DEC', 'EBV', 'PSFDEPTH_W1/W2/G/R/Z', 'NOBS_G/R/Z'
+        'GALDEPTH_G/R/Z', 'PSFSIZE_G/R/Z', 'MASKBITS'.
     targets : :class:`~numpy.ndarray` or `str`
         Corresponding (i.e. same Data Release) catalog or file of targets
         as made by, e.g., :func:`desitarget.cuts.select_targets()`, or

--- a/py/desitarget/test/test_brightmask.py
+++ b/py/desitarget/test/test_brightmask.py
@@ -70,6 +70,9 @@ class TestBRIGHTMASK(unittest.TestCase):
                                       dtypes='>i4')
         cls.targs["BRICK_OBJID"] = cls.targs["OBJID"]
 
+        # ADM mask_targets checks for unique TARGETIDs, so create some.
+        cls.targs["TARGETID"] = np.arange(len(cls.targs))
+
         # ADM invent a mask with various testing properties.
         cls.mask = np.zeros(3, dtype=brightmask.maskdatamodel.dtype)
         cls.mask["DEC"] = [0, 70, 35]


### PR DESCRIPTION
This PR cleans up the targets and skies with a view to making files for commissioning using DR9 imaging. It also continues a refactor of the randoms that allows large random catalogs to be produced without memory issues. It includes:
- Use HEALPixels instead of `BRICKID`s for "supp" skies, which avoids "supp" skies having duplicated `TARGETID`s in regions where bricks span multiple pixels (this addresses #647).
- Update the faint-end cut for `STD_DITHER_GAIA` cmx targets near the Galaxy to G < 19.
- Allow `gather_targets` to restrict to just a subset of columns when concatenating FITS files.
- Ignore the new "light-curve" and "extra" flavors of sweeps when searching for input sweep files.
- Smarter processing of the randoms when writing and executing the "bundled" slurm file.
  * The new process is to break the HEALPixel-split files into `N` smaller files first and _then_ to combine across the different pixels to make `N` random catalogs.
  * This circumvents the need to make a large random catalog and then split it into smaller random catalogs, which saves a factor of `N` in memory.