### PR TITLE
Main survey Random Forest cuts in cmx now also need RA and Dec passed

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.45.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Add RA/Dec to the Main Survey calls for the QSO RF in cmx [`PR #654`_].
+
+.. _`PR #654`: https://github.com/desihub/desitarget/pull/654
 
 0.45.0 (2020-11-22)
 -------------------

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2358,7 +2358,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
                 primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
                 w1flux=w1flux, w2flux=w2flux, deltaChi2=deltaChi2,
                 maskbits=maskbits, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                objtype=objtype, release=release, south=south
+                objtype=objtype, release=release, ra=ra, dec=dec, south=south
             )
     qso_north, qso_hiz_north = qso_classes[0]
     qso_south, qso_hiz_south = qso_classes[1]


### PR DESCRIPTION
This is a very minor update to the commissioning cuts for the QSO Random Forest. The Main Survey QSO RF now requires RA and Dec as inputs. As the cmx cuts call the Main Survey for "mini SV," RA and Dec need to be passed in cmx too.

I'll merge this as soon as tests pass to continue work on making DR9 commissioning targets.