### PR TITLE
General clean-ups and speed-ups for DR9 work

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,18 @@ desitarget Change Log
 0.45.2 (unreleased)
 -------------------
 
-Extension of mag limit to 22.3 for RF selection
+* General clean-ups and speed-ups for DR9 work [`PR #656`_]. Includes:
+    * Corrected data model when repartitioning skies into HEALPixels.
+    * Faster versions of all of the read_targets_in_X functions:
+        * e.g., in_box, in_cap, in_tiles, in_hp.
+        * less general, but run faster by assuming the data model.
+        * Speed-up is 10x or more for files pixelized at higher nsides.
+    * Read "standard" MASKBITS cuts automatically for pixweight files.
+    * Catch if MTL ledgers are at a lower resolution that target files.
+* Extension of mag limit to 22.3 for RF selection [`PR #655`_].
+
+.. _`PR #655`: https://github.com/desihub/desitarget/pull/655
+.. _`PR #656`: https://github.com/desihub/desitarget/pull/656
 
 0.45.1 (2020-11-22)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.45.2 (unreleased)
 -------------------
 
-* General clean-ups and speed-ups for DR9 work [`PR #656`_]. Includes:
+* General clean-ups and speed-ups for DR9 work [`PR #658`_]. Includes:
     * Corrected data model when repartitioning skies into HEALPixels.
     * Faster versions of all of the `read_targets_in_X` functions:
         * e.g., `in_box`, `in_cap`, `in_tiles`, `in_hp`.
@@ -20,7 +20,7 @@ desitarget Change Log
 .. _`issue #20`: https://github.com/desihub/desitarget/issues/20
 .. _`PR #641`: https://github.com/desihub/desitarget/pull/641
 .. _`PR #655`: https://github.com/desihub/desitarget/pull/655
-.. _`PR #656`: https://github.com/desihub/desitarget/pull/656
+.. _`PR #658`: https://github.com/desihub/desitarget/pull/658
 
 0.45.1 (2020-11-22)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1438,7 +1438,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
             # Compute optimized proba cut
             tmp_r_Reduced = r_Reduced[tmpReleaseOK]
             if not south:
-                #threshold selection for North footprint
+                # threshold selection for North footprint.
                 pcut = 0.857 - 0.03*np.tanh(tmp_r_Reduced - 20.5)
                 pcut_HighZ = 0.7
             else:
@@ -1449,10 +1449,10 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
                          (znobs[preSelection][tmpReleaseOK] > 4) &\
                          ((ra[preSelection][tmpReleaseOK] >= 320) | (ra[preSelection][tmpReleaseOK] <= 100)) &\
                          (dec[preSelection][tmpReleaseOK] <= 10)
-                #threshold selection for Des footprint
+                # threshold selection for DES footprint.
                 pcut[is_des] = 0.75 - 0.05*np.tanh(tmp_r_Reduced[is_des] - 20.5)
                 pcut_HighZ[is_des] = 0.50
-                #threshold selection for South footprint
+                # threshold selection for South footprint.
                 pcut[~is_des] = 0.85 - 0.04*np.tanh(tmp_r_Reduced[~is_des] - 20.5)
                 pcut_HighZ[~is_des] = 0.65
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1036,7 +1036,7 @@ def notinBGS_mask(gnobs=None, rnobs=None, znobs=None, primary=None,
     bgs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
 
     # ADM geometric masking cuts from the Legacy Surveys.
-    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
+    bgs &= imaging_mask(maskbits, bgsmask=True)
 
     if targtype == 'bright':
         bgs &= ((Grr > 0.6) | (gaiagmag == 0))
@@ -1128,7 +1128,7 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
 
     bgs |= LX
     # ADM geometric masking cuts from the Legacy Surveys.
-    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
+    bgs &= imaging_mask(maskbits, bgsmask=True)
 
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -33,40 +33,80 @@ from desiutil.log import get_logger
 log = get_logger()
 
 
-def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"],
-                 bgsmask=False):
-    """Apply the 'geometric' masks from the Legacy Surveys imaging.
+def get_imaging_maskbits(bitnamelist=None):
+    """Return MASKBITS names and bits from the Legacy Surveys.
 
     Parameters
     ----------
-    maskbits : :class:`~numpy.ndarray` or ``None``
-        General array of `Legacy Surveys mask`_ bits.
-    bitnamelist : :class:`list`, defaults to ["BRIGHT", "GALAXY", "CLUSTER"]
-        List of Legacy Surveys mask bits to set to ``False``.
-    bgsmask : :class:`bool`, default to ``False``.
-        Load the "default" scheme for Bright Galaxy Survey targets.
-        Overrides `bitnamelist`.
+    bitnamelist : :class:`list`, optional, defaults to ``None``
+        If not ``None``, return the bit values corresponding to the
+        passed names. Otherwise, return the full MASKBITS dictionary.
+
     Returns
     -------
-    :class:`~numpy.ndarray`
-        A boolean array that is the same length as `maskbits` that
-        contains ``False`` where any bits in `bitnamelist` are set.
+    :class:`list` or `dict`
+        A list of the MASKBITS values if `bitnamelist` is passed,
+        otherwise the full MASKBITS dictionary of names-to-values.
 
     Notes
     -----
         - For the definitions of the mask bits, see, e.g.,
              https://www.legacysurvey.org/dr8/bitmasks/#maskbits
     """
-    # ADM default for the BGS.
-    if bgsmask:
-        bitnamelist = ["BRIGHT", "CLUSTER"]
-
-    # ADM a dictionary of how the bit-names correspond to the bit-values.
     bitdict = {"BRIGHT": 1, "ALLMASK_G": 5, "ALLMASK_R": 6, "ALLMASK_Z": 7,
                "BAILOUT": 10, "MEDIUM": 11, "GALAXY": 12, "CLUSTER": 13}
 
     # ADM look up the bit value for each passed bit name.
-    bits = [bitdict[bitname] for bitname in bitnamelist]
+    if bitnamelist is not None:
+        return [bitdict[bitname] for bitname in bitnamelist]
+
+    return bitdict
+
+
+def get_default_maskbits(bgs=False):
+    """Return the names of the default MASKBITS for targets.
+
+    Parameters
+    ----------
+    bgs : :class:`bool`, defaults to ``False``.
+        If ``True`` load the "default" scheme for Bright Galaxy Survey
+        targets. Otherwise, load the default for other target classes.
+
+    Returns
+    -------
+    :class:`list`
+        A list of the default MASKBITS names for targets.
+    """
+    if bgs:
+        return ["BRIGHT", "CLUSTER"]
+    return ["BRIGHT", "GALAXY", "CLUSTER"]
+
+
+def imaging_mask(maskbits, bitnamelist=get_default_maskbits(), bgsmask=False):
+    """Apply the 'geometric' masks from the Legacy Surveys imaging.
+
+    Parameters
+    ----------
+    maskbits : :class:`~numpy.ndarray` or ``None``
+        General array of `Legacy Surveys mask`_ bits.
+    bitnamelist : :class:`list`, defaults to func:`get_default_maskbits()`
+        List of Legacy Surveys mask bits to set to ``False``.
+    bgsmask : :class:`bool`, defaults to ``False``.
+        Load the "default" scheme for Bright Galaxy Survey targets.
+        Overrides `bitnamelist`.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        A boolean array that is the same length as `maskbits` that
+        contains ``False`` where any bits in `bitnamelist` are set.
+    """
+    # ADM default for the BGS.
+    if bgsmask:
+        bitnamelist = get_default_maskbits(bgs=True)
+
+    # ADM get the bit values for the passed (or default) bit names.
+    bits = get_imaging_maskbits(bitnamelist)
 
     # ADM Create array of True and set to False where a mask bit is set.
     mb = np.ones_like(maskbits, dtype='?')

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -33,16 +33,19 @@ from desiutil.log import get_logger
 log = get_logger()
 
 
-def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"]):
+def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"],
+                 bgsmask=False):
     """Apply the 'geometric' masks from the Legacy Surveys imaging.
 
     Parameters
     ----------
     maskbits : :class:`~numpy.ndarray` or ``None``
         General array of `Legacy Surveys mask`_ bits.
-    bright : :class:`list`, defaults to ["BRIGHT", "GALAXY", "CLUSTER"]
-        list of Legacy Surveys mask bits to set to ``False``.
-
+    bitnamelist : :class:`list`, defaults to ["BRIGHT", "GALAXY", "CLUSTER"]
+        List of Legacy Surveys mask bits to set to ``False``.
+    bgsmask : :class:`bool`, default to ``False``.
+        Load the "default" scheme for Bright Galaxy Survey targets.
+        Overrides `bitnamelist`.
     Returns
     -------
     :class:`~numpy.ndarray`
@@ -54,6 +57,10 @@ def imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"]):
         - For the definitions of the mask bits, see, e.g.,
              https://www.legacysurvey.org/dr8/bitmasks/#maskbits
     """
+    # ADM default for the BGS.
+    if bgsmask:
+        bitnamelist = ["BRIGHT", "CLUSTER"]
+
     # ADM a dictionary of how the bit-names correspond to the bit-values.
     bitdict = {"BRIGHT": 1, "ALLMASK_G": 5, "ALLMASK_R": 6, "ALLMASK_Z": 7,
                "BAILOUT": 10, "MEDIUM": 11, "GALAXY": 12, "CLUSTER": 13}

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -412,6 +412,12 @@ def make_ledger(hpdirname, outdirname, obscon="DARK", numproc=1):
     # ADM the nside at which to write the MTLs.
     mtlnside = _get_mtl_nside()
 
+    # ADM check that the nside for writing MTLs is not at a lower
+    # ADM resolution that the nside at which the files are stored.
+    msg = "Ledger nside ({}) must be higher than file nside ({})!!!".format(
+        mtlnside, nside)
+    assert mtlnside >= nside, msg
+
     from desitarget.geomask import nside2nside
 
     # ADM the common function that is actually parallelized across.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -413,7 +413,7 @@ def make_ledger(hpdirname, outdirname, obscon="DARK", numproc=1):
     mtlnside = _get_mtl_nside()
 
     # ADM check that the nside for writing MTLs is not at a lower
-    # ADM resolution that the nside at which the files are stored.
+    # ADM resolution than the nside at which the files are stored.
     msg = "Ledger nside ({}) must be higher than file nside ({})!!!".format(
         mtlnside, nside)
     assert mtlnside >= nside, msg

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -19,6 +19,7 @@ from glob import glob, iglob
 
 from desitarget.gaiamatch import get_gaia_dir
 from desitarget.geomask import bundle_bricks, box_area
+from desitarget.geomask import get_imaging_maskbits, get_default_maskbits
 from desitarget.targets import resolve, main_cmx_or_sv, finalize
 from desitarget.skyfibers import get_brick_info
 from desitarget.io import read_targets_in_box, target_columns_from_header
@@ -1132,9 +1133,8 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
     # ADM areal coverage for some combinations of MASKBITS.
     mbcomb = []
     mbstore = []
-    for mb in [[10, 12, 13],
-               [1, 5, 6, 7, 10, 12, 13],
-               [1, 5, 6, 7, 11, 12, 13]]:
+    for mb in [get_imaging_maskbits(get_default_maskbits()),
+               get_imaging_maskbits(get_default_maskbits(bgs=True))]:
         bitint = np.sum(2**np.array(mb))
         mbcomb.append(bitint)
         log.info('Determining footprint for maskbits not in {}...t = {:.1f}s'

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1096,7 +1096,7 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
                                values in the passed random catalog.
             - FRACAREA_X: Fraction of pixel with at least one observation
                           in any band with MASKBITS==X (bitwise OR, so,
-                          e.g. if X=7.
+                          e.g. if X=7 then fraction for 2^0 | 2^1 | 2^2).
             - One column for every bit that is returned by
               :func:`desitarget.QA._load_targdens()`. Each column
               contains the target density in the pixel.

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1056,7 +1056,7 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
         bgs &= bgs_qcs
 
     # ADM geometric masking cuts from the Legacy Surveys.
-    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
+    bgs &= imaging_mask(maskbits, bgsmask=True)
 
     return bgs
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -650,8 +650,8 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None,
         # Data reduction to preselected objects
         colorsReduced = colors[preSelection]
         r_Reduced = r[preSelection]
-        colorsReduced[:, 10][r_Reduced>23.0] = 22.95
-        
+        colorsReduced[:, 10][r_Reduced > 23.0] = 22.95
+
         colorsIndex = np.arange(0, nbEntries, dtype=np.int64)
         colorsReducedIndex = colorsIndex[preSelection]
 
@@ -672,7 +672,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None,
         tmp_rf_HighZ_proba = rf_HighZ.predict_proba()
         # Compute optimized proba cut (all different for SV)
         if not south:
-                #threshold selection for North footprint
+                # threshold selection for North footprint.
                 pcut = 0.84 - 0.035*np.tanh(r_Reduced - 20.5)
                 pcut_HighZ = 0.65
         else:
@@ -684,10 +684,10 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None,
                 (znobs[preSelection] > 4) &\
                 ((ra[preSelection] >= 320) | (ra[preSelection] <= 100)) &\
                 (dec[preSelection] <= 10)
-            #threshold selection for Des footprint
+            # threshold selection for Des footprint.
             pcut[is_des] = 0.70 - 0.06*np.tanh(r_Reduced[is_des] - 20.5)
             pcut_HighZ[is_des] = 0.40
-            #threshold selection for South footprint
+            # threshold selection for South footprint.
             pcut[~is_des] = 0.80 - 0.05*np.tanh(r_Reduced[~is_des] - 20.5)
             pcut_HighZ[~is_des] = 0.55
 
@@ -754,14 +754,17 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None,
     wflux = 0.75*w1flux + 0.25*w2flux
     grzflux = (gflux + 0.8*rflux + 0.5*zflux) / 2.3
 
-    flux_defined = (wflux>0) & (grzflux>0) & (gflux>0) & (rflux>0) & (zflux>0)
+    flux_defined = (wflux > 0) & (grzflux > 0) &  \
+                   (gflux > 0) & (rflux > 0) & (zflux > 0)
     color_cut = flux_defined
-    
+
     color_cut[flux_defined] = ((wflux[flux_defined] < gflux[flux_defined]*10**(2.7/2.5)) |
-                  (rflux[flux_defined]*(gflux[flux_defined]**0.3) > gflux[flux_defined]*(wflux[flux_defined]**0.3)*10**(0.3/2.5)))  # (g-w<2.7 or g-r>O.3*(g-w)+0.3)
-    color_cut[flux_defined] &= (wflux[flux_defined] * (rflux[flux_defined]**1.5) < (zflux[flux_defined]**1.5) * grzflux[flux_defined] * 10**(+1.6/2.5))  # (grz-W) < (r-z)*1.5+1.6
+                               (rflux[flux_defined]*(gflux[flux_defined]**0.3) >
+                                gflux[flux_defined]*(wflux[flux_defined]**0.3)*10**(0.3/2.5)))  # (g-w<2.7 or g-r>O.3*(g-w)+0.3)
+    color_cut[flux_defined] &= (wflux[flux_defined] * (rflux[flux_defined]**1.5)
+                                < (zflux[flux_defined]**1.5) * grzflux[flux_defined] * 10**(+1.6/2.5))  # (grz-W) < (r-z)*1.5+1.6
     preSelection &= color_cut
-        
+
     # Standard morphology cut.
     preSelection &= _psflike(objtype)
 
@@ -798,20 +801,20 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None,
         tmp_rf_proba = rf.predict_proba()
 
         # Compute optimized proba cut (all different for SV).
-        # The probabilities may be different for the north and the south.       
+        # The probabilities may be different for the north and the south.
         if not south:
-            #threshold selection for North footprint
+            # threshold selection for North footprint.
             pcut = 0.94
         else:
             pcut = np.ones(tmp_rf_proba.size)
-            is_des = (gnobs[preSelection] > 4) &\
-                        (rnobs[preSelection] > 4) &\
-                        (znobs[preSelection] > 4) &\
-                        ((ra[preSelection] >= 320) | (ra[preSelection] <= 100)) &\
-                        (dec[preSelection] <= 10)
-            #threshold selection for Des footprint
+            is_des = (gnobs[preSelection] > 4) &  \
+                     (rnobs[preSelection] > 4) &  \
+                     (znobs[preSelection] > 4) &  \
+                     ((ra[preSelection] >= 320) | (ra[preSelection] <= 100)) &  \
+                     (dec[preSelection] <= 10)
+            # threshold selection for Des footprint.
             pcut[is_des] = 0.85
-            #threshold selection for South footprint
+            # threshold selection for South footprint.
             pcut[~is_des] = 0.90
 
         # Add rf proba test result to "qso" mask


### PR DESCRIPTION
This PR cleans-up (and speeds-up) some functionality as we move towards producing DR9 targets and fiberassign files. It includes:

- A corrected data model when repartitioning `skies` into their correct HEALPixels.
    * `skies` are run in bricks that are centered in HEALPixels, rather than in the actual boundaries of a HEALPixel, so they need to be "repartitioned" into the correct pixels (see #621); this PR changes the organization of the input/output files to automatically reflect the data model that I have started to use when releasing targets.
- Faster versions of all of the `desitarget.io.read_targets_in_X` functions:
    * i.e., `read_targets_in_tiles(quick=True)`, `read_targets_in_box(quick=True)`, `read_targets_in_cap(quick=True)`, `read_targets_in_hp(quick=True)`.
    * The new functions are less general, but they run 2-10x faster.
    * The speed-up is achieved by _assuming_ the HEALPixel-split data model rather than by _checking and determining_ the data model from header information (so the `"quick=True"` versions are more fragile).
    * The speed-up is greater for HEALPixel-split files at higher `nside`. Comparing targets partitioned into files at `nside=2` versus `nside=8`, the speed-up was 5x.
- Establishing "standard" `MASKBITS` combinations for all of the target classes that can be read via convenience functions, and using those convenience functions to automatically inform the `"FRACAREA_X"` calculations in `pixweight` files.
    * This makes it far easier to ensure that the `MASKBITS` cuts adopted by the target files are always aligned with those calculated in the `pixweight` files.
- Catching the case where a user tried to construct MTL ledgers at a lower resolution than the corresponding target files (which partially addresses #650).
