### PR TITLE
Bgs sv update

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -16,7 +16,7 @@ desitarget Change Log
 .. _`issue #20`: https://github.com/desihub/desitarget/issues/20
 .. _`PR #641`: https://github.com/desihub/desitarget/pull/641
 .. _`PR #655`: https://github.com/desihub/desitarget/pull/655
-.. _`PR #659`: https://github.com/desihub/desitarget/pull/
+.. _`PR #659`: https://github.com/desihub/desitarget/pull/659
 
 0.45.1 (2020-11-22)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,10 @@ desitarget Change Log
 0.45.2 (unreleased)
 -------------------
 
+* Two main changes for BGS SV selection for DR9 [`PR #659`_]:
+    * We've removed the FRACS* cuts. but the LOWQ superset does include rejections by the FRACS*.
+    * The FIBMAG superset has been shrunk to the limit of 20.5 instead 21.0 in the r-band magnitude.
+
 * Extension of mag limit to 22.3 for RF selection [`PR #655`_].
 * Add input sweep files and their checksums to target files [`PR #641`_].
     * Addresses `issue #20`_.
@@ -12,6 +16,7 @@ desitarget Change Log
 .. _`issue #20`: https://github.com/desihub/desitarget/issues/20
 .. _`PR #641`: https://github.com/desihub/desitarget/pull/641
 .. _`PR #655`: https://github.com/desihub/desitarget/pull/655
+.. _`PR #659`: https://github.com/desihub/desitarget/pull/
 
 0.45.1 (2020-11-22)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1036,7 +1036,7 @@ def notinBGS_mask(gnobs=None, rnobs=None, znobs=None, primary=None,
     bgs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
 
     # ADM geometric masking cuts from the Legacy Surveys.
-    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
+    bgs &= imaging_mask(maskbits)
 
     if targtype == 'bright':
         bgs &= ((Grr > 0.6) | (gaiagmag == 0))
@@ -1128,7 +1128,7 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
 
     bgs |= LX
     # ADM geometric masking cuts from the Legacy Surveys.
-    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
+    bgs &= imaging_mask(maskbits)
 
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1128,7 +1128,7 @@ def isBGS_lslga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
 
     bgs |= LX
     # ADM geometric masking cuts from the Legacy Surveys.
-    bgs &= imaging_mask(maskbits)
+    bgs &= imaging_mask(maskbits, ["BRIGHT", "CLUSTER"])
 
     if targtype == 'bright':
         bgs &= rflux > 10**((22.5-19.5)/2.5)

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1026,14 +1026,17 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
     if primary is None:
         primary = np.ones_like(gnobs, dtype='?')
     bgs_qcs = primary.copy()
+    bgs_fracs = primary.copy()
     bgs = primary.copy()
 
     # quality cuts definitions
     bgs_qcs &= (gnobs >= 1) & (rnobs >= 1) & (znobs >= 1)
-    bgs_qcs &= (gfracmasked < 0.4) & (rfracmasked < 0.4) & (zfracmasked < 0.4)
-    bgs_qcs &= (gfracflux < 5.0) & (rfracflux < 5.0) & (zfracflux < 5.0)
-    bgs_qcs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
-    bgs_qcs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
+    # ORM Turn off the FRACMASKED, FRACFLUX & FRACIN cuts for now
+    
+    bgs_fracs &= (gfracmasked < 0.4) & (rfracmasked < 0.4) & (zfracmasked < 0.4)
+    bgs_fracs &= (gfracflux < 5.0) & (rfracflux < 5.0) & (zfracflux < 5.0)
+    bgs_fracs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
+    #bgs_qcs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
 
     # color box
     bgs_qcs &= rflux > gflux * 10**(-1.0/2.5)
@@ -1045,7 +1048,7 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
         bgs &= Grr > 0.6
         bgs |= gaiagmag == 0
         bgs |= (Grr < 0.6) & (~_psflike(objtype)) & (gaiagmag != 0)
-        bgs &= ~bgs_qcs
+        bgs &= ~((bgs_qcs) & (bgs_fracs))
     else:
         bgs &= Grr > 0.6
         bgs |= gaiagmag == 0
@@ -1083,6 +1086,7 @@ def isBGS_colors(rflux=None, rfiberflux=None, south=True, targtype=None, primary
         bgs &= rflux <= 10**((22.5-20.1)/2.5)
         bgs &= ~np.logical_and(rflux <= 10**((22.5-20.1)/2.5), rfiberflux > 10**((22.5-21.0511)/2.5))
     elif targtype == 'fibmag':
+        bgs &= rflux > 10**((22.5-20.5)/2.5)
         bgs &= rflux <= 10**((22.5-20.1)/2.5)
         bgs &= rfiberflux > 10**((22.5-21.0511)/2.5)
     else:


### PR DESCRIPTION
Two main changes for BGS SV selection: 
(1) We've removed the FRACS* cuts. but the LOWQ superset does include rejections by the FRACS*. 
(2) The FIBMAG superset has been shrunk to the limit of 20.5 instead 21.0 in the r-band magnitude.