### PR TITLE
Finalize retuning of LRG cuts for DR9 and modify LRG SV bits

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,12 @@ desitarget Change Log
 0.45.2 (unreleased)
 -------------------
 
+* Re-tune LRG cuts for DR9 and updating the LRG SV target bits [`PR #660`_].
+  Other changes include:
+    * Only use the default BRIGHT, GALAXY and CLUSTER masks (ignoring ALLMASK
+      and MEDIUM)
+    * Increase the SV faint limits from z < 20.5 to z < 21.0 and from
+      zfiber < 21.9 to zfiber < 22.0
 * Two main changes for BGS SV selection for DR9 [`PR #659`_]:
     * Remove FRACS* cuts, except for LOWQ superset.
     * Limit FIBMAG superset to r < 20.5 instead of r < 21.0.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,12 +5,11 @@ desitarget Change Log
 0.45.2 (unreleased)
 -------------------
 
-* Re-tune LRG cuts for DR9 and updating the LRG SV target bits [`PR #660`_].
-  Other changes include:
-    * Only use the default BRIGHT, GALAXY and CLUSTER masks (ignoring ALLMASK
-      and MEDIUM)
+* Retune LRG cuts for DR9 and update the LRG SV target bits [`PR #660`_]:
+    * Only use the default `BRIGHT`, `GALAXY` and `CLUSTER` masks (ignore
+     `ALLMASK` and `MEDIUM`).
     * Increase the SV faint limits from z < 20.5 to z < 21.0 and from
-      zfiber < 21.9 to zfiber < 22.0
+      zfiber < 21.9 to zfiber < 22.0.
 * Two main changes for BGS SV selection for DR9 [`PR #659`_]:
     * Remove FRACS* cuts, except for LOWQ superset.
     * Limit FIBMAG superset to r < 20.5 instead of r < 21.0.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,10 +6,10 @@ desitarget Change Log
 -------------------
 
 * Retune LRG cuts for DR9 and update the LRG SV target bits [`PR #661`_]:
-    * Only use the default `BRIGHT`, `GALAXY` and `CLUSTER` masks (ignore
-     `ALLMASK` and `MEDIUM`).
-    * Increase the SV faint limits from z < 20.5 to z < 21.0 and from
-      zfiber < 21.9 to zfiber < 22.0.
+    * Only use the default `BRIGHT`, `GALAXY` and `CLUSTER` masks.
+        * i.e. ignore `ALLMASK` and `MEDIUM`.
+    * Increase the SV faint limits from z < 20.5 to z < 21.0.
+    * Increase the SV faint limits from zfiber < 21.9 to zfiber < 22.0.
 * `PR #660`_: Work completed in `PR #661`_.
 * Two main changes for BGS SV selection for DR9 [`PR #659`_]:
     * Remove FRACS* cuts, except for LOWQ superset.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,12 @@ desitarget Change Log
 0.45.2 (unreleased)
 -------------------
 
-* Retune LRG cuts for DR9 and update the LRG SV target bits [`PR #660`_]:
+* Retune LRG cuts for DR9 and update the LRG SV target bits [`PR #661`_]:
     * Only use the default `BRIGHT`, `GALAXY` and `CLUSTER` masks (ignore
      `ALLMASK` and `MEDIUM`).
     * Increase the SV faint limits from z < 20.5 to z < 21.0 and from
       zfiber < 21.9 to zfiber < 22.0.
+* `PR #660`_: Work completed in `PR #661`_.
 * Two main changes for BGS SV selection for DR9 [`PR #659`_]:
     * Remove FRACS* cuts, except for LOWQ superset.
     * Limit FIBMAG superset to r < 20.5 instead of r < 21.0.
@@ -31,6 +32,7 @@ desitarget Change Log
 .. _`PR #658`: https://github.com/desihub/desitarget/pull/658
 .. _`PR #659`: https://github.com/desihub/desitarget/pull/659
 .. _`PR #660`: https://github.com/desihub/desitarget/pull/660
+.. _`PR #661`: https://github.com/desihub/desitarget/pull/661
 
 0.45.1 (2020-11-22)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -31,6 +31,7 @@ desitarget Change Log
 .. _`PR #655`: https://github.com/desihub/desitarget/pull/655
 .. _`PR #658`: https://github.com/desihub/desitarget/pull/658
 .. _`PR #659`: https://github.com/desihub/desitarget/pull/659
+.. _`PR #660`: https://github.com/desihub/desitarget/pull/660
 
 0.45.1 (2020-11-22)
 -------------------

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2325,7 +2325,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
             primary=primary,
             gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
             zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-            rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr,
+            rfluxivar=rfluxivar, zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
             maskbits=maskbits, south=south
         )
     lrg_north, lrg_south = lrg_classes

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -2158,7 +2158,7 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
 
     photsys_north, photsys_south, obs_rflux, gflux, rflux, zflux,                     \
         w1flux, w2flux, gfiberflux, rfiberflux, zfiberflux,                           \
-        objtype, release, ra, dec, gfluxivar, rfluxivar, zfluxivar,                   \
+        objtype, release, ra, dec, gfluxivar, rfluxivar, zfluxivar, w1fluxivar,       \
         gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,                         \
         gfracmasked, rfracmasked, zfracmasked,                                        \
         gfracin, rfracin, zfracin, gallmask, rallmask, zallmask,                      \

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -269,7 +269,7 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM default mask bits from the Legacy Surveys not set.
-    lrg &= imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"])
+    lrg &= imaging_mask(maskbits)
 
     return lrg
 

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -5,11 +5,11 @@ sv1_desi_mask:
     - [QSO,         2, "QSO", {obsconditions: DARK}]
 
     #- ADM LRG sub-classes
-    - [LRG_INIT_4PASS,  3, "Bright LRG using initial optical and IR cuts",               {obsconditions: DARK}]
-    - [LRG_SUPER_4PASS, 4, "Bright LRG that is a superset of other cuts",                {obsconditions: DARK}]
-    - [LRG_INIT_8PASS,  5, "Faint LRG using initial optical and IR cuts",                {obsconditions: DARK}]
-    - [LRG_SUPER_8PASS, 6, "Faint LRG that is a superset of other cuts",                 {obsconditions: DARK}]
-    - [LOWZ_FILLER,     7, "LRG-like low-z filler sample (will NOT also have LRG set)",  {obsconditions: DARK}]
+    - [LRG_OPT,     3, "LRG from baseline version of optical cuts",             {obsconditions: DARK}]
+    - [LRG_IR,      4, "LRG from baseline version of IR cuts",                  {obsconditions: DARK}]
+    - [LRG_SV_OPT,  5, "LRG from relaxed version of optical cuts",              {obsconditions: DARK}]
+    - [LRG_SV_IR,   6, "LRG from relaxed version of IR cuts",                   {obsconditions: DARK}]
+    - [LOWZ_FILLER, 7, "LRG-like low-z filler sample (NOT used for SV1)",  {obsconditions: DARK}]
 
     #- ADM ELG sub-classes
     - [ELG_SV_GTOT,        8, "ELG from relaxed version of FDR cuts and g-limit",        {obsconditions: DARK|GRAY}]
@@ -26,17 +26,17 @@ sv1_desi_mask:
     - [QSO_Z5,            17, "z~5 QSO",                                      {obsconditions: DARK}]
 
     #- North vs. South selections for different sub-classes
-    - [LRG_INIT_4PASS_NORTH,   18, "Bright LRG using initial optical and IR cuts tuned for Bok/Mosaic", {obsconditions: DARK}]
-    - [LRG_SUPER_4PASS_NORTH,  19, "Bright LRG that is a superset of other cuts tuned for Bok/Mosaic",  {obsconditions: DARK}]
-    - [LRG_INIT_8PASS_NORTH,   20, "Faint LRG using initial optical and IR cuts tuned for Bok/Mosaic",  {obsconditions: DARK}]
-    - [LRG_SUPER_8PASS_NORTH,  21, "Faint LRG that is a superset of other cuts tuned for Bok/Mosaic",   {obsconditions: DARK}]
-    - [LOWZ_FILLER_NORTH,      22, "LRG-like low-z filler sample tuned for Bok/Mosaic",                 {obsconditions: DARK}]
+    - [LRG_OPT_NORTH,     18, "LRG from baseline version of optical cuts tuned for Bok/Mosaic",       {obsconditions: DARK}]
+    - [LRG_IR_NORTH,      19, "LRG from baseline version of IR cuts tuned for Bok/Mosaic",            {obsconditions: DARK}]
+    - [LRG_SV_OPT_NORTH,  20, "LRG from relaxed version of optical cuts tuned for Bok/Mosaic",        {obsconditions: DARK}]
+    - [LRG_SV_IR_NORTH,   21, "LRG from relaxed version of IR cuts tuned for Bok/Mosaic",             {obsconditions: DARK}]
+    - [LOWZ_FILLER_NORTH, 22, "LRG-like low-z filler sample tuned for Bok/Mosaic (NOT used for SV1)", {obsconditions: DARK}]
 
-    - [LRG_INIT_4PASS_SOUTH,   23, "Bright LRG using initial optical and IR cuts tuned for DECam", {obsconditions: DARK}]
-    - [LRG_SUPER_4PASS_SOUTH,  24, "Bright LRG that is a superset of other cuts tuned for DECam",  {obsconditions: DARK}]
-    - [LRG_INIT_8PASS_SOUTH,   25, "Faint LRG using initial optical and IR cuts tuned for DECam",  {obsconditions: DARK}]
-    - [LRG_SUPER_8PASS_SOUTH,  26, "Faint LRG that is a superset of other cuts tuned for DECam",   {obsconditions: DARK}]
-    - [LOWZ_FILLER_SOUTH,      27, "LRG-like low-z filler sample tuned for DECam",                 {obsconditions: DARK}]
+    - [LRG_OPT_SOUTH,     23, "LRG from baseline version of optical cuts tuned for DECam",       {obsconditions: DARK}]
+    - [LRG_IR_SOUTH,      24, "LRG from baseline version of IR cuts tuned for DECam",            {obsconditions: DARK}]
+    - [LRG_SV_OPT_SOUTH,  25, "LRG from relaxed version of optical cuts tuned for DECam",        {obsconditions: DARK}]
+    - [LRG_SV_IR_SOUTH,   26, "LRG from relaxed version of IR cuts tuned for DECam",             {obsconditions: DARK}]
+    - [LOWZ_FILLER_SOUTH, 27, "LRG-like low-z filler sample tuned for DECam (NOT used for SV1)", {obsconditions: DARK}]
 
     - [ELG_SV_GTOT_NORTH,      28, "ELG from relaxed version of FDR cuts and g-limit for Bok/Mosaic",        {obsconditions: DARK|GRAY}]
     - [ELG_SV_GFIB_NORTH,      29, "ELG from relaxed version of FDR cuts and g-fiber-limit for Bok/Mosaic",  {obsconditions: DARK|GRAY}]
@@ -232,10 +232,10 @@ priorities:
         ELG: {UNOBS: 3000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         LRG: {UNOBS: 3200, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         QSO: {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        LRG_INIT_4PASS: SAME_AS_LRG
-        LRG_SUPER_4PASS: SAME_AS_LRG
-        LRG_INIT_8PASS: SAME_AS_LRG
-        LRG_SUPER_8PASS: SAME_AS_LRG
+        LRG_OPT: SAME_AS_LRG
+        LRG_IR: SAME_AS_LRG
+        LRG_SV_OPT: SAME_AS_LRG
+        LRG_SV_IR: SAME_AS_LRG
         LOWZ_FILLER: {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         ELG_SV_GTOT: SAME_AS_ELG
         ELG_SV_GFIB: SAME_AS_ELG
@@ -248,36 +248,36 @@ priorities:
         QSO_HZ_F:        SAME_AS_QSO
         QSO_Z5:          SAME_AS_QSO
         # ADM don't prioritize a N/S target if it doesn't have other bits set
-        LRG_INIT_4PASS_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
-        LRG_SUPER_4PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        LRG_INIT_8PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        LRG_SUPER_8PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        LOWZ_FILLER_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        LRG_INIT_4PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        LRG_SUPER_4PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        LRG_INIT_8PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        LRG_SUPER_8PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        LOWZ_FILLER_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_SV_GTOT_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_SV_GFIB_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_FDR_GTOT_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_FDR_GFIB_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_SV_GTOT_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_SV_GFIB_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_FDR_GTOT_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        ELG_FDR_GFIB_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_COLOR_4PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_RF_4PASS_NORTH:    SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_COLOR_8PASS_NORTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_RF_8PASS_NORTH:    SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_HZ_F_NORTH:        SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_Z5_NORTH:          SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_COLOR_4PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_RF_4PASS_SOUTH:    SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_COLOR_8PASS_SOUTH: SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_RF_8PASS_SOUTH:    SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_HZ_F_SOUTH:        SAME_AS_LRG_INIT_4PASS_NORTH
-        QSO_Z5_SOUTH:          SAME_AS_LRG_INIT_4PASS_NORTH
+        LRG_OPT_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
+        LRG_IR_NORTH: SAME_AS_LRG_OPT_NORTH
+        LRG_SV_OPT_NORTH: SAME_AS_LRG_OPT_NORTH
+        LRG_SV_IR_NORTH: SAME_AS_LRG_OPT_NORTH
+        LOWZ_FILLER_NORTH: SAME_AS_LRG_OPT_NORTH
+        LRG_OPT_SOUTH: SAME_AS_LRG_OPT_NORTH
+        LRG_IR_SOUTH: SAME_AS_LRG_OPT_NORTH
+        LRG_SV_OPT_SOUTH: SAME_AS_LRG_OPT_NORTH
+        LRG_SV_IR_SOUTH: SAME_AS_LRG_OPT_NORTH
+        LOWZ_FILLER_SOUTH: SAME_AS_LRG_OPT_NORTH
+        ELG_SV_GTOT_NORTH: SAME_AS_LRG_OPT_NORTH
+        ELG_SV_GFIB_NORTH: SAME_AS_LRG_OPT_NORTH
+        ELG_FDR_GTOT_NORTH: SAME_AS_LRG_OPT_NORTH
+        ELG_FDR_GFIB_NORTH: SAME_AS_LRG_OPT_NORTH
+        ELG_SV_GTOT_SOUTH: SAME_AS_LRG_OPT_NORTH
+        ELG_SV_GFIB_SOUTH: SAME_AS_LRG_OPT_NORTH
+        ELG_FDR_GTOT_SOUTH: SAME_AS_LRG_OPT_NORTH
+        ELG_FDR_GFIB_SOUTH: SAME_AS_LRG_OPT_NORTH
+        QSO_COLOR_4PASS_NORTH: SAME_AS_LRG_OPT_NORTH
+        QSO_RF_4PASS_NORTH:    SAME_AS_LRG_OPT_NORTH
+        QSO_COLOR_8PASS_NORTH: SAME_AS_LRG_OPT_NORTH
+        QSO_RF_8PASS_NORTH:    SAME_AS_LRG_OPT_NORTH
+        QSO_HZ_F_NORTH:        SAME_AS_LRG_OPT_NORTH
+        QSO_Z5_NORTH:          SAME_AS_LRG_OPT_NORTH
+        QSO_COLOR_4PASS_SOUTH: SAME_AS_LRG_OPT_NORTH
+        QSO_RF_4PASS_SOUTH:    SAME_AS_LRG_OPT_NORTH
+        QSO_COLOR_8PASS_SOUTH: SAME_AS_LRG_OPT_NORTH
+        QSO_RF_8PASS_SOUTH:    SAME_AS_LRG_OPT_NORTH
+        QSO_HZ_F_SOUTH:        SAME_AS_LRG_OPT_NORTH
+        QSO_Z5_SOUTH:          SAME_AS_LRG_OPT_NORTH
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FAINT:  -1
@@ -390,10 +390,10 @@ numobs:
         ELG: 1
         LRG: 2
         QSO: 4
-        LRG_INIT_4PASS: 4
-        LRG_SUPER_4PASS: 4
-        LRG_INIT_8PASS: 8
-        LRG_SUPER_8PASS: 8
+        LRG_OPT: 4
+        LRG_IR: 4
+        LRG_SV_OPT: 4
+        LRG_SV_IR: 4
         LOWZ_FILLER: 1
         ELG_SV_GTOT: SAME_AS_ELG
         ELG_SV_GFIB: SAME_AS_ELG
@@ -406,15 +406,15 @@ numobs:
         QSO_HZ_F:        SAME_AS_QSO
         QSO_Z5:          SAME_AS_QSO
         # ADM don't observe a N/S target if it doesn't have other bits set
-        LRG_INIT_4PASS_NORTH:  0
-        LRG_SUPER_4PASS_NORTH: 0
-        LRG_INIT_8PASS_NORTH:  0
-        LRG_SUPER_8PASS_NORTH: 0
+        LRG_OPT_NORTH:  0
+        LRG_IR_NORTH: 0
+        LRG_SV_OPT_NORTH:  0
+        LRG_SV_IR_NORTH: 0
         LOWZ_FILLER_NORTH: 0
-        LRG_INIT_4PASS_SOUTH:  0
-        LRG_SUPER_4PASS_SOUTH: 0
-        LRG_INIT_8PASS_SOUTH:  0
-        LRG_SUPER_8PASS_SOUTH: 0
+        LRG_OPT_SOUTH:  0
+        LRG_IR_SOUTH: 0
+        LRG_SV_OPT_SOUTH:  0
+        LRG_SV_IR_SOUTH: 0
         LOWZ_FILLER_SOUTH: 0
         ELG_SV_GTOT_NORTH: 0
         ELG_SV_GFIB_NORTH: 0

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1491,8 +1491,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the LRG selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    lrg_classes = [[tcfalse, tcfalse, tcfalse, tcfalse, tcfalse],
-                   [tcfalse, tcfalse, tcfalse, tcfalse, tcfalse]]
+    lrg_classes = [[tcfalse, tcfalse, tcfalse, tcfalse],
+                   [tcfalse, tcfalse, tcfalse, tcfalse]]
     if "LRG" in tcnames:
         # ADM run the LRG target types (potentially) for both north and south.
         for south in south_cuts:
@@ -1731,7 +1731,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # ADM add the per-bit information in the south for LRGs...
     desi_target |= lrg_opt_s * desi_mask.LRG_OPT_SOUTH
     desi_target |= lrg_ir_s * desi_mask.LRG_IR_SOUTH
-    desi_target |= lrg_sv_opt_s * desi_mask.LRG_OSV_PT_SOUTH
+    desi_target |= lrg_sv_opt_s * desi_mask.LRG_SV_OPT_SOUTH
     desi_target |= lrg_sv_ir_s * desi_mask.LRG_SV_IR_SOUTH
     # ADM ...and ELGs...
     desi_target |= elgsvgtot_s * desi_mask.ELG_SV_GTOT_SOUTH
@@ -1749,7 +1749,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # ADM add the per-bit information in the north for LRGs...
     desi_target |= lrg_opt_n * desi_mask.LRG_OPT_NORTH
     desi_target |= lrg_ir_n * desi_mask.LRG_IR_NORTH
-    desi_target |= lrg_sv_opt_n * desi_mask.LRG_OSV_PT_NORTH
+    desi_target |= lrg_sv_opt_n * desi_mask.LRG_SV_OPT_NORTH
     desi_target |= lrg_sv_ir_n * desi_mask.LRG_SV_IR_NORTH
     # ADM ...and ELGs...
     desi_target |= elgsvgtot_n * desi_mask.ELG_SV_GTOT_NORTH
@@ -1767,7 +1767,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # ADM combined per-bit information for the LRGs...
     desi_target |= lrg_opt * desi_mask.LRG_OPT
     desi_target |= lrg_ir * desi_mask.LRG_IR
-    desi_target |= lrg_sv_opt * desi_mask.LRG_OSV_PT
+    desi_target |= lrg_sv_opt * desi_mask.LRG_SV_OPT
     desi_target |= lrg_sv_ir * desi_mask.LRG_SV_IR
     # ADM ...and ELGs...
     desi_target |= elgsvgtot * desi_mask.ELG_SV_GTOT

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -91,7 +91,7 @@ def isBACKUP(ra=None, dec=None, gaiagmag=None, primary=None):
 
 
 def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
-          zfiberflux=None, rflux_snr=None, zflux_snr=None, w1flux_snr=None,
+          zfiberflux=None, rfluxivar=None, zfluxivar=None, w1fluxivar=None,
           gnobs=None, rnobs=None, znobs=None, maskbits=None,
           primary=None, south=True):
     """Target Definition of LRG. Returns a boolean array.
@@ -118,7 +118,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     Notes
     -----
-    - Current version (02/18/20) is version 123 on `the SV wiki`_.
+    - Current version (12/07/2020) is version 140 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # ADM LRG SV targets.
@@ -129,23 +129,23 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None,
     lrg &= notinLRG_mask(
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
         zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-        rflux_snr=rflux_snr, zflux_snr=zflux_snr, w1flux_snr=w1flux_snr,
+        rfluxivar=rfluxivar, zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
         maskbits=maskbits
     )
 
     # ADM pass the lrg that pass cuts as primary, to restrict to the
     # ADM sources that weren't in a mask/logic cut.
-    lrg_all, lrginit4, lrgsuper4, lrginit8, lrgsuper8 = isLRG_colors(
+    lrg_opt, lrg_ir, lrg_sv_opt, lrg_sv_ir = isLRG_colors(
         gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
         zfiberflux=zfiberflux, south=south, primary=lrg
     )
 
-    return lrg_all, lrginit4, lrgsuper4, lrginit8, lrgsuper8
+    return lrg_opt, lrg_ir, lrg_sv_opt, lrg_sv_ir
 
 
 def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
                   zfiberflux=None, gnobs=None, rnobs=None, znobs=None,
-                  rflux_snr=None, zflux_snr=None, w1flux_snr=None,
+                  rfluxivar=None, zfluxivar=None, w1fluxivar=None,
                   maskbits=None):
     """See :func:`~desitarget.sv1.sv1_cuts.isLRG` for details.
 
@@ -163,15 +163,15 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
         log.warning('Setting zfiberflux to zflux!!!')
         zfiberflux = zflux.copy()
 
-    lrg &= (rflux_snr > 0) & (rflux > 0)   # ADM quality in r.
-    lrg &= (zflux_snr > 0) & (zflux > 0) & (zfiberflux > 0)   # ADM quality in z.
-    lrg &= (w1flux_snr > 4) & (w1flux > 0)  # ADM quality in W1.
+    lrg &= (rfluxivar > 0) & (rflux > 0)   # ADM quality in r.
+    lrg &= (zfluxivar > 0) & (zflux > 0) & (zfiberflux > 0)   # ADM quality in z.
+    lrg &= (w1fluxivar > 0) & (w1flux > 0)  # ADM quality in W1.
 
     # ADM observed in every band.
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM default mask bits from the Legacy Surveys not set.
-    lrg &= imaging_mask(maskbits)
+    lrg &= imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"])
 
     return lrg
 
@@ -182,8 +182,7 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
     """
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
-    lrg = primary.copy()
-    lrginit, lrgsuper = np.tile(primary, [2, 1])
+    lrg_opt, lrg_ir, lrg_sv_opt, lrg_sv_ir = np.tile(primary, [4, 1])
 
     # ADM to maintain backwards-compatibility with mocks.
     if zfiberflux is None:
@@ -199,93 +198,87 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     if south:
 
-        # LRG_INIT: Nominal optical + Nominal IR:
-        lrginit &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.6     # non-stellar cut
-        lrginit &= zfibermag < 21.5                           # faint limit
-        lrginit &= rmag - zmag > 0.7                          # remove outliers
-        lrg_opt = (gmag - w1mag > 2.6) & (gmag - rmag > 1.4)  # low-z cut
-        lrg_opt |= rmag - w1mag > 1.8                         # ignore low-z cut for faint objects
-        lrg_opt &= rmag - zmag > (zmag - 16.83) * 0.45        # sliding optical cut
-        lrg_opt &= rmag - zmag > (zmag - 13.80) * 0.19        # low-z sliding optical cut
-        lrg_ir = rmag - w1mag > 1.1                           # Low-z cut
-        lrg_ir &= rmag - w1mag > (w1mag - 17.23) * 1.8        # sliding IR cut
-        lrg_ir &= rmag - w1mag > w1mag - 16.38                # low-z sliding IR cut
-        lrginit &= lrg_opt | lrg_ir
+        # LRG_OPT: baseline optical selection
+        lrg_opt &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.6      # non-stellar cut
+        lrg_opt &= (zfibermag < 21.5)                          # faint limit
+        mask_red = (gmag - w1mag > 2.6) & (gmag - rmag > 1.4)  # low-z cut
+        mask_red |= (rmag-w1mag) > 1.8                         # ignore low-z cut for faint objects
+        lrg_opt &= mask_red
+        lrg_opt &= rmag - zmag > (zmag - 16.83) * 0.45         # sliding optical cut
+        lrg_opt &= rmag - zmag > (zmag - 13.80) * 0.19         # low-z sliding optical cut
 
-        # LRG_SUPER: SV superset:
-        lrgsuper &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.8    # non-stellar cut
-        lrgsuper &= (zmag < 20.5) | (zfibermag < 21.9)        # faint limit
-        lrgsuper &= rmag - zmag > 0.6                         # remove outliers
-        lrg_opt = (gmag - w1mag > 2.5) & (gmag - rmag > 1.3)  # low-z cut
-        lrg_opt |= rmag - w1mag > 1.7                         # ignore low-z cut for faint objects
+        # LRG_IR: baseline IR selection
+        lrg_ir &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.6       # non-stellar cut
+        lrg_ir &= (zfibermag < 21.5)                           # faint limit
+        lrg_ir &= (rmag - w1mag > 1.1)                         # low-z cut
+        lrg_ir &= rmag - w1mag > (w1mag - 17.22) * 1.8         # sliding IR cut
+        lrg_ir &= rmag - w1mag > w1mag - 16.37                 # low-z sliding IR cut
+
+        # LRG_SV_OPT: SV optical selection
+        lrg_sv_opt &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.8   # non-stellar cut
+        lrg_sv_opt &= ((zmag < 21.0) | (zfibermag < 22.0))     # faint limit
+        mask_red = (gmag - w1mag > 2.5) & (gmag - rmag > 1.3)  # low-z cut
+        mask_red |= (rmag-w1mag) > 1.7                         # ignore low-z cut for faint objects
+        lrg_sv_opt &= mask_red
         # straight cut for low-z:
-        lrg_opt_lowz = zmag < 20.2
-        lrg_opt_lowz &= rmag - zmag > (zmag - 17.15) * 0.45
-        lrg_opt_lowz &= rmag - zmag > (zmag - 14.12) * 0.19
+        lrg_mask_lowz = zmag < 20.2
+        lrg_mask_lowz &= rmag - zmag > (zmag - 17.20) * 0.45
+        lrg_mask_lowz &= rmag - zmag > (zmag - 14.17) * 0.19
         # curved sliding cut for high-z:
-        lrg_opt_highz = zmag >= 20.2
-        lrg_opt_highz &= ((zmag - 23.15) / 1.3)**2 + (rmag - zmag + 2.5)**2 > 4.485**2
-        lrg_opt &= lrg_opt_lowz | lrg_opt_highz
-        lrg_ir = rmag - w1mag > 1.0                           # Low-z cut
-        # low-z sliding cut:
-        lrg_ir_lowz = (w1mag < 18.96) & (rmag - w1mag > (w1mag - 17.46) * 1.8)
-        # high-z sliding cut:
-        lrg_ir_highz = (w1mag >= 18.96) & ((w1mag - 21.65)**2 + ((rmag - w1mag + 0.66) / 1.5)**2 > 3.5**2)
-        lrg_ir_highz |= (w1mag >= 18.96) & (rmag - w1mag > 3.1)
-        lrg_ir &= lrg_ir_lowz | lrg_ir_highz
-        lrgsuper &= lrg_opt | lrg_ir
+        lrg_mask_highz = zmag >= 20.2
+        lrg_mask_highz &= (((zmag - 23.18) / 1.3)**2 + (rmag - zmag + 2.5)**2 > 4.48**2)
+        lrg_sv_opt &= (lrg_mask_lowz | lrg_mask_highz)
+
+        # LRG_SV_IR: SV IR selection
+        lrg_sv_ir &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.8    # non-stellar cut
+        lrg_sv_ir &= ((zmag < 21.0) | (zfibermag < 22.0))      # faint limit
+        lrg_sv_ir &= (rmag - w1mag > 1.0)                      # low-z cut
+        lrg_mask_slide = rmag - w1mag > (w1mag - 17.48) * 1.8  # sliding IR cut
+        lrg_mask_slide |= (rmag - w1mag > 3.1)                 # add high-z objects
+        lrg_sv_ir &= lrg_mask_slide
 
     else:
 
-        # LRG_INIT: Nominal optical + Nominal IR:
-        lrginit &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.65      # non-stellar cut
-        lrginit &= zfibermag < 21.5                             # faint limit
-        lrginit &= rmag - zmag > 0.7                            # remove outliers
-        lrg_opt = (gmag - w1mag > 2.67) & (gmag - rmag > 1.45)  # low-z cut
-        lrg_opt |= rmag - w1mag > 1.85                          # ignore low-z cut for faint objects
-        lrg_opt &= rmag - zmag > (zmag - 16.69) * 0.45          # sliding optical cut
-        lrg_opt &= rmag - zmag > (zmag - 13.68) * 0.19          # low-z sliding optical cut
-        lrg_ir = rmag - w1mag > 1.15                            # Low-z cut
-        lrg_ir &= rmag - w1mag > (w1mag - 17.193) * 1.8         # sliding IR cut
-        lrg_ir &= rmag - w1mag > w1mag - 16.343                 # low-z sliding IR cut
-        lrginit &= lrg_opt | lrg_ir
+        # LRG_OPT: baseline optical selection
+        lrg_opt &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.6        # non-stellar cut
+        lrg_opt &= (zfibermag < 21.5)                            # faint limit
+        mask_red = (gmag - w1mag > 2.67) & (gmag - rmag > 1.45)  # low-z cut
+        mask_red |= (rmag-w1mag) > 1.85                          # ignore low-z cut for faint objects
+        lrg_opt &= mask_red
+        lrg_opt &= rmag - zmag > (zmag - 16.79) * 0.45           # sliding optical cut
+        lrg_opt &= rmag - zmag > (zmag - 13.76) * 0.19           # low-z sliding optical cut
 
-        # LRG_SUPER: SV superset:
-        lrgsuper &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.85     # non-stellar cut
-        lrgsuper &= (zmag < 20.5) | (zfibermag < 21.9)          # faint limit
-        lrgsuper &= rmag - zmag > 0.6                           # remove outliers
-        lrg_opt = (gmag - w1mag > 2.57) & (gmag - rmag > 1.35)  # low-z cut
-        lrg_opt |= rmag - w1mag > 1.75                          # ignore low-z cut for faint objects
+        # LRG_IR: baseline IR selection
+        lrg_ir &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.6         # non-stellar cut
+        lrg_ir &= (zfibermag < 21.5)                             # faint limit
+        lrg_ir &= (rmag - w1mag > 1.13)                          # low-z cut
+        lrg_ir &= rmag - w1mag > (w1mag - 17.18) * 1.8           # sliding IR cut
+        lrg_ir &= rmag - w1mag > w1mag - 16.33                   # low-z sliding IR cut
+
+        # LRG_SV_OPT: SV optical selection
+        lrg_sv_opt &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.8     # non-stellar cut
+        lrg_sv_opt &= ((zmag < 21.0) | (zfibermag < 22.0))       # faint limit
+        mask_red = (gmag - w1mag > 2.57) & (gmag - rmag > 1.35)  # low-z cut
+        mask_red |= (rmag-w1mag) > 1.75                          # ignore low-z cut for faint objects
+        lrg_sv_opt &= mask_red
         # straight cut for low-z:
-        lrg_opt_lowz = zmag < 20.2
-        lrg_opt_lowz &= rmag - zmag > (zmag - 17.025) * 0.45    # sliding optical cut
-        lrg_opt_lowz &= rmag - zmag > (zmag - 14.015) * 0.19    # low-z sliding optical cut
+        lrg_mask_lowz = zmag < 20.2
+        lrg_mask_lowz &= rmag - zmag > (zmag - 17.17) * 0.45
+        lrg_mask_lowz &= rmag - zmag > (zmag - 14.14) * 0.19
         # curved sliding cut for high-z:
-        lrg_opt_highz = zmag >= 20.2
-        lrg_opt_highz &= ((zmag - 23.175) / 1.3)**2 + (rmag - zmag + 2.43)**2 > 4.485**2
-        lrg_opt &= lrg_opt_lowz | lrg_opt_highz
-        lrg_ir = rmag - w1mag > 1.05                            # Low-z cut
-        # low-z sliding cut:
-        lrg_ir_lowz = (w1mag < 18.94) & (rmag - w1mag > (w1mag - 17.43) * 1.8)
-        # high-z sliding cut:
-        lrg_ir_highz = (w1mag >= 18.94) & ((w1mag - 21.63)**2 + ((rmag - w1mag + 0.65) / 1.5)**2 > 3.5**2)
-        lrg_ir_highz |= (w1mag >= 18.94) & (rmag - w1mag > 3.1)
-        lrg_ir &= lrg_ir_lowz | lrg_ir_highz
-        lrgsuper &= lrg_opt | lrg_ir
+        lrg_mask_highz = zmag >= 20.2
+        lrg_mask_highz &= (((zmag - 23.15) / 1.3)**2 + (rmag - zmag + 2.5)**2 > 4.48**2)
+        lrg_sv_opt &= (lrg_mask_lowz | lrg_mask_highz)
 
-    lrg &= lrginit | lrgsuper
+        # LRG_SV_IR: SV IR selection
+        lrg_sv_ir &= zmag - w1mag > 0.8 * (rmag-zmag) - 0.8      # non-stellar cut
+        lrg_sv_ir &= ((zmag < 21.0) | (zfibermag < 22.0))        # faint limit
+        lrg_sv_ir &= (rmag - w1mag > 1.03)                       # low-z cut
+        lrg_mask_slide = rmag - w1mag > (w1mag - 17.44) * 1.8    # sliding IR cut
+        lrg_mask_slide |= (rmag - w1mag > 3.1)                   # add high-z objects
+        lrg_sv_ir &= lrg_mask_slide
 
-    lrginit4, lrginit8 = lrginit.copy(), lrginit.copy()
-    lrgsuper4, lrgsuper8 = lrgsuper.copy(), lrgsuper.copy()
-
-    # ADM 4-pass LRGs are z < 20
-    lrginit4 &= zmag < 20.
-    lrgsuper4 &= zmag < 20.
-    # ADM 8-pass LRGs are z >= 20
-    lrginit8 &= zmag >= 20.
-    lrgsuper8 &= zmag >= 20.
-
-    return lrg, lrginit4, lrgsuper4, lrginit8, lrgsuper8
+    return lrg_opt, lrg_ir, lrg_sv_opt, lrg_sv_ir
 
 
 def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
@@ -1458,8 +1451,8 @@ def isMWS_WD(primary=None, gaia=None, galb=None, astrometricexcessnoise=None,
 
 def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     gflux, rflux, zflux, w1flux, w2flux,
-                    gfiberflux, rfiberflux, zfiberflux,
-                    objtype, release, ra, dec, gfluxivar, rfluxivar, zfluxivar,
+                    gfiberflux, rfiberflux, zfiberflux, objtype, release,
+                    ra, dec, gfluxivar, rfluxivar, zfluxivar, w1fluxivar,
                     gnobs, rnobs, znobs, gfracflux, rfracflux, zfracflux,
                     gfracmasked, rfracmasked, zfracmasked,
                     gfracin, rfracin, zfracin, gallmask, rallmask, zallmask,
@@ -1506,19 +1499,21 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
             lrg_classes[int(south)] = isLRG(
                 primary=primary, south=south,
                 gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
-                zfiberflux=zfiberflux, rflux_snr=rsnr, zflux_snr=zsnr,
-                w1flux_snr=w1snr, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                zfiberflux=zfiberflux, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
+                w1fluxivar=w1fluxivar, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                 maskbits=maskbits
             )
-    lrg_north, lrginit_n_4, lrgsup_n_4, lrginit_n_8, lrgsup_n_8 = lrg_classes[0]
-    lrg_south, lrginit_s_4, lrgsup_s_4, lrginit_s_8, lrgsup_s_8 = lrg_classes[1]
+    lrg_opt_n, lrg_ir_n, lrg_sv_opt_n, lrg_sv_ir_n = lrg_classes[0]
+    lrg_opt_s, lrg_ir_s, lrg_sv_opt_s, lrg_sv_ir_s = lrg_classes[1]
 
     # ADM combine LRG target bits for an LRG target based on any imaging
-    lrg = (lrg_north & photsys_north) | (lrg_south & photsys_south)
-    lrginit_4 = (lrginit_n_4 & photsys_north) | (lrginit_s_4 & photsys_south)
-    lrgsup_4 = (lrgsup_n_4 & photsys_north) | (lrgsup_s_4 & photsys_south)
-    lrginit_8 = (lrginit_n_8 & photsys_north) | (lrginit_s_8 & photsys_south)
-    lrgsup_8 = (lrgsup_n_8 & photsys_north) | (lrgsup_s_8 & photsys_south)
+    lrg_n = lrg_opt_n | lrg_ir_n | lrg_sv_opt_n | lrg_sv_ir_n
+    lrg_s = lrg_opt_s | lrg_ir_s | lrg_sv_opt_s | lrg_sv_ir_s
+    lrg = (lrg_n & photsys_north) | (lrg_s & photsys_south)
+    lrg_opt = (lrg_opt_n & photsys_north) | (lrg_opt_s & photsys_south)
+    lrg_ir = (lrg_ir_n & photsys_north) | (lrg_ir_s & photsys_south)
+    lrg_sv_opt = (lrg_sv_opt_n & photsys_north) | (lrg_sv_opt_s & photsys_south)
+    lrg_sv_ir = (lrg_sv_ir_n & photsys_north) | (lrg_sv_ir_s & photsys_south)
 
     # ADM initially set everything to arrays of False for the ELG selection
     # ADM the zeroth element stores the northern targets bits (south=False).
@@ -1734,10 +1729,10 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= qso * desi_mask.QSO
 
     # ADM add the per-bit information in the south for LRGs...
-    desi_target |= lrginit_s_4 * desi_mask.LRG_INIT_4PASS_SOUTH
-    desi_target |= lrgsup_s_4 * desi_mask.LRG_SUPER_4PASS_SOUTH
-    desi_target |= lrginit_s_8 * desi_mask.LRG_INIT_8PASS_SOUTH
-    desi_target |= lrgsup_s_8 * desi_mask.LRG_SUPER_8PASS_SOUTH
+    desi_target |= lrg_opt_s * desi_mask.LRG_OPT_SOUTH
+    desi_target |= lrg_ir_s * desi_mask.LRG_IR_SOUTH
+    desi_target |= lrg_sv_opt_s * desi_mask.LRG_OSV_PT_SOUTH
+    desi_target |= lrg_sv_ir_s * desi_mask.LRG_SV_IR_SOUTH
     # ADM ...and ELGs...
     desi_target |= elgsvgtot_s * desi_mask.ELG_SV_GTOT_SOUTH
     desi_target |= elgsvgfib_s * desi_mask.ELG_SV_GFIB_SOUTH
@@ -1752,10 +1747,10 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= qsoz5_south * desi_mask.QSO_Z5_SOUTH
 
     # ADM add the per-bit information in the north for LRGs...
-    desi_target |= lrginit_n_4 * desi_mask.LRG_INIT_4PASS_NORTH
-    desi_target |= lrgsup_n_4 * desi_mask.LRG_SUPER_4PASS_NORTH
-    desi_target |= lrginit_n_8 * desi_mask.LRG_INIT_8PASS_NORTH
-    desi_target |= lrgsup_n_8 * desi_mask.LRG_SUPER_8PASS_NORTH
+    desi_target |= lrg_opt_n * desi_mask.LRG_OPT_NORTH
+    desi_target |= lrg_ir_n * desi_mask.LRG_IR_NORTH
+    desi_target |= lrg_sv_opt_n * desi_mask.LRG_OSV_PT_NORTH
+    desi_target |= lrg_sv_ir_n * desi_mask.LRG_SV_IR_NORTH
     # ADM ...and ELGs...
     desi_target |= elgsvgtot_n * desi_mask.ELG_SV_GTOT_NORTH
     desi_target |= elgsvgfib_n * desi_mask.ELG_SV_GFIB_NORTH
@@ -1770,10 +1765,10 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= qsoz5_north * desi_mask.QSO_Z5_NORTH
 
     # ADM combined per-bit information for the LRGs...
-    desi_target |= lrginit_4 * desi_mask.LRG_INIT_4PASS
-    desi_target |= lrgsup_4 * desi_mask.LRG_SUPER_4PASS
-    desi_target |= lrginit_8 * desi_mask.LRG_INIT_8PASS
-    desi_target |= lrgsup_8 * desi_mask.LRG_SUPER_8PASS
+    desi_target |= lrg_opt * desi_mask.LRG_OPT
+    desi_target |= lrg_ir * desi_mask.LRG_IR
+    desi_target |= lrg_sv_opt * desi_mask.LRG_OSV_PT
+    desi_target |= lrg_sv_ir * desi_mask.LRG_SV_IR
     # ADM ...and ELGs...
     desi_target |= elgsvgtot * desi_mask.ELG_SV_GTOT
     desi_target |= elgsvgfib * desi_mask.ELG_SV_GFIB

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1028,11 +1028,11 @@ def notinBGS_mask(gflux=None, rflux=None, zflux=None, gnobs=None, rnobs=None, zn
     # quality cuts definitions
     bgs_qcs &= (gnobs >= 1) & (rnobs >= 1) & (znobs >= 1)
     # ORM Turn off the FRACMASKED, FRACFLUX & FRACIN cuts for now
-    
+
     bgs_fracs &= (gfracmasked < 0.4) & (rfracmasked < 0.4) & (zfracmasked < 0.4)
     bgs_fracs &= (gfracflux < 5.0) & (rfracflux < 5.0) & (zfracflux < 5.0)
     bgs_fracs &= (gfracin > 0.3) & (rfracin > 0.3) & (zfracin > 0.3)
-    #bgs_qcs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
+    # bgs_qcs &= (gfluxivar > 0) & (rfluxivar > 0) & (zfluxivar > 0)
 
     # color box
     bgs_qcs &= rflux > gflux * 10**(-1.0/2.5)

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -171,7 +171,7 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
 
     # ADM default mask bits from the Legacy Surveys not set.
-    lrg &= imaging_mask(maskbits, bitnamelist=["BRIGHT", "GALAXY", "CLUSTER"])
+    lrg &= imaging_mask(maskbits)
 
     return lrg
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -112,6 +112,7 @@ class TestCuts(unittest.TestCase):
         gfluxivar = targets['FLUX_IVAR_G']
         rfluxivar = targets['FLUX_IVAR_R']
         zfluxivar = targets['FLUX_IVAR_Z']
+        w1fluxivar = targets['FLUX_IVAR_W1']
 
         gsnr = targets['FLUX_G'] * np.sqrt(targets['FLUX_IVAR_G'])
         rsnr = targets['FLUX_R'] * np.sqrt(targets['FLUX_IVAR_R'])
@@ -150,13 +151,14 @@ class TestCuts(unittest.TestCase):
             lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
                               zflux=zflux, w1flux=w1flux, zfiberflux=ff,
                               gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                              maskbits=maskbits,
-                              rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
+                              maskbits=maskbits, rfluxivar=rfluxivar,
+                              zfluxivar=zfluxivar, w1fluxivar=w1fluxivar)
             lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux, zflux=zflux,
                               w1flux=w1flux, zfiberflux=ff,
                               gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                              maskbits=maskbits,
-                              rflux_snr=rsnr, zflux_snr=zsnr, w1flux_snr=w1snr)
+                              maskbits=maskbits, rfluxivar=rfluxivar,
+                              zfluxivar=zfluxivar, w1fluxivar=w1fluxivar)
+
             self.assertTrue(np.all(lrg1 == lrg2))
 
             # ADM also check that the color selections alone work. This tripped us up once


### PR DESCRIPTION
This PR supersedes #660. It includes code to:

- Retune the LRG cuts for DR9 and update the LRG SV target bits.
- Switch to only using the default `BRIGHT`, `GALAXY` and `CLUSTER` masks in `MASKBITS` (i.e. ignoring `ALLMASK` and `MEDIUM`).
- Increase the SV faint limits from `z < 20.5` to `z < 21.0` and from `zfiber < 21.9` to `zfiber < 22.0`.