### PR TITLE
Update ELG cuts for DR9 imaging for SV and the Main Survey

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.45.2 (unreleased)
 -------------------
 
+* Update ELG cuts for DR9 imaging for SV and Main Survey [`PR #662`_]:
 * Retune LRG cuts for DR9 and update the LRG SV target bits [`PR #661`_]:
     * Only use the default `BRIGHT`, `GALAXY` and `CLUSTER` masks.
         * i.e. ignore `ALLMASK` and `MEDIUM`.
@@ -33,6 +34,7 @@ desitarget Change Log
 .. _`PR #659`: https://github.com/desihub/desitarget/pull/659
 .. _`PR #660`: https://github.com/desihub/desitarget/pull/660
 .. _`PR #661`: https://github.com/desihub/desitarget/pull/661
+.. _`PR #662`: https://github.com/desihub/desitarget/pull/662
 
 0.45.1 (2020-11-22)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -328,7 +328,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     (see :func:`~desitarget.cuts.set_target_bits` for parameters).
 
     Notes:
-    - Current version (10/16/19) is version 202 on `the wiki`_.
+    - Current version (12/09/20) is version 233 on `the wiki`_.
     """
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
@@ -387,12 +387,12 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
 
     # ADM cuts that are unique to the north or south.
     if south:
-        elg &= g < 23.5  # faint cut.
+        elg &= g < 23.4  # faint cut.
         # ADM south has the FDR cut to remove stars and low-z galaxies.
         elg &= g - r < 1.15*(r - z) - 0.15
     else:
-        elg &= g < 23.6  # faint cut.
-        elg &= g - r < 1.15*(r - z) - 0.35  # remove stars and low-z galaxies.
+        elg &= g < 23.5  # faint cut.
+        elg &= g - r < 1.15*(r - z) - 0.20  # remove stars and low-z galaxies.
 
     return elg
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1110,7 +1110,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (10/14/19) is version 107 on `the SV wiki`_.
+    - Current version (12/09/20) is version 142 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if primary is None:
@@ -1165,13 +1165,15 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     # ADM some cuts specific to north or south
     if south:
+        gtotfaint_fdr = 23.4
+        gfibfaint_fdr = 24.0
+        lowzcut_zp = -0.15
+        gr_blue = 0.3
+    else:
         gtotfaint_fdr = 23.5
         gfibfaint_fdr = 24.1
-        lowzcut_zp = -0.15
-    else:
-        gtotfaint_fdr = 23.6
-        gfibfaint_fdr = 24.2
-        lowzcut_zp = -0.35
+        lowzcut_zp = -0.20
+        gr_blue = 0.4
 
     # ADM work in magnitudes not fluxes. THIS IS ONLY OK AS the snr cuts
     # ADM in notinELG_mask ENSURE positive fluxes in all of g, r and z.
@@ -1195,9 +1197,8 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     sv, fdr = elg.copy(), elg.copy()
 
     # ADM create the SV classes.
-    sv &= rz > -1.           # blue cut.
-    sv &= gr < -1.2*rz+2.5   # OII cut.
-    sv &= (gr < 0.2) | (gr < 1.15*rz + lowzcut_zp)   # star/lowz cut.
+    sv &= gr < -1.2*rz+2.0   # OII cut.
+    sv &= (gr < gr_blue) | (gr < 1.15*rz + lowzcut_zp + 0.1)   # star/lowz cut.
 
     # ADM gfib/g split for SV-like classes.
     svgtot, svgfib = sv.copy(), sv.copy()

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1110,7 +1110,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (12/09/20) is version 142 on `the SV wiki`_.
+    - Current version (12/09/20) is version 143 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if primary is None:
@@ -1166,7 +1166,7 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     # ADM some cuts specific to north or south
     if south:
         gtotfaint_fdr = 23.4
-        gfibfaint_fdr = 24.0
+        gfibfaint_fdr = 24.1
         lowzcut_zp = -0.15
         gr_blue = 0.3
     else:


### PR DESCRIPTION
This PR returns the ELG cuts for SV and the Main Survey based on DR9 imaging.