### PR TITLE
One more update to the ELG cuts for DR9 imaging for SV.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 0.46.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Update the gr_blue ELG cut for DR9 imaging for SV [`PR #663`_]:
+
+.. _`PR #663`: https://github.com/desihub/desitarget/pull/663
 
 0.46.0 (2020-12-10)
 -------------------

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1110,7 +1110,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (12/09/20) is version 143 on `the SV wiki`_.
+    - Current version (12/09/20) is version 144 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if primary is None:

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1110,7 +1110,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (12/09/20) is version 144 on `the SV wiki`_.
+    - Current version (12/09/20) is version 145 on `the SV wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if primary is None:

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -1168,12 +1168,12 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         gtotfaint_fdr = 23.4
         gfibfaint_fdr = 24.1
         lowzcut_zp = -0.15
-        gr_blue = 0.3
+        gr_blue = 0.2
     else:
         gtotfaint_fdr = 23.5
         gfibfaint_fdr = 24.1
         lowzcut_zp = -0.20
-        gr_blue = 0.4
+        gr_blue = 0.2
 
     # ADM work in magnitudes not fluxes. THIS IS ONLY OK AS the snr cuts
     # ADM in notinELG_mask ENSURE positive fluxes in all of g, r and z.


### PR DESCRIPTION
This PR updates the `gr_blue` ELG cut for DR9 imaging for SV.