### PR TITLE
Updates and bug fixes for DR9 now SV is on-sky

### DIFF
--- a/bin/select_sv_targets
+++ b/bin/select_sv_targets
@@ -83,7 +83,8 @@ extra = " --numproc {}".format(ns.numproc)
 if ns.tcnames is not None:
     extra += " --tcnames {}".format(ns.tcnames)
 nsdict = vars(ns)
-for nskey in "noresolve", "nomaskbits", "writeall", "nosecondary", "nobackup":
+for nskey in ["noresolve", "nomaskbits", "writeall",
+              "nosecondary", "nobackup", "nochecksum"]:
     if nsdict[nskey]:
         extra += " --{}".format(nskey)
 

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -85,7 +85,8 @@ extra = " --numproc {}".format(ns.numproc)
 if ns.tcnames is not None:
     extra += " --tcnames {}".format(ns.tcnames)
 nsdict = vars(ns)
-for nskey in "noresolve", "nomaskbits", "writeall", "nosecondary", "nobackup":
+for nskey in ["noresolve", "nomaskbits", "writeall",
+              "nosecondary", "nobackup", "nochecksum"]:
     if nsdict[nskey]:
         extra += " --{}".format(nskey)
 

--- a/bin/supplement_randoms
+++ b/bin/supplement_randoms
@@ -27,6 +27,9 @@ ap.add_argument("dest",
 ap.add_argument("--density", type=int,
                 help='Number of points per sq. deg. to generate (defaults to the value of DENSITY in the header of the "randomcat" input file)',
                 default=None)
+ap.add_argument("--seed",
+                help='Force a particular seed to be used instead of reading from the header card "SEED"',
+                default=None)
 ap.add_argument("--numproc", type=int,
                 help='number of concurrent processes to use [{}]'.format(nproc),
                 default=nproc)
@@ -51,12 +54,16 @@ except OSError:
     sys.exit(1)
 
 # ADM determine the seed used for the existing random catalog.
-try:
-    seed = ranhead["SEED"]
-    log.info('read seed of {} from {}'.format(seed, ns.randomcat))
-except KeyError:
-    seed = 1
-    log.info('defaulting to a SEED of {}'.format(seed))
+if ns.seed is None:
+    try:
+        seed = ranhead["SEED"]
+        log.info('read seed of {} from {}'.format(seed, ns.randomcat))
+    except KeyError:
+        seed = 1
+        log.info('defaulting to a SEED of {}'.format(seed))
+else:
+    seed = ns.seed
+    log.info('using a seed of 615 + {}' format(seed)
 
 # ADM grab the density used for the existing random catalog, if needed.
 if ns.density is None:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,16 @@ desitarget Change Log
 0.47.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Updates and bug fixes for DR9 now SV is on-sky [`PR #665`_]. Includes:
+    * Pass `MASKBITS` column forward for GFAs.
+    * Bug fixes necessitated by target files having a second extension.
+        * Notably, not all shasums were checked in North/South overlaps.
+    * Some minor additional functionality for creating randoms.
+    * Clean-up code style and syntax errors introduced in `PR #664`_.
+* Tutorial (and initial code) to train DR9 Random Forests [`PR #664`_].
+
+.. _`PR #664`: https://github.com/desihub/desitarget/pull/664
+.. _`PR #665`: https://github.com/desihub/desitarget/pull/665
 
 0.47.0 (2020-12-10)
 -------------------
@@ -17,7 +26,7 @@ desitarget Change Log
 0.46.0 (2020-12-10)
 -------------------
 
-* Update ELG cuts for DR9 imaging for SV and Main Survey [`PR #662`_]:
+* Update ELG cuts for DR9 imaging for SV and Main Survey [`PR #662`_].
 * Retune LRG cuts for DR9 and update the LRG SV target bits [`PR #661`_]:
     * Only use the default `BRIGHT`, `GALAXY` and `CLUSTER` masks.
         * i.e. ignore `ALLMASK` and `MEDIUM`.

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -2183,8 +2183,9 @@ def make_qa_page(targs, mocks=False, makeplots=True, max_bin_area=1.0, qadir='.'
         if svs[0:2] == 'SV':
             for tc in 'QSO', 'ELG', 'LRG', 'BGS', 'MWS':
                 hl = [h.replace(tc, tc[0]) for h in hl]
-                # ADM also change SUPER->SUP to squeeze space
+                # ADM also change SUPER->SUP, COLOR->COL to squeeze space
                 hl = [h.replace('SUPER', 'SUP') for h in hl]
+                hl = [h.replace('COLOR', 'COL') for h in hl]
         # ADM truncate the bit names at "trunc" characters to pack them more easily.
         trunc = 8
         truncform = '{:>'+str(trunc)+'s}'

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2532,7 +2532,9 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         surveydirs = list(set([os.path.dirname(fn) for fn in infiles]))
         bundle_bricks([0], bundlefiles, nside, gather=False, extra=extra,
                       prefix=prefix, surveydirs=surveydirs)
-        return
+        if return_infiles:
+            return None, None
+        return None
 
     # ADM restrict to only input files in a set of HEALPixels, if requested.
     if pixlist is not None:

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -39,7 +39,7 @@ gfadatamodel = np.array([], dtype=[
     ('RELEASE', '>i4'), ('TARGETID', 'i8'),
     ('BRICKID', 'i4'), ('BRICK_OBJID', 'i4'),
     ('RA', 'f8'), ('DEC', 'f8'), ('RA_IVAR', 'f4'), ('DEC_IVAR', 'f4'),
-    ('TYPE', 'S4'),
+    ('TYPE', 'S4'), ('MASKBITS', '>i2'),
     ('FLUX_G', 'f4'), ('FLUX_R', 'f4'), ('FLUX_Z', 'f4'),
     ('FLUX_IVAR_G', 'f4'), ('FLUX_IVAR_R', 'f4'), ('FLUX_IVAR_Z', 'f4'),
     ('REF_ID', 'i8'), ('REF_CAT', 'S2'), ('REF_EPOCH', 'f4'),
@@ -229,8 +229,10 @@ def gaia_in_file(infile, maglim=18, mindec=-30., mingalb=10.,
             gfas[col] = -1
     # ADM some default special cases. Default to REF_EPOCH of Gaia DR2,
     # ADM make RA/Dec very precise for Gaia measurements.
+    # ADM MASKBITS should default to zero indicating no flags are set.
     gfas["REF_EPOCH"] = 2015.5
     gfas["RA_IVAR"], gfas["DEC_IVAR"] = 1e16, 1e16
+    gfas["MASKBITS"] = 0
 
     # ADM populate the common columns in the Gaia/GFA data models.
     cols = set(gfas.dtype.names).intersection(set(objs.dtype.names))

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1882,8 +1882,7 @@ def get_checksums(infiles, verbose=False, check_existing=True):
     shatab['SHA256'] = list(shadict.values())
 
     # ADM grab the unique directories that host files.
-    filedic = {os.path.basename(fn): os.path.dirname(fn) for fn in infiles}
-    ldir = list(set(filedic.values()))
+    ldir = set([os.path.dirname(fn) for fn in infiles])
     # ADM loop through each directory and build a dictionary of the
     # ADM expected files and their associated SHA checksums.
     checkdict = {}

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2394,13 +2394,15 @@ def read_target_files(filename, columns=None, rows=None, header=False,
     start = time()
     # ADM start with some checking that this is a target file.
     targtypes = "TARGETS", "GFA_TARGETS", "SKY_TARGETS", "MASKS", "MTL"
-    # ADM read in the FITS extention info.
+    # ADM read in the FITS extension info.
     f = fitsio.FITS(filename)
     if len(f) != 2:
-        log.info(f)
-        msg = "targeting files should only have 2 extensions?!"
-        log.error(msg)
-        raise IOError(msg)
+        # ADM target files have an extra extension.
+        if not f[1].get_extname() == 'TARGETS' and len(f) == 3:
+            log.info(f)
+            msg = "targeting files should only have 2 extensions?!"
+            log.error(msg)
+            raise IOError(msg)
     # ADM check for allowed extensions.
     extname = f[1].get_extname()
     if extname not in targtypes:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -691,7 +691,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
 
 
 def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
-              nsidefile=None, hpxlist=None, extra=None, ecsv=True):
+              nsidefile=None, hpxlist=None, extra=None, ecsv=True, mixed=False):
     """Write Merged Target List ledgers or files.
 
     Parameters
@@ -720,6 +720,11 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
         values to the output header.
     ecsv : :class:`bool`, defaults to ``True``
         If ``True`` write a .ecsv file, if ``False`` with a .fits file.
+    mixed : :class:`bool`, defaults to ``False``
+        If ``True`` allow `data` to be from different Data Releases and
+        write out the largest data release integer to the file headers.
+        Useful when writing targets from, e.g., DR9 of the Legacy Surveys
+        and DR2 of Gaia to the same file.
 
     Returns
     -------
@@ -747,7 +752,11 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
 
     # ADM determine the data release from a TARGETID.
     _, _, release, _, _, _ = decode_targetid(data["TARGETID"])
-    dr = np.unique(release//1000)
+    # ADM if the mixed kwarg was sent, allow multiple data releases.
+    if mixed:
+        dr = np.atleast_1d(np.max(release//1000))
+    else:
+        dr = np.unique(release//1000)
     if len(dr) == 0:
         drint = 'X'
     else:

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1298,9 +1298,8 @@ def select_randoms_bricks(brickdict, bricknames, numproc=32, drdir=None,
                      .format(nbrick, nbricks, rate, elapsed/60.))
             # ADM if we're going to exceed 4 hours, warn the user.
             if nbricks/rate > 4*3600.:
-                msg = 'May take > 4 hours to run. Run with bundlebricks instead.'
-                log.critical(msg)
-                raise IOError(msg)
+                msg = 'May take > 4 hours to run. May fail on interactive nodes.'
+                log.warning(msg)
 
         nbrick[...] += 1    # this is an in-place modification.
         return result

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -452,7 +452,7 @@ def isQSO_cuts(gflux=None, rflux=None, zflux=None,
 
     # ADM default mask bits from the Legacy Surveys not set.
     if maskbits is not None:
-            qso &= imaging_mask(maskbits)
+        qso &= imaging_mask(maskbits)
 
     # ADM observed in every band.
     qso &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
@@ -665,9 +665,9 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None,
         tmp_rf_HighZ_proba = rf_HighZ.predict_proba()
         # Compute optimized proba cut (all different for SV)
         if not south:
-                # threshold selection for North footprint.
-                pcut = 0.84 - 0.035*np.tanh(r_Reduced - 20.5)
-                pcut_HighZ = 0.65
+            # threshold selection for North footprint.
+            pcut = 0.84 - 0.035*np.tanh(r_Reduced - 20.5)
+            pcut_HighZ = 0.65
         else:
             pcut_HighZ = 0.50
             pcut = np.ones(tmp_rf_proba.size)

--- a/py/desitarget/train/data_collection/RA_DEC_MatchingClassModule.py
+++ b/py/desitarget/train/data_collection/RA_DEC_MatchingClassModule.py
@@ -4,6 +4,7 @@
 import numpy as np
 from sklearn.neighbors import BallTree
 
+
 class RA_DEC_MatchingClass():
     def __init__(self):
         self.RA_CatalogData = None

--- a/py/desitarget/train/data_collection/my_tractor_extract.py
+++ b/py/desitarget/train/data_collection/my_tractor_extract.py
@@ -7,13 +7,13 @@ import numpy as np
 import fitsio
 from data_collection.RA_DEC_MatchingClassModule import RA_DEC_MatchingClass
 
-# settings
+# settings.
 fpn_QSO_cat = "/global/cfs/cdirs/desi/target/analysis/RF/Catalogs/DR16Q_red.fits"
 fpn_var_cat = "/global/cfs/cdirs/desi/target/analysis/RF/Catalogs/Str82_variability_wise_bdt_qso_star_DR7_BOSS_-50+60.fits"
-radius4matching = 1.4/3600. # [deg]
+radius4matching = 1.4/3600.  # [deg]
 NNVar_th = 0.5
 
-# reading arguments
+# reading arguments.
 parser = ArgumentParser()
 parser.add_argument('-i', '--infits', type=str, default=None, metavar='INFITS', help='input fits')
 parser.add_argument('-o', '--outfits', type=str, default=None, metavar='OUTFITS', help='output fits')
@@ -25,22 +25,22 @@ parser.add_argument('-l', '--logfile', type=str, default='none', metavar='LOGFIL
 arg = parser.parse_args()
 INFITS, OUTFITS, RELEASE, RADEC, SELCRIT, LOGFILE = arg.infits, arg.outfis, arg.release, arg.radec, arg.selcrit, arg.logfile
 
-# RADEC
+# RADEC.
 RAMIN, RAMAX, DECMIN, DECMAX = np.array(RADEC.split(',')).astype('float')
 
 # print()
 print('[start: '+datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")+']')
 # print()
 
-# reading
+# reading.
 hdu = fitsio.FITS(INFITS)[1]
 ra = hdu['RA'][:]
 dec = hdu['DEC'][:]
 
-if (RAMAX<RAMIN):
-	keep_radec = ((ra > RAMIN) | (ra < RAMAX)) & (dec > DECMIN) & (dec < DECMAX)
+if (RAMAX < RAMIN):
+    keep_radec = ((ra > RAMIN) | (ra < RAMAX)) & (dec > DECMIN) & (dec < DECMAX)
 else:
-	keep_radec = (ra > RAMIN) & (ra < RAMAX) & (dec > DECMIN) & (dec < DECMAX)
+    keep_radec = (ra > RAMIN) & (ra < RAMAX) & (dec > DECMIN) & (dec < DECMAX)
 
 ra = ra[keep_radec]
 dec = dec[keep_radec]
@@ -50,25 +50,25 @@ ramax = np.max(ra)
 decmax = np.max(dec)
 decmin = np.min(dec)
 
-# QSO
+# QSO.
 if (SELCRIT == 'qso'):
     QSO_hdu = fitsio.FITS(fpn_QSO_cat)[1]
     QSO_ra = QSO_hdu['RA'][:]
     QSO_dec = QSO_hdu['DEC'][:]
     if (ramax < ramin):
-    	QSO_keep_radec = ((QSO_ra > ramin) | (QSO_ra < ramax)) & (QSO_dec > decmin) & (QSO_dec < decmax)
+        QSO_keep_radec = ((QSO_ra > ramin) | (QSO_ra < ramax)) & (QSO_dec > decmin) & (QSO_dec < decmax)
     else:
-    	QSO_keep_radec = (QSO_ra > ramin) & (QSO_ra < ramax) & (QSO_dec > decmin) & (QSO_dec < decmax)
+        QSO_keep_radec = (QSO_ra > ramin) & (QSO_ra < ramax) & (QSO_dec > decmin) & (QSO_dec < decmax)
     if np.any(QSO_keep_radec):
         QSO_ra = QSO_ra[QSO_keep_radec]
         QSO_dec = QSO_dec[QSO_keep_radec]
         RA_DEC_MatchingObj = RA_DEC_MatchingClass()
         RA_DEC_MatchingObj.LoadRA_DEC_CatalogData(ra, dec)
         RA_DEC_MatchingObj.LoadRA_DEC4MatchingData(QSO_ra, QSO_dec)
-        RA_DEC_MatchingObj(radius4matching, 1) # "1" seul voisin le plus proche
+        RA_DEC_MatchingObj(radius4matching, 1)  # "1" seul voisin le plus proche.
         res = RA_DEC_MatchingObj.nNeighResInd
         valid_res = res[0] > -1
-        if np.any(valid_res): #facultatif
+        if np.any(valid_res):  # facultatif.
             hdu_temp = hdu[:][keep_radec][res[0][valid_res]]
             QSO_hdu_temp = QSO_hdu[:][QSO_keep_radec][res[1][valid_res]]
         else:
@@ -87,19 +87,20 @@ if (SELCRIT == 'qso'):
 
 # STARS
 elif (SELCRIT == 'stars'):
-    #ATTENTION EN FONCTION DES RELEASES ILS NE SONT PAS CAPABLES DE GARDER LE MEME NOM DE VARIABLE pour dr8 : 'PSF '
+    # ATTENTION EN FONCTION DES RELEASES ILS NE SONT PAS CAPABLES DE
+    # GARDER LE MEME NOM DE VARIABLE pour dr8 : 'PSF '.
     keep_PSF = (hdu['TYPE'][:][keep_radec] == 'PSF')
     hdu_temp = hdu[:][keep_radec][keep_PSF]
 
-    # Virer les objets *connus* ET variables
+    # Virer les objets *connus* ET variables.
     if np.any(keep_PSF):
         var_hdu = fitsio.FITS(fpn_var_cat)[1]
         var_ra = var_hdu['RA'][:]
         var_dec = var_hdu['DEC'][:]
         if (ramax < ramin):
-        	var_keep_radec = ((var_ra > ramin) | (var_ra < ramax)) & (var_dec > decmin) & (var_dec < decmax)
+            var_keep_radec = ((var_ra > ramin) | (var_ra < ramax)) & (var_dec > decmin) & (var_dec < decmax)
         else:
-        	var_keep_radec = (var_ra > ramin) & (var_ra < ramax) & (var_dec > decmin) & (var_dec < decmax)
+            var_keep_radec = (var_ra > ramin) & (var_ra < ramax) & (var_dec > decmin) & (var_dec < decmax)
         if np.any(var_keep_radec):
             ra = hdu_temp['RA']
             dec = hdu_temp['DEC']
@@ -108,7 +109,7 @@ elif (SELCRIT == 'stars'):
             RA_DEC_MatchingObj = RA_DEC_MatchingClass()
             RA_DEC_MatchingObj.LoadRA_DEC_CatalogData(ra, dec)
             RA_DEC_MatchingObj.LoadRA_DEC4MatchingData(var_ra, var_dec)
-            RA_DEC_MatchingObj(radius4matching, 1)  # "1" seul voisin le plus proche
+            RA_DEC_MatchingObj(radius4matching, 1)   # "1" seul voisin le plus proche.
             res = RA_DEC_MatchingObj.nNeighResInd
             valid_res = res[0] > -1
             if np.any(valid_res):
@@ -117,15 +118,15 @@ elif (SELCRIT == 'stars'):
                 rej_var = var_hdu_temp['NNVariability'] > NNVar_th
                 hdu_temp = np.delete(hdu_temp, rej_data_ind[rej_var])
 
-    # Virer les QSO connus
+    # Virer les QSO connus.
     if len(hdu_temp) > 0:
         QSO_hdu = fitsio.FITS(fpn_QSO_cat)[1]
         QSO_ra = QSO_hdu['RA'][:]
         QSO_dec = QSO_hdu['DEC'][:]
         if (ramax < ramin):
-        	QSO_keep_radec = ((QSO_ra > ramin) | (QSO_ra < ramax)) & (QSO_dec > decmin) & (QSO_dec < decmax)
+            QSO_keep_radec = ((QSO_ra > ramin) | (QSO_ra < ramax)) & (QSO_dec > decmin) & (QSO_dec < decmax)
         else:
-        	QSO_keep_radec = (QSO_ra > ramin) & (QSO_ra < ramax) & (QSO_dec > decmin) & (QSO_dec < decmax)
+            QSO_keep_radec = (QSO_ra > ramin) & (QSO_ra < ramax) & (QSO_dec > decmin) & (QSO_dec < decmax)
         if np.any(QSO_keep_radec):
             ra = hdu_temp['RA']
             dec = hdu_temp['DEC']
@@ -134,27 +135,27 @@ elif (SELCRIT == 'stars'):
             RA_DEC_MatchingObj = RA_DEC_MatchingClass()
             RA_DEC_MatchingObj.LoadRA_DEC_CatalogData(ra, dec)
             RA_DEC_MatchingObj.LoadRA_DEC4MatchingData(QSO_ra, QSO_dec)
-            RA_DEC_MatchingObj(radius4matching, 1) # "1" seul voisin le plus proche
+            RA_DEC_MatchingObj(radius4matching, 1)  # "1" seul voisin le plus proche.
             res = RA_DEC_MatchingObj.nNeighResInd
             valid_res = res[0] > -1
             rej_data_ind = res[0][valid_res]
-            hdu_temp = np.delete(hdu_temp , rej_data_ind)
+            hdu_temp = np.delete(hdu_temp, rej_data_ind)
 
     newhdu = fitsio.FITS(OUTFITS, 'rw')
     newhdu.write(hdu_temp)
     newhdu.close()
 
-# TEST SAMPLE
+# TEST SAMPLE.
 elif (SELCRIT == 'test'):
     hdu_temp = hdu[:][keep_radec]
-    # Identifier les QSOs connus
+    # Identifier les QSOs connus.
     QSO_hdu = fitsio.FITS(fpn_QSO_cat)[1]
     QSO_ra = QSO_hdu['RA'][:]
     QSO_dec = QSO_hdu['DEC'][:]
     if (ramax < ramin):
-    	QSO_keep_radec = ((QSO_ra > ramin) | (QSO_ra < ramax)) & (QSO_dec > decmin) & (QSO_dec < decmax)
+        QSO_keep_radec = ((QSO_ra > ramin) | (QSO_ra < ramax)) & (QSO_dec > decmin) & (QSO_dec < decmax)
     else:
-    	QSO_keep_radec = (QSO_ra > ramin) & (QSO_ra < ramax) & (QSO_dec > decmin) & (QSO_dec < decmax)
+        QSO_keep_radec = (QSO_ra > ramin) & (QSO_ra < ramax) & (QSO_dec > decmin) & (QSO_dec < decmax)
     QSO_hdu_temp = QSO_hdu[:][QSO_keep_radec]
     if np.any(QSO_keep_radec):
         QSO_ra = QSO_ra[QSO_keep_radec]
@@ -162,7 +163,7 @@ elif (SELCRIT == 'test'):
         RA_DEC_MatchingObj = RA_DEC_MatchingClass()
         RA_DEC_MatchingObj.LoadRA_DEC_CatalogData(ra, dec)
         RA_DEC_MatchingObj.LoadRA_DEC4MatchingData(QSO_ra, QSO_dec)
-        RA_DEC_MatchingObj(radius4matching, 1) # "1" seul voisin le plus proche
+        RA_DEC_MatchingObj(radius4matching, 1)  # "1" seul voisin le plus proche
         res = RA_DEC_MatchingObj.nNeighResInd
         valid_res = res[0] > -1
         sel_data_ind = res[0][valid_res]
@@ -184,9 +185,9 @@ elif (SELCRIT == 'test'):
 else:
     print("[WARNING] WE DO NOTHING BECAUSE SELCRIT is not in the list : [qso, stars, test]")
 
-#print()
+# print()
 print('[end: ' + datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S") + ']')
-#print()
+# print()
 
 if (LOGFILE != 'none'):
-	subprocess.call('echo ' + OUTFITS + ' >> ' + LOGFILE, shell=True)
+    subprocess.call('echo ' + OUTFITS + ' >> ' + LOGFILE, shell=True)

--- a/py/desitarget/train/data_collection/my_tractor_extract_batch.py
+++ b/py/desitarget/train/data_collection/my_tractor_extract_batch.py
@@ -9,38 +9,39 @@ import numpy as np
 import astropy.io.fits as fits
 from astropy.io import ascii
 
-def my_tractor_extract_batch(NRUNS, OUTFITS, RELEASE, RADEC, SELCRIT, path_train, DIR):
-    LISTFILE=None
-    # RADEC
-    RAMIN,RAMAX,DECMIN,DECMAX = np.array(RADEC.split(',')).astype('float')
 
-    # settings
+def my_tractor_extract_batch(NRUNS, OUTFITS, RELEASE, RADEC, SELCRIT, path_train, DIR):
+    LISTFILE = None
+    # RADEC.
+    RAMIN, RAMAX, DECMIN, DECMAX = np.array(RADEC.split(',')).astype('float')
+
+    # settings.
     STILTSCMD = 'java -jar -Xmx4096M /global/homes/e/edmondc/Software/topcat/topcat-full.jar -stilts'
-    tmpdir    = DIR + 'tmpdir/'
-    pid       = str(os.getpid())
-    tmplog    = tmpdir + 'tmp.log_' + pid
-    tmpasc    = tmpdir + 'tmp.asc_' + pid
+    tmpdir = DIR + 'tmpdir/'
+    pid = str(os.getpid())
+    tmplog = tmpdir + 'tmp.log_' + pid
+    tmpasc = tmpdir + 'tmp.asc_' + pid
 
     print()
     print('[start: '+datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")+']')
     print()
 
-    # if no LISTFILE is provided, we built it from the ramin,ramax,decmin,decmax infos
-    if (LISTFILE==None):
+    # if no LISTFILE is provided, we built it from the ramin,ramax,decmin,decmax info.
+    if (LISTFILE is None):
         LISTFILE = tmpdir+'tmp.list_'+pid
-        if (RELEASE=='dr3'):
+        if (RELEASE == 'dr3'):
             SWEEPDIR = '/global/project/projectdirs/cosmo/data/legacysurvey/dr3/sweep/3.1'
-        if (RELEASE=='dr4'):
+        if (RELEASE == 'dr4'):
             SWEEPDIR = '/global/project/projectdirs/cosmo/data/legacysurvey/dr4/sweep/4.0'
-        if (RELEASE=='dr5'):
+        if (RELEASE == 'dr5'):
             SWEEPDIR = '/global/project/projectdirs/cosmo/data/legacysurvey/dr5/sweep/5.0'
-        if (RELEASE=='dr6'):
+        if (RELEASE == 'dr6'):
             SWEEPDIR = '/global/project/projectdirs/cosmo/data/legacysurvey/dr6/sweep/6.0'
-        if (RELEASE=='dr7'):
+        if (RELEASE == 'dr7'):
             SWEEPDIR = '/global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1'
-        if(RELEASE=='dr8n'): #BASS/MzLS
+        if (RELEASE == 'dr8n'):  # BASS/MzLS
             SWEEPDIR = '/global/project/projectdirs/cosmo/data/legacysurvey/dr8/north/sweep/8.0'
-        if (RELEASE=='dr8s'): #DECaLS
+        if (RELEASE == 'dr8s'):  # DECaLS
             SWEEPDIR = '/global/project/projectdirs/cosmo/data/legacysurvey/dr8/south/sweep/8.0'
         if (RELEASE == 'dr9n'):
             SWEEPDIR = '/global/cscratch1/sd/adamyers/dr9m/north/sweep/'
@@ -50,47 +51,47 @@ def my_tractor_extract_batch(NRUNS, OUTFITS, RELEASE, RADEC, SELCRIT, path_train
         SWEEPFILE = DIR + RELEASE + '_sweep_meta.fits'
         # listing the sweeps in the considered region
         hdu = fits.open(SWEEPFILE)
-        data= hdu[1].data
+        data = hdu[1].data
 
         if (RAMIN > RAMAX):
             keep = ((data['ramax'] > RAMIN) | (data['ramin'] < RAMAX)) & (data['decmax'] > DECMIN) & (data['decmin'] < DECMAX)
         else:
             keep = (data['ramax'] > RAMIN) & (data['ramin'] < RAMAX) & (data['decmax'] > DECMIN) & (data['decmin'] < DECMAX)
-        f = open(LISTFILE,'w')
+        f = open(LISTFILE, 'w')
         for name in data['sweepname'][keep]:
             f.write(SWEEPDIR+'/'+name+'\t'+tmpdir+'tmp.'+name+'_'+pid+'\n')
         f.close()
 
     # reading LISTFILE
     data = ascii.read(LISTFILE, delimiter='\t', Reader=ascii.NoHeader)
-    n    = len(data)
+    n = len(data)
 
     i = 0
-    while (i < =n-1):
+    while (i <= n-1):
         j = 0
         if (os.path.isfile(tmplog)):
             os.remove(tmplog)
-        while ((j < NRUNS) & (i < =n-1)):
-            INFITS_i  = data[i][0]
+        while ((j < NRUNS) & (i <= n-1)):
+            INFITS_i = data[i][0]
             OUTFITS_i = data[i][1]
-            tmpstr    = (f'python {path_train}data_collection/my_tractor_extract.py '+
-                        '-i '+INFITS_i+' '+
-                        '-o '+OUTFITS_i+' '+
-                        '-r '+RELEASE+' '+
-                        '-rd '+RADEC+' '+
-                        '-s '+SELCRIT+' '+
-                        '-l '+tmplog+' &')
+            tmpstr = (f'python {path_train}data_collection/my_tractor_extract.py ' +
+                      '-i ' + INFITS_i + ' ' +
+                      '-o ' + OUTFITS_i + ' ' +
+                      '-r ' + RELEASE + ' ' +
+                      '-rd ' + RADEC + ' ' +
+                      '-s ' + SELCRIT + ' ' +
+                      '-l ' + tmplog + ' &')
             print('i='+str(i)+' , j='+str(j)+' , '+tmpstr)
             subprocess.call(tmpstr, shell=True)
             j += 1
             i += 1
         # we wait for the runs to finish
         ndone = 0
-        while (ndone!=j):
+        while (ndone != j):
             if (os.path.isfile(tmplog)):
                 tmpstr = "wc -l "+tmplog+" | awk '{print $1}'"
-                p1     = subprocess.Popen(tmpstr, stdout=subprocess.PIPE, shell=True)
-                ndone  = int(p1.communicate()[0].decode('ascii').split('\n')[0])
+                p1 = subprocess.Popen(tmpstr, stdout=subprocess.PIPE, shell=True)
+                ndone = int(p1.communicate()[0].decode('ascii').split('\n')[0])
             print('i='+str(i)+'/'+str(n)+' , j='+str(j)+' , ndone='+str(ndone)+' ['+datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")+']')
             time.sleep(10)
 

--- a/py/desitarget/train/data_collection/sweep_meta.py
+++ b/py/desitarget/train/data_collection/sweep_meta.py
@@ -5,6 +5,7 @@ import subprocess
 import numpy as np
 import astropy.io.fits as fits
 
+
 def sweep_meta(release, outfits):
     if (release == 'dr3'):
         sweepdir = '/global/project/projectdirs/cosmo/data/legacysurvey/dr3/sweep/3.1'
@@ -16,9 +17,9 @@ def sweep_meta(release, outfits):
         sweepdir = '/global/project/projectdirs/cosmo/data/legacysurvey/dr6/sweep/6.0'
     if (release == 'dr7'):
         sweepdir = '/global/project/projectdirs/cosmo/data/legacysurvey/dr7/sweep/7.1'
-    if (release == 'dr8n'): #BASS/MzLS
+    if (release == 'dr8n'):  # BASS/MzLS
         sweepdir = '/global/project/projectdirs/cosmo/data/legacysurvey/dr8/north/sweep/8.0'
-    if (release == 'dr8s'): #DECaLS
+    if (release == 'dr8s'):  # DECaLS
         sweepdir = '/global/project/projectdirs/cosmo/data/legacysurvey/dr8/south/sweep/8.0'
     if (release == 'dr9n'):
         sweepdir = '/global/cscratch1/sd/adamyers/dr9m/north/sweep/'
@@ -38,11 +39,11 @@ def sweep_meta(release, outfits):
         sweep = sweeplist[i]
         ramin[i] = float(sweep[6:9])
         ramax[i] = float(sweep[14:17])
-        if (sweep[ 9] == 'm') :
+        if (sweep[9] == 'm'):
             decmin[i] = -1. * float(sweep[10:13])
         else:
             decmin[i] = float(sweep[10:13])
-        if (sweep[17] == 'm') :
+        if (sweep[17] == 'm'):
             decmax[i] = -1. * float(sweep[18:21])
         else:
             decmax[i] = float(sweep[18:21])

--- a/py/desitarget/train/data_preparation/PredCountsFromQLF_ClassModule.py
+++ b/py/desitarget/train/data_preparation/PredCountsFromQLF_ClassModule.py
@@ -6,6 +6,7 @@ import numpy as np
 from scipy.interpolate import interp2d
 from scipy.interpolate import interp1d
 
+
 class PredCountsFromQLF_Class():
     def __init__(self):
         self.QLF_OK = False
@@ -51,14 +52,14 @@ class PredCountsFromQLF_Class():
         self.QLF4Compl_dNdzdmag = None
         self.Compl_dzdmag = None
 
-    def LoadQLF_Data(self, fpn_QLF_Data, mMzred = np.array([0., 6.]), skyArea = 10000.):
+    def LoadQLF_Data(self, fpn_QLF_Data, mMzred=np.array([0., 6.]), skyArea=10000.):
         # Data loading in "dataStr"
-        dataStr = np.loadtxt(fpn_QLF_Data, dtype = str, delimiter = '\n')
+        dataStr = np.loadtxt(fpn_QLF_Data, dtype=str, delimiter='\n')
         self.QLF_nz = len(re.findall(r'\d+(?:\.\d+)?', dataStr[0])) - 1
         self.QLF_nmag = len(dataStr)
 
         # ZRED
-        self.QLF_zlimit = np.linspace(mMzred[0], mMzred[1], self.QLF_nz + 1, endpoint = True)
+        self.QLF_zlimit = np.linspace(mMzred[0], mMzred[1], self.QLF_nz + 1, endpoint=True)
         self.QLF_stepz = self.QLF_zlimit[1] - self.QLF_zlimit[0]
         # self.QLF_tabz = self.QLF_zlimit[0:-1] + self.QLF_stepz / 2.
 
@@ -67,9 +68,9 @@ class PredCountsFromQLF_Class():
 
         for nL, line in enumerate(dataStr):
             dNdzdmag = re.findall(r'\d+(?:\.\d+)?', line)
-            dNdzdmag  = np.asarray(dNdzdmag ).astype(np.float)
-            self.QLF_tabmag[nL] = dNdzdmag [0]
-            self.QLF_dNdzdmag[nL + 1, 1:] = dNdzdmag [1:]
+            dNdzdmag = np.asarray(dNdzdmag).astype(np.float)
+            self.QLF_tabmag[nL] = dNdzdmag[0]
+            self.QLF_dNdzdmag[nL + 1, 1:] = dNdzdmag[1:]
 
         self.QLF_stepmag = self.QLF_tabmag[1] - self.QLF_tabmag[0]
 
@@ -81,7 +82,7 @@ class PredCountsFromQLF_Class():
         self.QLF_dNdzdmag /= skyArea
 
         self.QLF_Ndzdmag = np.cumsum(np.cumsum(
-            self.QLF_dNdzdmag, axis = 0), axis = 1)
+            self.QLF_dNdzdmag, axis=0), axis=1)
 
         self.QLF_OK = True
         self.QLF_EFF_OK = False
@@ -100,9 +101,9 @@ class PredCountsFromQLF_Class():
             self.QLF_EFF_zlimit = np.unique(np.hstack((self.QLF_zlimit, self.EFF_zlimit)))
 
             maxQLF_EFF_zlimit = min(float(np.max(self.QLF_zlimit)),
-                                     float(np.max(self.EFF_zlimit)))
+                                    float(np.max(self.EFF_zlimit)))
             minQLF_EFF_zlimit = max(float(np.min(self.QLF_zlimit)),
-                                     float(np.min(self.EFF_zlimit)))
+                                    float(np.min(self.EFF_zlimit)))
             test = (self.QLF_EFF_zlimit >= minQLF_EFF_zlimit) & \
                    (self.QLF_EFF_zlimit <= maxQLF_EFF_zlimit)
 
@@ -111,12 +112,12 @@ class PredCountsFromQLF_Class():
             # QLF_EFFmaglimit
             self.QLF_EFF_maglimit = np.unique(
                 np.hstack((self.QLF_maglimit,
-                             self.EFF_maglimit)))
+                           self.EFF_maglimit)))
 
             maxQLF_EFF_maglimit = min(float(np.max(self.QLF_maglimit)),
-                                       float(np.max(self.EFF_maglimit)))
+                                      float(np.max(self.EFF_maglimit)))
             minQLF_EFF_maglimit = max(float(np.min(self.QLF_maglimit)),
-                                       float(np.min(self.EFF_maglimit)))
+                                      float(np.min(self.EFF_maglimit)))
             test = (self.QLF_EFF_maglimit >= minQLF_EFF_maglimit) & \
                    (self.QLF_EFF_maglimit <= maxQLF_EFF_maglimit)
 
@@ -130,11 +131,11 @@ class PredCountsFromQLF_Class():
             y = self.EFF_maglimit.flatten()
             z = self.EFF_dzdmag
 
-#==============================================================================
+# ==============================================================================
 #             f2d_EFF = interp2d(x, y, z, kind = 'linear',
 #                                 copy = True, bounds_error = True)
 #             interpEFF_dzdmag = f2d_EFF(xnew, ynew)
-#==============================================================================
+# ==============================================================================
 
             interpXinds = np.digitize(xnew, x, right=True) - 1
             interpXinds = np.maximum(interpXinds, 0)
@@ -145,7 +146,7 @@ class PredCountsFromQLF_Class():
             interpXYgridInds = np.meshgrid(interpXinds, interpYinds)
 
             self.interpEFF_dzdmag = z[interpXYgridInds[1],
-                                       interpXYgridInds[0]]
+                                      interpXYgridInds[0]]
 
             # QLF
             x = self.QLF_zlimit.flatten()
@@ -174,11 +175,11 @@ class PredCountsFromQLF_Class():
             assert(np.min(zlimit) >= np.min(xnew))
             assert(np.max(zlimit) <= np.max(xnew))
 
-            interpQLF_dNdz = np.sum(self.interpQLF_dNdzdmag, axis = 0)
+            interpQLF_dNdz = np.sum(self.interpQLF_dNdzdmag, axis=0)
             interpQLF_Ndz = np.cumsum(interpQLF_dNdz)
 
             # QLF_EFF dNdz
-            interpQLF_EFF_dNdz = np.sum(self.interpQLF_EFF_dNdzdmag, axis = 0)
+            interpQLF_EFF_dNdz = np.sum(self.interpQLF_EFF_dNdzdmag, axis=0)
             interpQLF_EFF_Ndz = np.cumsum(interpQLF_EFF_dNdz)
 
             f1d_QLF_EFF = interp1d(xnew, interpQLF_EFF_Ndz, kind='linear', copy=True, bounds_error=True)
@@ -257,7 +258,7 @@ class PredCountsFromQLF_Class():
 
             self.QLF4Compl_dNdzdmag = QLF4Compl_dNdzdmag
 
-            self.Compl_dzdmag = self.QLF_EFF4Compl_dNdzdmag[1:,1:] / self.QLF4Compl_dNdzdmag[1:,1:]
+            self.Compl_dzdmag = self.QLF_EFF4Compl_dNdzdmag[1:, 1:] / self.QLF4Compl_dNdzdmag[1:, 1:]
             self.Compl_dzdmag[np.isnan(self.Compl_dzdmag)] = 0.
 
             return self.Compl_dzdmag
@@ -267,7 +268,7 @@ class PredCountsFromQLF_Class():
         self.Eff4Compl_dzdmag = np.copy(self.Compl_dzdmag)
 
         if True:
-            self.EffVar4Compl_dzdmag = self.Eff4Compl_dzdmag * (1. -  self.Eff4Compl_dzdmag)
+            self.EffVar4Compl_dzdmag = self.Eff4Compl_dzdmag * (1. - self.Eff4Compl_dzdmag)
             self.EffVar4Compl_dzdmag /= OBJ_QSO_dNdzdmag
             self.EffVar4Compl_dzdmag[OBJ_QSO_dNdzdmag == 0.] = 0.
         else:
@@ -280,10 +281,10 @@ class PredCountsFromQLF_Class():
         return self.EffVar4Compl_dzdmag
 
     def ZRED_EffVarEvalFunc(self):
-        self.EffVar4Compl_dz = self.EffVar4Compl_dzdmag * (self.QLF4Compl_dNdzdmag[1:,1:])**2
+        self.EffVar4Compl_dz = self.EffVar4Compl_dzdmag * (self.QLF4Compl_dNdzdmag[1:, 1:])**2
 
-        self.EffVar4Compl_dz = np.sum(self.EffVar4Compl_dz, axis = 0)
-        tmp_var = np.sum(self.QLF4Compl_dNdzdmag[1:,1:], axis = 0)**2
+        self.EffVar4Compl_dz = np.sum(self.EffVar4Compl_dz, axis=0)
+        tmp_var = np.sum(self.QLF4Compl_dNdzdmag[1:, 1:], axis=0)**2
         self.EffVar4Compl_dz /= tmp_var
 
         self.EffVar4Compl_dz[tmp_var == 0.] = 0.
@@ -291,10 +292,10 @@ class PredCountsFromQLF_Class():
         return self.EffVar4Compl_dz
 
     def R_EffVarEvalFunc(self):
-        self.EffVar4Compl_dmag = self.EffVar4Compl_dzdmag * (self.QLF4Compl_dNdzdmag[1:,1:])**2
+        self.EffVar4Compl_dmag = self.EffVar4Compl_dzdmag * (self.QLF4Compl_dNdzdmag[1:, 1:])**2
 
-        self.EffVar4Compl_dmag = np.sum(self.EffVar4Compl_dmag, axis = 1)
-        tmp_var = np.sum(self.QLF4Compl_dNdzdmag[1:,1:], axis = 1)**2
+        self.EffVar4Compl_dmag = np.sum(self.EffVar4Compl_dmag, axis=1)
+        tmp_var = np.sum(self.QLF4Compl_dNdzdmag[1:, 1:], axis=1)**2
         self.EffVar4Compl_dmag /= tmp_var
 
         self.EffVar4Compl_dmag[tmp_var == 0.] = 0.

--- a/py/desitarget/train/data_preparation/funcs.py
+++ b/py/desitarget/train/data_preparation/funcs.py
@@ -6,10 +6,9 @@ import operator
 import collections
 import numpy as np
 
-#------------------------------------------------------------------------------
+# ***Fonction qui produit un string formaté pour afficher une durée à partir
+# d'une quantité donnée en secondes***
 
-#***Fonction qui produit un string formaté pour afficher une durée à partir
-#   d'une quantité donnée en secondes***
 
 def Time2StrFunc(tm):
     tmStr = []
@@ -30,11 +29,10 @@ def Time2StrFunc(tm):
         tmStr.append("{:d} h".format(int(var_tm[0])))
 
     tmStr = tmStr[::-1]
-    tmStr = reduce(lambda a, b : a + ' - ' + b, tmStr)
+    tmStr = reduce(lambda a, b: a + ' - ' + b, tmStr)
 
     return tmStr
 
-#------------------------------------------------------------------------------
 
 def shift_photo_north(gflux=None, rflux=None, zflux=None):
     """Convert fluxes in the northern (BASS/MzLS) to the southern (DECaLS) system.
@@ -65,7 +63,6 @@ def shift_photo_north(gflux=None, rflux=None, zflux=None):
 
     return gshift, rshift, zshift
 
-#------------------------------------------------------------------------------
 
 def _Flux2MagFunc(OBJ_Data_flux, OBJ_Data_mw_transmission):
     OBJ_flux = OBJ_Data_flux/OBJ_Data_mw_transmission
@@ -77,25 +74,24 @@ def _Flux2MagFunc(OBJ_Data_flux, OBJ_Data_mw_transmission):
 
     return OBJ_mag
 
-#------------------------------------------------------------------------------
 
 def Flux2MagFunc(dataArray):
-    gflux  = dataArray.FLUX_G[:]/dataArray.MW_TRANSMISSION_G[:]
-    rflux  = dataArray.FLUX_R[:]/dataArray.MW_TRANSMISSION_R[:]
-    zflux  = dataArray.FLUX_Z[:]/dataArray.MW_TRANSMISSION_Z[:]
+    gflux = dataArray.FLUX_G[:]/dataArray.MW_TRANSMISSION_G[:]
+    rflux = dataArray.FLUX_R[:]/dataArray.MW_TRANSMISSION_R[:]
+    zflux = dataArray.FLUX_Z[:]/dataArray.MW_TRANSMISSION_Z[:]
     W1flux = dataArray.FLUX_W1[:]/dataArray.MW_TRANSMISSION_W1[:]
     W2flux = dataArray.FLUX_W2[:]/dataArray.MW_TRANSMISSION_W2[:]
 
-    limitInf=1.e-04
+    limitInf = 1.e-04
     gflux = gflux.clip(limitInf)
     rflux = rflux.clip(limitInf)
     zflux = zflux.clip(limitInf)
     W1flux = W1flux.clip(limitInf)
     W2flux = W2flux.clip(limitInf)
 
-    g = np.where(gflux > limitInf,22.5-2.5*np.log10(gflux), 0.)
-    r = np.where(rflux > limitInf,22.5-2.5*np.log10(rflux), 0.)
-    z = np.where(zflux > limitInf,22.5-2.5*np.log10(zflux), 0.)
+    g = np.where(gflux > limitInf, 22.5-2.5*np.log10(gflux), 0.)
+    r = np.where(rflux > limitInf, 22.5-2.5*np.log10(rflux), 0.)
+    z = np.where(zflux > limitInf, 22.5-2.5*np.log10(zflux), 0.)
     W1 = np.where(W1flux > limitInf, 22.5-2.5*np.log10(W1flux), 0.)
     W2 = np.where(W2flux > limitInf, 22.5-2.5*np.log10(W2flux), 0.)
 
@@ -110,73 +106,72 @@ def Flux2MagFunc(dataArray):
     W2[np.isnan(W2)] = 0.
     W2[np.isinf(W2)] = 0.
 
-    return g,r,z,W1,W2
+    return g, r, z, W1, W2
 
-#------------------------------------------------------------------------------
 
-def ColorsFunc(nbEntries,nfeatures,g,r,z,W1,W2):
-    colors  = np.zeros((nbEntries,nfeatures))
+def ColorsFunc(nbEntries, nfeatures, g, r, z, W1, W2):
+    colors = np.zeros((nbEntries, nfeatures))
 
-    colors[:,0] = g-r
-    colors[:,1] = r-z
-    colors[:,2] = g-z
-    colors[:,3] = g-W1
-    colors[:,4] = r-W1
-    colors[:,5] = z-W1
-    colors[:,6] = g-W2
-    colors[:,7] = r-W2
-    colors[:,8] = z-W2
-    colors[:,9] = W1-W2
-    colors[:,10] = r
+    colors[:, 0] = g-r
+    colors[:, 1] = r-z
+    colors[:, 2] = g-z
+    colors[:, 3] = g-W1
+    colors[:, 4] = r-W1
+    colors[:, 5] = z-W1
+    colors[:, 6] = g-W2
+    colors[:, 7] = r-W2
+    colors[:, 8] = z-W2
+    colors[:, 9] = W1-W2
+    colors[:, 10] = r
 
     return colors
 
-#------------------------------------------------------------------------------
 
 def GetColorsFunc(data, color_names):
     colors = np.zeros((len(data), len(color_names)))
     for i, col_name in enumerate(color_names):
-        colors[:,i] = data[col_name]
+        colors[:, i] = data[col_name]
     return colors
 
-#------------------------------------------------------------------------------
 
 def AreaFunc(dec1, dec2, alpha1, alpha2):
     res = (alpha2 - alpha1) * (np.sin(dec2) - np.sin(dec1)) * (180./np.pi)**2
     return res
 
-#------------------------------------------------------------------------------
 
 def RA_DEC_AreaFunc(OBJ_RA, OBJ_DEC, binVect_RA, binVect_DEC, N_OBJ_th=2):
     RA_DEC_meshgrid = np.meshgrid(binVect_RA, binVect_DEC)
     OBJ_dNdRAdDEC = np.histogram2d(x=OBJ_DEC, y=OBJ_RA, bins=[binVect_DEC, binVect_RA])[0]
     med_OBJ_dNdRAdDEC = np.median(OBJ_dNdRAdDEC)
     skyArea_meshgrid = AreaFunc(RA_DEC_meshgrid[1][0:-1, 0:-1] * np.pi/180.,
-                                 RA_DEC_meshgrid[1][1:, 0:-1] * np.pi/180.,
-                                 RA_DEC_meshgrid[0][0:-1, 0 :-1] * np.pi/180.,
-                                 RA_DEC_meshgrid[0][0:-1, 1:] * np.pi/180.)
+                                RA_DEC_meshgrid[1][1:, 0:-1] * np.pi/180.,
+                                RA_DEC_meshgrid[0][0:-1, 0:-1] * np.pi/180.,
+                                RA_DEC_meshgrid[0][0:-1, 1:] * np.pi/180.)
     area_OK = (OBJ_dNdRAdDEC) >= N_OBJ_th
     res_area = np.sum(skyArea_meshgrid[area_OK])
     return res_area, med_OBJ_dNdRAdDEC
 
-#------------------------------------------------------------------------------
 
 def getFromDict(dataDict, mapList):
     return reduce(operator.getitem, mapList, dataDict)
 
+
 def setInDict(dataDict, mapList, value):
     getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
+
 
 def speGetFromDict(dataDict, tag):
     mapList = tag.split(':')
     return getFromDict(dataDict, mapList)
 
+
 def speSetInDict(dataDict, tag, value):
     mapList = tag.split(':')
     getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
 
-# 'RecursiveHyParamDictExplorationFunc' = 'Tree2FlatHyParamDictConversionFunc'
+
 def RecHyParamDictExplFunc(hyParamDict):
+    # 'RecursiveHyParamDictExplorationFunc' = 'Tree2FlatHyParamDictConversionFunc'
     new_dict = collections.OrderedDict()
     for key, value in hyParamDict.items():
         if (type(value) == dict) or (type(value) == collections.OrderedDict):
@@ -188,8 +183,9 @@ def RecHyParamDictExplFunc(hyParamDict):
             new_dict[key] = value
     return new_dict
 
-# 'Flat2TreeHyParamDictConversionFunc'
+
 def Flat2TreeHyParamConvFunc(coords, hyParamDictTemplate, hyParamSpaceTags, hyParamSpaceItems):
+    # 'Flat2TreeHyParamDictConversionFunc'
     for it, indEl in enumerate(coords):
         tag = hyParamSpaceTags[it]
         value = hyParamSpaceItems[it][indEl]

--- a/py/desitarget/train/data_preparation/make_test_sample.py
+++ b/py/desitarget/train/data_preparation/make_test_sample.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-#****************************************
+# ****************************************
 # MAKE TEST SAMPLE
-#****************************************
+# ****************************************
 
 import argparse
 import numpy as np
@@ -11,10 +11,11 @@ import astropy.io.fits as pyfits
 
 from desitarget.train.data_preparation.funcs import shift_photo_north, Flux2MagFunc, ColorsFunc, AreaFunc
 
+
 def make_test_sample(fpn_input, fpn_output, RELEASE='DR9', is_north=False):
-    #***CONFIGURATION***
+    # ***CONFIGURATION***
     min_rmag = 17.5
-    max_rmag = 23.0 # 23.5 pour SV avec DR8/9 ?
+    max_rmag = 23.0  # 23.5 pour SV avec DR8/9 ?
 
     # Selection criteria
     OBJ_extraSelCMD = ""
@@ -32,10 +33,10 @@ def make_test_sample(fpn_input, fpn_output, RELEASE='DR9', is_north=False):
         OBJ_extraSelCMD += " & (OBJ_W1mag > 0.)"
         OBJ_extraSelCMD += " & (OBJ_W2mag > 0.)"
         print("MASKBIT USED : 1, 11, 12, 13 ")
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 1))   == 0)" # 'BRIGHT'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 11))  == 0)" # 'MEDIUM'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 12))  == 0)" # 'GALAXY'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 13))  == 0)" # 'CLUSTER'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 1))   == 0)"  # 'BRIGHT'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 11))  == 0)"  # 'MEDIUM'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 12))  == 0)"  # 'GALAXY'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 13))  == 0)"  # 'CLUSTER'
     elif RELEASE == 'DR9':
         OBJ_extraKeys = ['MASKBITS']
         OBJ_extraSelCMD += "OBJ_selection_OK &= True"
@@ -43,17 +44,17 @@ def make_test_sample(fpn_input, fpn_output, RELEASE='DR9', is_north=False):
         OBJ_extraSelCMD += " & (OBJ_W1mag > 0.)"
         OBJ_extraSelCMD += " & (OBJ_W2mag > 0.)"
         print("MASKBIT USED : 1, 5, 6, 7, 10, 12, 13 ")
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 1))   == 0)" # 'BRIGHT'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 5))  == 0)" # 'MEDIUM'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 6))  == 0)" # 'GALAXY'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 7))  == 0)" # 'CLUSTER'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 10))  == 0)" # 'MEDIUM'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 12))  == 0)" # 'GALAXY'
-        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 13))  == 0)" # 'CLUSTER'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 1))   == 0)"  # 'BRIGHT'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 5))  == 0)"  # 'MEDIUM'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 6))  == 0)"  # 'GALAXY'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 7))  == 0)"  # 'CLUSTER'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 10))  == 0)"  # 'MEDIUM'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 12))  == 0)"  # 'GALAXY'
+        OBJ_extraSelCMD += " & ((OBJ_MASKBITS & np.power(2, 13))  == 0)"  # 'CLUSTER'
     else:
         assert(False), "'RELEASE' unvailable !"
 
-    #***OBJ DATA LOADING & SELECTION***
+    # ***OBJ DATA LOADING & SELECTION***
 
     # Data loading
     OBJ_data = pyfits.open(fpn_input, memmap=True)[1].data
@@ -66,7 +67,7 @@ def make_test_sample(fpn_input, fpn_output, RELEASE='DR9', is_north=False):
         OBJ_data.FLUX_G, OBJ_data.FLUX_R, OBJ_data.FLUX_Z = shift_photo_north(OBJ_data.FLUX_G, OBJ_data.FLUX_R, OBJ_data.FLUX_Z)
 
     # Flux to magnitudes
-    OBJ_gmag , OBJ_rmag , OBJ_zmag , OBJ_W1mag , OBJ_W2mag = Flux2MagFunc(OBJ_data)
+    OBJ_gmag, OBJ_rmag, OBJ_zmag, OBJ_W1mag, OBJ_W2mag = Flux2MagFunc(OBJ_data)
 
     # Data selection
     OBJ_selection_OK = (OBJ_gmag > 0.) & (OBJ_rmag > 0.) & (OBJ_zmag > 0.)
@@ -74,11 +75,11 @@ def make_test_sample(fpn_input, fpn_output, RELEASE='DR9', is_north=False):
 
     # Extra data selection
     for key in OBJ_extraKeys:
-    	exec('OBJ_' + key + " = OBJ_data['" + key + "']")
+        exec('OBJ_' + key + " = OBJ_data['" + key + "']")
     exec(OBJ_extraSelCMD)
 
     n_OBJ = np.sum(OBJ_selection_OK)
-    assert(n_OBJ > 0) , 'No OBJ'
+    assert(n_OBJ > 0), 'No OBJ'
 
     # Reduction !
     OBJ_data = OBJ_data[OBJ_selection_OK]
@@ -102,9 +103,7 @@ def make_test_sample(fpn_input, fpn_output, RELEASE='DR9', is_north=False):
     print("n_OBJ :", n_OBJ)
     print("n_QSO :", n_QSO)
 
-    #------------------------------------------------------------------------------
-
-    #***COMPUTE AND ADD COLORS***
+    # ***COMPUTE AND ADD COLORS***
 
     color_names = ['g_r', 'r_z', 'g_z', 'g_W1', 'r_W1', 'z_W1', 'g_W2', 'r_W2', 'z_W2', 'W1_W2', 'r']
     n_colors = len(color_names)
@@ -116,10 +115,10 @@ def make_test_sample(fpn_input, fpn_output, RELEASE='DR9', is_north=False):
     OBJ_Colors = ColorsFunc(n_OBJ, n_colors, OBJ_gmag, OBJ_rmag, OBJ_zmag, OBJ_W1mag, OBJ_W2mag)
 
     for i, col_name in enumerate(color_names):
-        col = pyfits.Column(name=col_name, format='D', array=OBJ_Colors[:,i])
+        col = pyfits.Column(name=col_name, format='D', array=OBJ_Colors[:, i])
         list_cols.append(col)
 
-    OBJ_hdu = pyfits.BinTableHDU(data = OBJ_data)
+    OBJ_hdu = pyfits.BinTableHDU(data=OBJ_data)
     if is_north:
         for i, col_name in enumerate(['FLUX_G', 'FLUX_R', 'FLUX_Z']):
             col = pyfits.Column(name=col_name + '_s',  format='D', array=OBJ_data[col_name].copy())
@@ -128,9 +127,7 @@ def make_test_sample(fpn_input, fpn_output, RELEASE='DR9', is_north=False):
 
     OBJ_hdu = pyfits.BinTableHDU.from_columns(list(OBJ_hdu.columns) + list_cols)
 
-    #------------------------------------------------------------------------------
-
-    #***TEST SAMPLE STORING***
+    # ***TEST SAMPLE STORING***
 
     OBJ_hdu.writeto(fpn_output, overwrite=True)
     print("Save :", fpn_output)

--- a/py/desitarget/train/data_preparation/make_training_samples.py
+++ b/py/desitarget/train/data_preparation/make_training_samples.py
@@ -1,36 +1,32 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-#****************************************
+# ****************************************
 # MAKE STARS & QSO TRAINING SAMPLES
-#****************************************
-
-import warnings
-warnings.simplefilter("ignore")
-
-import numpy as np
-import astropy.io.fits as pyfits
-
+# ****************************************
 from terminaltables import DoubleTable
 from desitarget.train.data_preparation.funcs import Flux2MagFunc, ColorsFunc
 from desitarget.train.data_preparation.PredCountsFromQLF_ClassModule import PredCountsFromQLF_Class
 
-#------------------------------------------------------------------------------
-#***QLF DATA FILE PATH NAME***
+import numpy as np
+import astropy.io.fits as pyfits
+import warnings
+warnings.simplefilter("ignore")
+
+# ***QLF DATA FILE PATH NAME***
 
 fpn_QLF_data = '../../py/desitarget/train/data_preparation/ROSS4_tabR.txt'
 
-#------------------------------------------------------------------------------
-#***STARS & QSO INPUT/OUTPUT FILE PATH NAMES***
+# ***STARS & QSO INPUT/OUTPUT FILE PATH NAMES***
+
 
 def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_STARS_output):
-    #for test : remove_test_region --> False ect...
+    # for test : remove_test_region --> False ect...
     remove_test_region = True
 
-    #------------------------------------------------------------------------------
-    #***CONFIGURATION***
+    # ***CONFIGURATION***
 
-    NORM_MODE = "NORMALIZE_PER_RMAG_BINS" # "NORMALIZE_PER_RMAG_BINS" by default
+    NORM_MODE = "NORMALIZE_PER_RMAG_BINS"  # "NORMALIZE_PER_RMAG_BINS" by default
     initRndm = 666
 
     # zred bins
@@ -49,10 +45,9 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     # Need to find a balance between acceptable errors in the measured data and
     # good representativeness of the photometric scattering inherent to QSO.
     # (ML model has to be trained over data which match real photo. data)
-    QSO_MAX_MAG_ERR_LEVEL = 0.02 # 0.02 by default
+    QSO_MAX_MAG_ERR_LEVEL = 0.02  # 0.02 by default
 
-    #------------------------------------------------------------------------------
-    #***FUNCTION***
+    # ***FUNCTION***
     def MAG_ERR_Func(FLUX, FLUX_IVAR):
         res = 2.5/np.log(10.)
         res /= (np.abs(FLUX)*np.sqrt(FLUX_IVAR))
@@ -61,38 +56,33 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
         res[res < 0.] = 0.
         return res
 
-    #------------------------------------------------------------------------------
-
     zred_binVect = np.arange(min_zred, max_zred + zred_binStep/2., zred_binStep)
 
     rmag_binVect = np.trunc(np.arange(min_rmag, max_rmag + rmag_binStep/2., rmag_binStep)*10.)/10.
     rmag_binVect = np.minimum(rmag_binVect, max_rmag)
     n_rmag_bin = rmag_binVect.size - 1
 
-    #------------------------------------------------------------------------------
-    #***CHECK "NORM_MODE" VALIDITY***
+    # ***CHECK "NORM_MODE" VALIDITY***
     if (NORM_MODE != "NORMALIZE_PER_RMAG_BINS"):
         assert(False), "NORM_MODE {:s} non valid".format(NORM_MODE)
 
-    #------------------------------------------------------------------------------
-    #***COMPUTE QLF4Compl_dNdrmag***
+    # ***COMPUTE QLF4Compl_dNdrmag***
     predCountsObj = PredCountsFromQLF_Class()
     predCountsObj.LoadQLF_Data(fpn_QLF_data)
 
     # Fictive efficiency required by "predCountsObj"
     tmp_eff = np.ones((n_rmag_bin, zred_binVect.size - 1))
 
-    predCountsObj.LoadEffData(tmp_eff, zred_binVect, rmag_binVect )
+    predCountsObj.LoadEffData(tmp_eff, zred_binVect, rmag_binVect)
     predCountsObj.PrelOpFunc()
     predCountsObj.R_ZREDComplEvalFunc(zred_binVect, rmag_binVect)
-    QLF4Compl_dNdzdrmag = predCountsObj.QLF4Compl_dNdzdmag[1:,1:]
+    QLF4Compl_dNdzdrmag = predCountsObj.QLF4Compl_dNdzdmag[1:, 1:]
 
-    QLF4Compl_dNdrmag = np.sum(QLF4Compl_dNdzdrmag, axis = 1)
+    QLF4Compl_dNdrmag = np.sum(QLF4Compl_dNdzdrmag, axis=1)
 
-    #------------------------------------------------------------------------------
-    #***STARS SELECTION***
+    # ***STARS SELECTION***
 
-    STARS_data = pyfits.open(fpn_STARS_input, memmap = True)[1].data
+    STARS_data = pyfits.open(fpn_STARS_input, memmap=True)[1].data
     n_STARS = len(STARS_data)
     print("n_STARS initial :", n_STARS)
 
@@ -107,19 +97,19 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     # STARS_noBSinBLOB_OK = ~STARS_data['BRIGHTSTARINBLOB']
     # "http://legacysurvey.org/dr9/bitmasks/"
     print("[WARNING] REMOVE FROM THE STARS TRAINING maskbits 1, 5, 6, 7, 10, 12, 13")
-    STARS_maskbits_OK  = (STARS_data['MASKBITS'] & np.power(2, 1))  == 0 # 'BRIGHT'
-    STARS_maskbits_OK  = (STARS_data['MASKBITS'] & np.power(2, 5))  == 0
-    STARS_maskbits_OK  = (STARS_data['MASKBITS'] & np.power(2, 6))  == 0
-    STARS_maskbits_OK  = (STARS_data['MASKBITS'] & np.power(2, 7))  == 0
-    STARS_maskbits_OK &= (STARS_data['MASKBITS'] & np.power(2, 10)) == 0 # 'BLOP'
-    STARS_maskbits_OK &= (STARS_data['MASKBITS'] & np.power(2, 12)) == 0 # 'GALAXY'
-    STARS_maskbits_OK &= (STARS_data['MASKBITS'] & np.power(2, 13)) == 0 # 'CLUSTER'
+    STARS_maskbits_OK = (STARS_data['MASKBITS'] & np.power(2, 1)) == 0  # 'BRIGHT'
+    STARS_maskbits_OK = (STARS_data['MASKBITS'] & np.power(2, 5)) == 0
+    STARS_maskbits_OK = (STARS_data['MASKBITS'] & np.power(2, 6)) == 0
+    STARS_maskbits_OK = (STARS_data['MASKBITS'] & np.power(2, 7)) == 0
+    STARS_maskbits_OK &= (STARS_data['MASKBITS'] & np.power(2, 10)) == 0  # 'BLOP'
+    STARS_maskbits_OK &= (STARS_data['MASKBITS'] & np.power(2, 12)) == 0  # 'GALAXY'
+    STARS_maskbits_OK &= (STARS_data['MASKBITS'] & np.power(2, 13)) == 0  # 'CLUSTER'
 
     STARS_NOBS_OK = ((STARS_data.NOBS_G >= STARS_NOBS_MIN) &
-                      (STARS_data.NOBS_R >= STARS_NOBS_MIN) &
-                      (STARS_data.NOBS_Z >= STARS_NOBS_MIN) &
-                      (STARS_data.NOBS_W1 >= STARS_NOBS_MIN) &
-                      (STARS_data.NOBS_W2 >= STARS_NOBS_MIN))
+                     (STARS_data.NOBS_R >= STARS_NOBS_MIN) &
+                     (STARS_data.NOBS_Z >= STARS_NOBS_MIN) &
+                     (STARS_data.NOBS_W1 >= STARS_NOBS_MIN) &
+                     (STARS_data.NOBS_W2 >= STARS_NOBS_MIN))
 
     # Already pre-sel PSF during data collection on NERSC
     STARS_PSF_OK = STARS_data['TYPE'] == "PSF"
@@ -128,10 +118,10 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     noTestRegion_OK = ~ ((STARS_data.RA <= 45.) & (STARS_data.RA >= 30.) & (np.abs(STARS_data.DEC) <= 5.))
 
     # STARS_OK =  STARS_rmag_OK & STARS_g_z_W1_W2_mag_OK & STARS_noBSinBLOB_OK
-    STARS_OK =  STARS_rmag_OK & STARS_g_z_W1_W2_mag_OK & STARS_maskbits_OK
+    STARS_OK = STARS_rmag_OK & STARS_g_z_W1_W2_mag_OK & STARS_maskbits_OK
     STARS_OK &= STARS_NOBS_OK & STARS_PSF_OK
 
-    if remove_test_region :
+    if remove_test_region:
         STARS_OK &= noTestRegion_OK
 
     STARS_data = STARS_data[STARS_OK]
@@ -141,10 +131,9 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     print("n_STARS after selection/before normalization :", n_STARS)
     print()
 
-    #------------------------------------------------------------------------------
-    #***QSO SELECTION***
+    # ***QSO SELECTION***
 
-    QSO_data = pyfits.open(fpn_QSO_input, memmap = True)[1].data
+    QSO_data = pyfits.open(fpn_QSO_input, memmap=True)[1].data
     n_QSO = len(QSO_data)
     print("n_QSO initial :", n_QSO)
 
@@ -159,13 +148,13 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     # QSO_noBSinBLOB_OK = ~QSO_data['BRIGHTSTARINBLOB']
     # "http://legacysurvey.org/dr8/bitmasks/"
     print("[WARNING] REMOVE FROM THE QSO TRAINING maskbits 1, 5, 6, 7, 10, 12, 13")
-    QSO_maskbits_OK  = (QSO_data['MASKBITS'] & np.power(2, 1))  == 0 # 'BRIGHT'
-    QSO_maskbits_OK  = (QSO_data['MASKBITS'] & np.power(2, 5))  == 0
-    QSO_maskbits_OK  = (QSO_data['MASKBITS'] & np.power(2, 6))  == 0
-    QSO_maskbits_OK  = (QSO_data['MASKBITS'] & np.power(2, 7))  == 0
-    QSO_maskbits_OK &= (QSO_data['MASKBITS'] & np.power(2, 10)) == 0 # 'BLOP'
-    QSO_maskbits_OK &= (QSO_data['MASKBITS'] & np.power(2, 12)) == 0 # 'GALAXY'
-    QSO_maskbits_OK &= (QSO_data['MASKBITS'] & np.power(2, 13)) == 0 # 'CLUSTER'
+    QSO_maskbits_OK = (QSO_data['MASKBITS'] & np.power(2, 1)) == 0  # 'BRIGHT'
+    QSO_maskbits_OK = (QSO_data['MASKBITS'] & np.power(2, 5)) == 0
+    QSO_maskbits_OK = (QSO_data['MASKBITS'] & np.power(2, 6)) == 0
+    QSO_maskbits_OK = (QSO_data['MASKBITS'] & np.power(2, 7)) == 0
+    QSO_maskbits_OK &= (QSO_data['MASKBITS'] & np.power(2, 10)) == 0  # 'BLOP'
+    QSO_maskbits_OK &= (QSO_data['MASKBITS'] & np.power(2, 12)) == 0  # 'GALAXY'
+    QSO_maskbits_OK &= (QSO_data['MASKBITS'] & np.power(2, 13)) == 0  # 'CLUSTER'
 
     # FatStripe82
     FatStripe82_OK = (QSO_data.RA <= 45.) & (QSO_data.RA >= 0.) & (np.abs(QSO_data.DEC) <= 5.)
@@ -193,10 +182,10 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
         (MAG_ERR_Func(QSO_data.FLUX_W1, QSO_data.FLUX_IVAR_W1) > 0))
 
     brightQSOutOfFatS82_exSel &= ((QSO_data.NOBS_G >= QSO_NOBS_MIN) &
-                                   (QSO_data.NOBS_R >= QSO_NOBS_MIN) &
-                                   (QSO_data.NOBS_Z >= QSO_NOBS_MIN) &
-                                   (QSO_data.NOBS_W1 >= QSO_NOBS_MIN) &
-                                   (QSO_data.NOBS_W2 >= QSO_NOBS_MIN))
+                                  (QSO_data.NOBS_R >= QSO_NOBS_MIN) &
+                                  (QSO_data.NOBS_Z >= QSO_NOBS_MIN) &
+                                  (QSO_data.NOBS_W1 >= QSO_NOBS_MIN) &
+                                  (QSO_data.NOBS_W2 >= QSO_NOBS_MIN))
 
     brightQSOutOfFatStripe82_OK &= brightQSOutOfFatS82_exSel
 
@@ -205,14 +194,14 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
 
     # Remove TestRegion --> we allready check that
     noTestRegion_OK = ~ ((QSO_data.RA <= 45.) & (QSO_data.RA >= 30.) &
-                          (np.abs(QSO_data.DEC) <= 5.))
+                         (np.abs(QSO_data.DEC) <= 5.))
 
     # QSO_OK
     # QSO_OK = QSO_rmag_OK & QSO_g_z_W1_W2_mag_OK & QSO_noBSinBLOB_OK
     QSO_OK = QSO_rmag_OK & QSO_g_z_W1_W2_mag_OK & QSO_maskbits_OK
     QSO_OK &= (FatStripe82_OK | brightQSOutOfFatStripe82_OK) & QSO_PSF_OK
 
-    if remove_test_region :
+    if remove_test_region:
         QSO_OK &= noTestRegion_OK
 
     QSO_data = QSO_data[QSO_OK]
@@ -225,18 +214,17 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     print()
 
     # QSO rmag histogram
-    QSO_dNdrmag = np.histogram(QSO_rmag, bins = rmag_binVect)[0]
+    QSO_dNdrmag = np.histogram(QSO_rmag, bins=rmag_binVect)[0]
 
-    #------------------------------------------------------------------------------
-    # Given only for informative purpose to assess the completeness of the sample
+    # Given only for informative purpose to assess sample completeness.
 
     max_QSO_dNdrmag_ind = np.argmax(QSO_dNdrmag)
     scale_factor = QLF4Compl_dNdrmag[max_QSO_dNdrmag_ind]/QSO_dNdrmag[max_QSO_dNdrmag_ind]
 
     QSO_W_drmag = QLF4Compl_dNdrmag/(scale_factor*QSO_dNdrmag)
-    QSO_W_drmag[QLF4Compl_dNdrmag == 0. ] = np.nan
-    QSO_W_drmag[np.isnan(QSO_W_drmag) ] = np.nan
-    QSO_W_drmag[np.isinf(QSO_W_drmag) ] = np.nan
+    QSO_W_drmag[QLF4Compl_dNdrmag == 0.] = np.nan
+    QSO_W_drmag[np.isnan(QSO_W_drmag)] = np.nan
+    QSO_W_drmag[np.isinf(QSO_W_drmag)] = np.nan
 
     if False:
         ref_QSO_dNdrmag_ind = np.nanargmin(QSO_W_drmag)
@@ -246,15 +234,14 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
         nw_QSO_target = n_QSO
         QSO_W_drmag *= nw_QSO_target/np.sum(QSO_dNdrmag*QSO_W_drmag)
 
-    QSO_W_drmag[QLF4Compl_dNdrmag == 0. ] = 1.
-    QSO_W_drmag[np.isnan(QSO_W_drmag) ] = 1.
-    QSO_W_drmag[np.isinf(QSO_W_drmag) ] = 1.
+    QSO_W_drmag[QLF4Compl_dNdrmag == 0.] = 1.
+    QSO_W_drmag[np.isnan(QSO_W_drmag)] = 1.
+    QSO_W_drmag[np.isinf(QSO_W_drmag)] = 1.
 
     w_QSO_dNdrmag = QSO_dNdrmag*QSO_W_drmag
     nw_QSO = np.sum(w_QSO_dNdrmag)
 
-    #-----------------------------------------------------------------------------
-    #***STARS rmag. DISTRIBUTION NORMALIZATION***
+    # ***STARS rmag. DISTRIBUTION NORMALIZATION***
     # Random generator seeding for reproducibility
     rs = np.random.RandomState(int(initRndm))
 
@@ -282,18 +269,18 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
             STARS_rnd_sel_ind = slice(None)
 
         STARS_sel_ind = np.arange(n_STARS)[STARS_drmag_OK][STARS_rnd_sel_ind]
-        list_STARS_sel_ind.extend(list(STARS_sel_ind.astype(np.int)) )
+        list_STARS_sel_ind.extend(list(STARS_sel_ind.astype(np.int)))
 
         tab2print.append(["{:.1f}".format(m_rmag), "{:.1f}".format(M_rmag),
-                            str(n_STARS_drmag), str(n_sel_STARS_drmag),
-                            str(n_QSO_drmag),
-                            str(int(w_QSO_dNdrmag[rmag_biNum]))])
+                          str(n_STARS_drmag), str(n_sel_STARS_drmag),
+                          str(n_QSO_drmag),
+                          str(int(w_QSO_dNdrmag[rmag_biNum]))])
 
     tab_title = "STARS/QSO TABLE"
     tab = DoubleTable(tab2print, tab_title)
     tab.inner_row_border = True
-    tab.justify_columns = {0:'center', 1:'center', 2:'center', 3:'center',
-                           4:'center', 5:'center'}
+    tab.justify_columns = {0: 'center', 1: 'center', 2: 'center', 3: 'center',
+                           4: 'center', 5: 'center'}
     print(tab.table)
     print()
 
@@ -304,8 +291,7 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     print("n_STARS after selection & normalization :", n_STARS)
     print()
 
-    #------------------------------------------------------------------------------
-    #***COMPUTE AND ADD COLORS***
+    # ***COMPUTE AND ADD COLORS***
 
     color_names = ['g_r', 'r_z', 'g_z', 'g_W1', 'r_W1', 'z_W1', 'g_W2', 'r_W2', 'z_W2', 'W1_W2', 'r']
     n_colors = len(color_names)
@@ -318,7 +304,7 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     STARS_Colors = ColorsFunc(n_STARS, n_colors, STARS_gmag, STARS_rmag, STARS_zmag, STARS_W1mag, STARS_W2mag)
 
     for i, col_name in enumerate(color_names):
-        col = pyfits.Column(name=col_name,  format='D', array=STARS_Colors[:,i])
+        col = pyfits.Column(name=col_name,  format='D', array=STARS_Colors[:, i])
         list_cols.append(col)
 
     STARS_hdu = pyfits.BinTableHDU(data=STARS_data)
@@ -332,14 +318,13 @@ def make_training_samples(fpn_QSO_input, fpn_STARS_input, fpn_QSO_output, fpn_ST
     QSO_Colors = ColorsFunc(n_QSO, n_colors, QSO_gmag, QSO_rmag, QSO_zmag, QSO_W1mag, QSO_W2mag)
 
     for i, col_name in enumerate(color_names):
-        col = pyfits.Column(name=col_name,  format='D', array=QSO_Colors[:,i])
+        col = pyfits.Column(name=col_name,  format='D', array=QSO_Colors[:, i])
         list_cols.append(col)
 
-    QSO_hdu = pyfits.BinTableHDU(data = QSO_data)
+    QSO_hdu = pyfits.BinTableHDU(data=QSO_data)
     QSO_hdu = pyfits.BinTableHDU.from_columns(list(QSO_hdu.columns) + list_cols)
 
-    #------------------------------------------------------------------------------
-    #***STARS & QSO TRAINING FITS CATALOG STORING***
+    # ***STARS & QSO TRAINING FITS CATALOG STORING***
 
     STARS_hdu.writeto(fpn_STARS_output, overwrite=True)
     print("Save :", fpn_STARS_output)

--- a/py/desitarget/train/train_test_RF/PipelineConfigScript.py
+++ b/py/desitarget/train/train_test_RF/PipelineConfigScript.py
@@ -11,12 +11,14 @@ import numpy as np
 
 from desitarget.train.train_test_RF.util.funcs import RecHyParamDictExplFunc
 
-def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_TestSample, fpn_QLF, fpn_config):
-    #***CONFIGURATION***
 
-    RELEASE = 'DR9s' # seulement à titre informatif, aucun impact dans le pipeline
-    random_state_seed = 666 # pour l'entraînement => reproductibilité
-    n_jobs = 20 # pour l'entraînement et l'application des RF
+def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample,
+                         fpn_TestSample, fpn_QLF, fpn_config):
+    # ***CONFIGURATION***
+
+    RELEASE = 'DR9s'  # seulement à titre informatif, aucun impact dans le pipeline
+    random_state_seed = 666  # pour l'entraînement => reproductibilité
+    n_jobs = 20  # pour l'entraînement et l'application des RF
 
     # Selection criteria
     OBJ_extraKeys = ['TYPE']
@@ -43,40 +45,34 @@ def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_T
     # min_zredVect = [[[0., 6.]], [[3.2, 6.]]] # [float] "[0., 6.]"
     # =============================================================================
 
-    nTreesVect = [[500], [500]] # [int]
-    maxDepthVect = [[25], [25]] # "None" ou [int]
-    maxLNodesVect = [[850], [850]] # "None" ou [int]
-    min_zredVect = [[[0., 6.]], [[3.2, 6.]]] # [float] "[0., 6.]"
+    nTreesVect = [[500], [500]]  # [int]
+    maxDepthVect = [[25], [25]]  # "None" ou [int]
+    maxLNodesVect = [[850], [850]]  # "None" ou [int]
+    min_zredVect = [[[0., 6.]], [[3.2, 6.]]]  # [float] "[0., 6.]"
 
-    #------------------------------------------------------------------------------
-
-    #***CONFIGURATION PAR DÉFAUT***
+    # ***CONFIGURATION PAR DÉFAUT***
 
     # NE PAS MODIFIER
     # MODEL file path name template
-    #dirpn_model = "./WorkingDir/" + str(RELEASE) + "/RFmodel/{}/"
-    #rootpn_model = "model_{}_z{}_MDepth{}_MLNodes{}_nTrees{}"
+    # dirpn_model = "./WorkingDir/" + str(RELEASE) + "/RFmodel/{}/"
+    # rootpn_model = "model_{}_z{}_MDepth{}_MLNodes{}_nTrees{}"
     fpn_model_template = "/model_{}_z{}_MDepth{}_MLNodes{}_nTrees{}"
 
     # NE PAS MODIFIER
     # TEST file path name template
-    #dirpn_test = "./WorkingDir/" + str(RELEASE) + "/test/{}/"
-    #rootpn_test = "test_{}_z{}_MDepth{}_MLNodes{}_nTrees{}"
+    # dirpn_test = "./WorkingDir/" + str(RELEASE) + "/test/{}/"
+    # rootpn_test = "test_{}_z{}_MDepth{}_MLNodes{}_nTrees{}"
     fpn_test_template = "/test_{}_z{}_MDepth{}_MLNodes{}_nTrees{}"
 
-    # NE PAS MODIFIER
-    feature_names = ['g_r','r_z','g_z','g_W1','r_W1','z_W1',
-                     'g_W2','r_W2','z_W2','W1_W2','r']
-
-    #------------------------------------------------------------------------------
+    # NE PAS MODIFIER.
+    feature_names = ['g_r', 'r_z', 'g_z', 'g_W1', 'r_W1', 'z_W1', 'g_W2', 'r_W2',
+                     'z_W2', 'W1_W2', 'r']
 
     print("\n///**********TS CONFIG SCRIPT**********///")
 
     LIST_MODEL_NAME = []
 
-    #------------------------------------------------------------------------------
-
-    #***FUNCTION***
+    # ***FUNCTION***
 
     from functools import reduce
     from operator import mul
@@ -97,9 +93,7 @@ def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_T
         hyParamDict['ALGO-hyParamSpace']['hyParamSpaceShape'] = hyParamSpaceShape
         hyParamDict['ALGO-hyParamSpace']['hyParamSpaceSize'] = hyParamSpaceSize
 
-    #------------------------------------------------------------------------------
-
-    #***MODELE DR9s_LOW***
+    # ***MODELE DR9s_LOW***
 
     LIST_MODEL_NAME.append(['DR9s_LOW'])
 
@@ -117,9 +111,7 @@ def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_T
 
     HyParamDictFunc(hyParamDict_DR9s_LOW)
 
-    #------------------------------------------------------------------------------
-
-    #***MODELE DR9s_HighZ***
+    # ***MODELE DR9s_HighZ***
 
     LIST_MODEL_NAME.append(['DR9s_HighZ'])
 
@@ -137,9 +129,7 @@ def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_T
 
     HyParamDictFunc(hyParamDict_DR9s_HighZ)
 
-    #------------------------------------------------------------------------------
-
-    #***MODÈLE À TESTER***
+    # ***MODÈLE À TESTER***
 
     testConfigDict = dict()
     nTEST = len(LIST_MODEL_NAME)
@@ -149,9 +139,7 @@ def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_T
         testConfigDict[TEST_NAME] = {}
         testConfigDict[TEST_NAME]['MODEL_NAME'] = LIST_MODEL_NAME[numTEST]
 
-    #------------------------------------------------------------------------------
-
-    #***SCENARIO = COMBINAISON DES MODÈLES TESTÉS***
+    # ***SCENARIO = COMBINAISON DES MODÈLES TESTÉS***
 
     # ATTENTION:
     # - "proba_thold" toujours entre [0., 1.] ou "None"
@@ -177,10 +165,10 @@ def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_T
     # DR9
     scenarioConfigDict['SCEN_DR9s_FULL'] = \
         {'TEST_NAME': ['TEST_DR9s_LOW', 'TEST_DR9s_HighZ'],
-          'target_density': [245, 15],
-          'proba_thold': [0.93, 0.55], # [0.83, 0.55]
-          'rmag_thold': [[21.5], [20.5]],
-          'slope': [[0.025], [0.025]]}
+         'target_density': [245, 15],
+         'proba_thold': [0.93, 0.55],  # [0.83, 0.55]
+         'rmag_thold': [[21.5], [20.5]],
+         'slope': [[0.025], [0.025]]}
 
     # DR7
     # =============================================================================
@@ -192,9 +180,7 @@ def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_T
     #       'slope': [[0.025, 0.15, 0.70], [0.025]]}
     # =============================================================================
 
-    #------------------------------------------------------------------------------
-
-    #***CONSTRUCTION DU FICHIER DE CONFIG***
+    # ***CONSTRUCTION DU FICHIER DE CONFIG***
 
     configDict = dict()
     configDict['RELEASE'] = RELEASE
@@ -224,9 +210,7 @@ def PipelineConfigScript(fpn_QSO_TrainingSample, fpn_STARS_TrainingSample, fpn_T
     configDict['TEST'] = testConfigDict
     configDict['SCENARIO'] = scenarioConfigDict
 
-    #------------------------------------------------------------------------------
-
-    #***STORING DU FICHIER DE CONFIG***
+    # ***STORING DU FICHIER DE CONFIG***
 
     if os.path.isfile(fpn_config):
         os.remove(fpn_config)

--- a/py/desitarget/train/train_test_RF/Some_tests.py
+++ b/py/desitarget/train/train_test_RF/Some_tests.py
@@ -9,68 +9,72 @@ from matplotlib.gridspec import GridSpec
 # number of variables
 nfeatures = 11
 
-                    ###############################
-                    ####       Functions       ####
-                    ###############################
 
 def read_file(inputFile):
 
-    sample = fitsio.read(inputFile, columns=['RA','DEC', 'TYPE', 'zred',
-              'g_r', 'r_z', 'g_z', 'g_W1', 'r_W1', 'z_W1', 'g_W2', 'r_W2', 'z_W2', 'W1_W2', 'r'], ext=1)
+    sample = fitsio.read(inputFile, columns=['RA', 'DEC', 'TYPE', 'zred', 'g_r',
+                                             'r_z', 'g_z', 'g_W1', 'r_W1',
+                                             'z_W1', 'g_W2', 'r_W2', 'z_W2',
+                                             'W1_W2', 'r'], ext=1)
 
-    # We keep only Correct Candidate
-    reduce_sample = sample[(((sample['TYPE'][:]=='PSF ')|(sample['TYPE'][:]=='PSF')) & (sample['r'][:]<23.0)&(sample['r'][:]>0.0))]
+    # We keep only Correct Candidates.
+    reduce_sample = sample[(((sample['TYPE'][:] == 'PSF ') |
+                             (sample['TYPE'][:] == 'PSF')) &
+                            (sample['r'][:] < 23.0) &
+                            (sample['r'][:] > 0.0))]
 
     print("\n############################################")
-    print('Input file = ',inputFile)
-    print('Original size : ', len(sample))
-    print('Reduce size   : ',len(reduce_sample))
+    print('Input file = ', inputFile)
+    print('Original size: ', len(sample))
+    print('Reduce size: ', len(reduce_sample))
     print("############################################\n")
 
     return reduce_sample
 
+
 def build_attributes(nbEntries, nfeatures, sample):
 
-    colors = np.zeros((nbEntries,nfeatures))
+    colors = np.zeros((nbEntries, nfeatures))
 
-    colors[:,0] = sample['g_r'][:]
-    colors[:,1] = sample['r_z'][:]
-    colors[:,2] = sample['g_z'][:]
-    colors[:,3] = sample['g_W1'][:]
-    colors[:,4] = sample['r_W1'][:]
-    colors[:,5] = sample['z_W1'][:]
-    colors[:,6] = sample['g_W2'][:]
-    colors[:,7] = sample['r_W2'][:]
-    colors[:,8] = sample['z_W2'][:]
-    colors[:,9] = sample['W1_W2'][:]
-    colors[:,10] = sample['r'][:]
+    colors[:, 0] = sample['g_r'][:]
+    colors[:, 1] = sample['r_z'][:]
+    colors[:, 2] = sample['g_z'][:]
+    colors[:, 3] = sample['g_W1'][:]
+    colors[:, 4] = sample['r_W1'][:]
+    colors[:, 5] = sample['z_W1'][:]
+    colors[:, 6] = sample['g_W2'][:]
+    colors[:, 7] = sample['r_W2'][:]
+    colors[:, 8] = sample['z_W2'][:]
+    colors[:, 9] = sample['W1_W2'][:]
+    colors[:, 10] = sample['r'][:]
 
     return colors
+
 
 def compute_proba(sample, RF_file, RF_Highz_file):
 
     attributes = build_attributes(len(sample), nfeatures, sample)
 
-    print('Load Random Forest : ')
+    print('Load Random Forest: ')
     print('    * ' + RF_file)
     print('    * ' + RF_Highz_file)
-    print ('Random Forest over : ', len(attributes),' objects\n')
+    print('Random Forest over: ', len(attributes), ' objects\n')
 
     RF = joblib.load(RF_file)
-    proba_rf = RF.predict_proba(attributes)[:,1]
+    proba_rf = RF.predict_proba(attributes)[:, 1]
     feature_imp = RF.feature_importances_
 
     RF_Highz = joblib.load(RF_Highz_file)
-    proba_rf_Highz = RF_Highz.predict_proba(attributes)[:,1]
+    proba_rf_Highz = RF_Highz.predict_proba(attributes)[:, 1]
     feature_imp_Highz = RF_Highz.feature_importances_
 
     return proba_rf, feature_imp, proba_rf_Highz, feature_imp_Highz
 
-#------------------------------------------------------------------------------#
 
-def plot_importance_feature(feature_imp, feature_imp_Highz, show=True, save=True, savename='Res_Compare/importance_feature.pdf'):
+def plot_importance_feature(feature_imp, feature_imp_Highz, show=True, save=True,
+                            savename='Res_Compare/importance_feature.pdf'):
 
-    fig, ax = plt.subplots(figsize=(6.0,4.0))
+    fig, ax = plt.subplots(figsize=(6.0, 4.0))
 
     labels = ['g_r', 'r_z', 'g_z', 'g_W1', 'r_W1', 'z_W1', 'g_W2', 'r_W2', 'z_W2', 'W1_W2', 'r']
 
@@ -93,8 +97,10 @@ def plot_importance_feature(feature_imp, feature_imp_Highz, show=True, save=True
     else:
         plt.close()
 
-def plot_cut_selection(r, sel, sel_qso, sel_Highz, proba_rf, proba_Highz_rf, show=True, save=True, savename='Res_Compare/cut_selection.pdf'):
-    fig = plt.figure(1,figsize=(12.0,8.0))
+
+def plot_cut_selection(r, sel, sel_qso, sel_Highz, proba_rf, proba_Highz_rf,
+                       show=True, save=True, savename='Res_Compare/cut_selection.pdf'):
+    fig = plt.figure(1, figsize=(12.0, 8.0))
 
     gs = GridSpec(nrows=4, ncols=2, figure=fig)
     ax_hist_21 = fig.add_subplot(gs[0, 0])
@@ -102,7 +108,8 @@ def plot_cut_selection(r, sel, sel_qso, sel_Highz, proba_rf, proba_Highz_rf, sho
     ax3 = fig.add_subplot(gs[1:, 0])
     ax4 = fig.add_subplot(gs[1:, 1])
 
-    plt.subplots_adjust(left=0.07, right=0.93, bottom=0.08, top=0.92, wspace= 0.08, hspace=0.10)
+    plt.subplots_adjust(left=0.07, right=0.93, bottom=0.08, top=0.92,
+                        wspace=0.08, hspace=0.10)
 
     rmag = np.linspace(17, 23, 1000)
 
@@ -110,7 +117,8 @@ def plot_cut_selection(r, sel, sel_qso, sel_Highz, proba_rf, proba_Highz_rf, sho
     cut_Highz = [0.5 for x in rmag]
 
     hist = [r[sel & ~sel_qso], r[sel & sel_qso], r[~sel & sel_qso]]
-    ax_hist_21.hist(hist, bins=50, range=(17.,23.), color=['gray', 'blue', 'red'], stacked=True, label=['not QS0', 'QSO', 'QS0 not selected'])
+    ax_hist_21.hist(hist, bins=50, range=(17., 23.), color=['gray', 'blue', 'red'],
+                    stacked=True, label=['not QS0', 'QSO', 'QS0 not selected'])
     ax_hist_21.set_ylabel('# objects', labelpad=8)
     ax_hist_21.set_xticklabels([])
     ax_hist_21.set_yticks([0, 1000, 2000])
@@ -128,7 +136,8 @@ def plot_cut_selection(r, sel, sel_qso, sel_Highz, proba_rf, proba_Highz_rf, sho
     ax3.set_ylabel(f'RF_DR9s Probability', labelpad=14)
 
     hist = [r[~sel_qso & ~sel & sel_Highz], r[sel_qso & ~sel & sel_Highz], r[sel_qso & ~sel & ~sel_Highz]]
-    ax_hist_22.hist(hist, bins=50, range=(17.,23.), color=['gray', 'blue', 'red'], stacked=True, label=['not QS0', 'QSO', 'QS0 not selected'])
+    ax_hist_22.hist(hist, bins=50, range=(17., 23.), color=['gray', 'blue', 'red'],
+                    stacked=True, label=['not QS0', 'QSO', 'QS0 not selected'])
     ax_hist_22.set_ylabel('# objects', rotation=270, labelpad=19)
     ax_hist_22.set_xticklabels([])
     ax_hist_22.set_yticks([0, 100, 200])
@@ -156,6 +165,7 @@ def plot_cut_selection(r, sel, sel_qso, sel_Highz, proba_rf, proba_Highz_rf, sho
     else:
         plt.close()
 
+
 def hist_ratio(n_x, n_y, bins):
 
     x = n_x.astype(float)
@@ -164,29 +174,33 @@ def hist_ratio(n_x, n_y, bins):
     bin_centers = (bins[:-1] + bins[1:])/2.
     # error in binomial case
     errors = np.sqrt(y*(x-y)/x**3)
-    errors[errors==0] = y[errors==0]/(x[errors==0]+1)**3
+    errors[errors == 0] = y[errors == 0]/(x[errors == 0]+1)**3
 
     return bin_centers, ratio, errors
 
-def plot_completness(r, sel_qso, sel_tot, zred, N_bins_r=10, N_bins_z=10, show=True, save=True, savename='Res_Compare/completeness.pdf'):
-    fig = plt.figure(1,figsize=(10.0,4.0))
+
+def plot_completness(r, sel_qso, sel_tot, zred, N_bins_r=10, N_bins_z=10,
+                     show=True, save=True, savename='Res_Compare/completeness.pdf'):
+    fig = plt.figure(1, figsize=(10.0, 4.0))
 
     gs = GridSpec(1, 2, figure=fig)
     ax1 = fig.add_subplot(gs[0, 0])
     ax2 = fig.add_subplot(gs[0, 1])
 
-    n_r_ref, bins_r = np.histogram(r[sel_qso], bins=N_bins_r, range=(17.,23.))
-    n_r, bins_r = np.histogram(r[sel_qso&sel_tot], bins=N_bins_r, range=(17.,23.))
+    n_r_ref, bins_r = np.histogram(r[sel_qso], bins=N_bins_r, range=(17., 23.))
+    n_r, bins_r = np.histogram(r[sel_qso & sel_tot], bins=N_bins_r, range=(17., 23.))
     bin_centers, ratio, errors = hist_ratio(n_r_ref, n_r, bins_r)
-    ax1.errorbar(x=bin_centers, y=ratio, yerr=errors, linestyle='none', marker='.',color='green', label=f"RF DR9s")
+    ax1.errorbar(x=bin_centers, y=ratio, yerr=errors, linestyle='none',
+                 marker='.', color='green', label=f"RF DR9s")
     ax1.set_xlabel('r mag')
     ax1.set_ylabel('Completeness')
     ax1.legend(loc='lower left')
 
-    n_z_ref, bins_z = np.histogram(zred[sel_qso], bins=N_bins_z, range=(0.,4.))
-    n_z, bins_z = np.histogram(zred[sel_qso&sel_tot], bins=N_bins_z, range=(0.,4.))
+    n_z_ref, bins_z = np.histogram(zred[sel_qso], bins=N_bins_z, range=(0., 4.))
+    n_z, bins_z = np.histogram(zred[sel_qso & sel_tot], bins=N_bins_z, range=(0., 4.))
     bin_centers, ratio, errors = hist_ratio(n_z_ref, n_z, bins_z)
-    ax2.errorbar(x=bin_centers, y=ratio, yerr=errors, linestyle='none', marker='.',color='green', label=f"RF DR9s")
+    ax2.errorbar(x=bin_centers, y=ratio, yerr=errors, linestyle='none',
+                 marker='.', color='green', label=f"RF DR9s")
     ax2.set_xlabel('redshift')
     ax2.legend(loc='lower left')
 
@@ -194,29 +208,20 @@ def plot_completness(r, sel_qso, sel_tot, zred, N_bins_r=10, N_bins_z=10, show=T
         plt.savefig(savename)
     if show:
         plt.show()
-    else :
+    else:
         plt.close()
 
-#------------------------------------------------------------------------------#
 
 def make_some_tests_and_plots(inputFile, RF_file, RF_Highz_file):
 
-                        ###############################
-                        ####       Load Data       ####
-                        ###############################
-
+    # Load data.
     test_sample = read_file(inputFile)
 
-                        ###############################
-                        ####       RF Output       ####
-                        ###############################
+    # RF output.
+    proba_rf, feature_imp, proba_Highz_rf, feature_imp_Highz = compute_proba(
+        test_sample, RF_file, RF_Highz_file)
 
-    proba_rf, feature_imp, proba_Highz_rf, feature_imp_Highz = compute_proba(test_sample, RF_file, RF_Highz_file)
-
-                        ###############################
-                        #### Magnitude & Geometry  ####
-                        ###############################
-
+    # Magnitude and Geometry.
     zred = test_sample['zred'][:]
     r = test_sample['r'][:]
     ra = test_sample['RA'][:]
@@ -227,7 +232,7 @@ def make_some_tests_and_plots(inputFile, RF_file, RF_Highz_file):
 
     r_sel = (r >= r_mag_min_sel) & (r <= r_mag_max_sel)
 
-    #selection from r_magnitude
+    # selection from r_magnitude
     zred = zred[r_sel]
     r = r[r_sel]
     ra = ra[r_sel]
@@ -241,7 +246,7 @@ def make_some_tests_and_plots(inputFile, RF_file, RF_Highz_file):
     print("R_mag max selected = ", r_mag_max_sel, " -- R_mag min selected = ", r_mag_min_sel)
     print("############################################\n")
 
-    #on regarde des objets quasiment à l'horizon --> cos(theta) = 1
+    # on regarde des objets quasiment à l'horizon --> cos(theta) = 1
     ra_min, ra_max = np.min(ra), np.max(ra)
     dec_min, dec_max = np.min(dec), np.max(dec)
     surface = (ra_max - ra_min)*(dec_max - dec_min)
@@ -253,43 +258,37 @@ def make_some_tests_and_plots(inputFile, RF_file, RF_Highz_file):
     print("Surface = ", surface)
     print("############################################\n")
 
-    sel_qso = zred>0
-    sel_qso_highz = zred>3
-    sel_qso_2 = zred>2
+    sel_qso = zred > 0
+    sel_qso_highz = zred > 3
+    sel_qso_2 = zred > 2
 
-                        ###############################
-                        ####       Selection       ####
-                        ###############################
-
+    # Selection.
     cut = 0.75 - 0.05*np.tanh(r - 20.5)
     cut_Highz = 0.5
 
-    sel = proba_rf>cut
-    sel_Highz = (proba_Highz_rf > cut_Highz) &  ~sel
+    sel = proba_rf > cut
+    sel_Highz = (proba_Highz_rf > cut_Highz) & ~sel
     sel_tot = sel + sel_Highz
 
     density = float(len(r[sel]))/surface
-    effi = float(len(r[sel&sel_qso]))/float(len(r[sel_qso]))
+    effi = float(len(r[sel & sel_qso])) / float(len(r[sel_qso]))
 
-    density_Highz = float(len(r[sel_Highz]))/surface
-    effi_Highz = float(len(r[sel_Highz&sel_qso]))/float(len(r[sel_qso]))
+    density_Highz = float(len(r[sel_Highz])) / surface
+    effi_Highz = float(len(r[sel_Highz & sel_qso])) / float(len(r[sel_qso]))
 
-    density_tot = float(len(r[sel_tot]))/surface
-    effi_tot = float(len(r[sel_tot&sel_qso]))/float(len(r[sel_qso]))
+    density_tot = float(len(r[sel_tot])) / surface
+    effi_tot = float(len(r[sel_tot & sel_qso])) / float(len(r[sel_qso]))
 
     print('\n############################################')
-    print(f'density dr9 = ',density,f' deg^-2 completeness dr9',effi)
-    print(f'density dr9 Highz = ',density_Highz,f' deg^-2 completeness dr9 Highz', effi_Highz)
-    print(f'density dr9 Total = ',density_tot,f' deg^-2 completeness dr9 Total', effi_tot)
+    print(f'density dr9 = ', density, f' deg^-2 completeness dr9', effi)
+    print(f'density dr9 Highz = ', density_Highz, f' deg^-2 completeness dr9 Highz', effi_Highz)
+    print(f'density dr9 Total = ', density_tot, f' deg^-2 completeness dr9 Total', effi_tot)
     print('############################################\n')
-    
+
     print('[INFO] TAKE CARE THE TEST REGION IS IN DES --> NEED TO TUNE INDEPENTENDLY EACH FOOTPRINT')
     print('[INFO] TEST REGION A LITTLE BIT CONTAMINATED BY STARS, FORCE HIGHER DENSITY TO GET 260 targets by deg2 IN THE REST OF THE FOOTPRINT\n')
 
-                        ###############################
-                        ####       Plots           ####
-                        ###############################
-
+    # Plots.
     plot_importance_feature(feature_imp, feature_imp_Highz, True, False)
     plot_cut_selection(r, sel, sel_qso, sel_Highz, proba_rf, proba_Highz_rf, True, False)
     plot_completness(r, sel_qso, sel_tot, zred, N_bins_r=40, N_bins_z=40, show=True, save=False)

--- a/py/desitarget/train/train_test_RF/train_RF.py
+++ b/py/desitarget/train/train_test_RF/train_RF.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-#****************************************
+# ****************************************
 # RF TRAINING
-#****************************************
+# ****************************************
 
 import argparse
 import time
@@ -18,12 +18,13 @@ from sklearn.ensemble import RandomForestClassifier
 
 from desitarget.train.train_test_RF.util.funcs import Time2StrFunc, GetColorsFunc, Flat2TreeHyParamConvFunc
 
+
 def train_RF(fpn_config, MODEL, dpn_RFmodel):
     print("\n///**********TRAIN RF**********///")
     infoRootStr = "INFO::TRAIN RF: "
     errRootStr = "ERR::TRAIN RF: "
 
-    #***CONFIG DATA LOADING***
+    # ***CONFIG DATA LOADING***
     # CONFIG
     configDict = dict(np.load(fpn_config, allow_pickle=True)['CONFIG'][()])
     RELEASE = str(configDict['RELEASE'])
@@ -46,8 +47,7 @@ def train_RF(fpn_config, MODEL, dpn_RFmodel):
 
     hyParamDictTemplate = copy.deepcopy(hyParamDict['ALGO'])
 
-
-    #***INITIALIZATION***
+    # ***INITIALIZATION***
     n_jobs = min(mp.cpu_count(), n_jobs)
 
     # print init infos
@@ -58,7 +58,7 @@ def train_RF(fpn_config, MODEL, dpn_RFmodel):
     infoStr = "MODEL : ('{:s}')".format(MODEL)
     print(infoRootStr + infoStr)
     print(infoRootStr + "HYPERPARAMETERS SPACE :")
-    pprint.pprint(flatHyParamSpaceDict, width = 1)
+    pprint.pprint(flatHyParamSpaceDict, width=1)
     print(infoRootStr + "hyParamSpaceSize : (", hyParamSpaceSize, ")")
     print(infoRootStr + "hyParamSpaceShape : (", hyParamSpaceShape, ")")
     print()
@@ -70,7 +70,7 @@ def train_RF(fpn_config, MODEL, dpn_RFmodel):
     print(infoRootStr + infoStr.format(n_jobs))
     print()
 
-    #***TRAINING DATA LOADING***
+    # ***TRAINING DATA LOADING***
     # STARS
     infoStr = "STARS Training Sample : ('{:s}')".format(fpn_STARS_TrainingSample)
     print(infoRootStr + infoStr)
@@ -91,8 +91,7 @@ def train_RF(fpn_config, MODEL, dpn_RFmodel):
     print(infoRootStr + infoStr)
     print()
 
-
-    #***TRAINING DES RF POUR DIFFÉRENTS JEUX DE PARAMÈTRES***
+    # ***TRAINING DES RF POUR DIFFÉRENTS JEUX DE PARAMÈTRES***
     infoStr = "TRAINING ..."
     print(infoRootStr + infoStr)
     glob_startTime = time.time()
@@ -100,10 +99,10 @@ def train_RF(fpn_config, MODEL, dpn_RFmodel):
         print("******************************************************************************")
         startTime = time.time()
 
-        # Définition du jeu d'hyparamètre courant
+        # Definition du jeu d'hyparamètre courant
         coords = np.unravel_index(it, hyParamSpaceShape)
         currentHyParams = Flat2TreeHyParamConvFunc(coords, hyParamDictTemplate,
-                              hyParamSpaceTags, hyParamSpaceItems)
+                                                   hyParamSpaceTags, hyParamSpaceItems)
         nTrees = int(currentHyParams['RF']['nTrees'])
         maxDepth = currentHyParams['RF']['maxDepth']
         maxLNodes = currentHyParams['RF']['maxLNodes']
@@ -136,9 +135,9 @@ def train_RF(fpn_config, MODEL, dpn_RFmodel):
         RF.fit(train_colors, train_labels)
 
         # RF storing
-        fpn_RFmodel = dpn_RFmodel + fpn_model_template.format(MODEL, str(min_zred),
-            str(maxDepth), str(maxLNodes), str(nTrees)) + '.pkl.gz'
-        joblib.dump(RF, fpn_RFmodel, compress = 9)
+        fpn_RFmodel = dpn_RFmodel + fpn_model_template.format(
+            MODEL, str(min_zred), str(maxDepth), str(maxLNodes), str(nTrees)) + '.pkl.gz'
+        joblib.dump(RF, fpn_RFmodel, compress=9)
         infoStr = "Save RF model : ('{:s}')".format(fpn_RFmodel)
         print(infoRootStr + infoStr)
 

--- a/py/desitarget/train/train_test_RF/util/PredCountsFromQLF_ClassModule.py
+++ b/py/desitarget/train/train_test_RF/util/PredCountsFromQLF_ClassModule.py
@@ -8,9 +8,10 @@ from scipy.interpolate import interp2d
 
 # '/home/charles-antoine/Bureau/ROSS4_tabR'
 
+
 class PredCountsFromQLF_Class():
 
-    def __init__]self):
+    def __init__(self):
 
         self.QLF_OK = False
         self.EFF_OK = False
@@ -55,17 +56,17 @@ class PredCountsFromQLF_Class():
         self.QLF4Compl_dNdzdmag = None
         self.Compl_dzdmag = None
 
-    def LoadQLF_Data(self, fpn_QLF_Data, mMzred = np.array([0., 6.]),
-                             skyArea = 10000.):
+    def LoadQLF_Data(self, fpn_QLF_Data, mMzred=np.array([0., 6.]),
+                     skyArea=10000.):
 
         # Data loading in "dataStr"
-        dataStr = np.loadtxt(fpn_QLF_Data, dtype = str, delimiter = '\n')
+        dataStr = np.loadtxt(fpn_QLF_Data, dtype=str, delimiter='\n')
         self.QLF_nz = len(re.findall(r'\d+(?:\.\d+)?', dataStr[0])) - 1
         self.QLF_nmag = len(dataStr)
 
         # ZRED
         self.QLF_zlimit = np.linspace(mMzred[0], mMzred[1],
-                                       self.QLF_nz + 1, endpoint = True)
+                                      self.QLF_nz + 1, endpoint=True)
         self.QLF_stepz = self.QLF_zlimit[1] - self.QLF_zlimit[0]
         # self.QLF_tabz = self.QLF_zlimit[0 : -1] + self.QLF_stepz / 2.
 
@@ -75,21 +76,21 @@ class PredCountsFromQLF_Class():
 
         for nL, line in enumerate(dataStr):
             dNdzdmag = re.findall(r'\d+(?:\.\d+)?', line)
-            dNdzdmag  = np.asarray(dNdzdmag ).astype(np.float)
-            self.QLF_tabmag[nL] = dNdzdmag [0]
-            self.QLF_dNdzdmag[nL + 1, 1 :] = dNdzdmag [1:]
+            dNdzdmag = np.asarray(dNdzdmag).astype(np.float)
+            self.QLF_tabmag[nL] = dNdzdmag[0]
+            self.QLF_dNdzdmag[nL + 1, 1:] = dNdzdmag[1:]
 
         self.QLF_stepmag = self.QLF_tabmag[1] - self.QLF_tabmag[0]
 
         # MAG
         self.QLF_maglimit = np.zeros(self.QLF_nmag + 1)
-        self.QLF_maglimit[0 : -1] = self.QLF_tabmag - self.QLF_stepmag / 2.
+        self.QLF_maglimit[0: -1] = self.QLF_tabmag - self.QLF_stepmag / 2.
         self.QLF_maglimit[-1] = self.QLF_maglimit[-2] + self.QLF_stepmag
 
         self.QLF_dNdzdmag /= skyArea
 
         self.QLF_Ndzdmag = np.cumsum(np.cumsum(
-            self.QLF_dNdzdmag, axis = 0), axis = 1)
+            self.QLF_dNdzdmag, axis=0), axis=1)
 
         self.QLF_OK = True
         self.QLF_EFF_OK = False
@@ -109,12 +110,12 @@ class PredCountsFromQLF_Class():
 
             # QLF_EFF_zlimit
             self.QLF_EFF_zlimit = np.unique(np.hstack((self.QLF_zlimit,
-                                                          self.EFF_zlimit)))
+                                                       self.EFF_zlimit)))
 
             maxQLF_EFF_zlimit = min(float(np.max(self.QLF_zlimit)),
-                                     float(np.max(self.EFF_zlimit)))
+                                    float(np.max(self.EFF_zlimit)))
             minQLF_EFF_zlimit = max(float(np.min(self.QLF_zlimit)),
-                                     float(np.min(self.EFF_zlimit)))
+                                    float(np.min(self.EFF_zlimit)))
             test = (self.QLF_EFF_zlimit >= minQLF_EFF_zlimit) & \
                    (self.QLF_EFF_zlimit <= maxQLF_EFF_zlimit)
 
@@ -123,12 +124,12 @@ class PredCountsFromQLF_Class():
             # QLF_EFFmaglimit
             self.QLF_EFF_maglimit = np.unique(
                 np.hstack((self.QLF_maglimit,
-                             self.EFF_maglimit)))
+                           self.EFF_maglimit)))
 
             maxQLF_EFF_maglimit = min(float(np.max(self.QLF_maglimit)),
-                                       float(np.max(self.EFF_maglimit)))
+                                      float(np.max(self.EFF_maglimit)))
             minQLF_EFF_maglimit = max(float(np.min(self.QLF_maglimit)),
-                                       float(np.min(self.EFF_maglimit)))
+                                      float(np.min(self.EFF_maglimit)))
             test = (self.QLF_EFF_maglimit >= minQLF_EFF_maglimit) & \
                    (self.QLF_EFF_maglimit <= maxQLF_EFF_maglimit)
 
@@ -142,37 +143,37 @@ class PredCountsFromQLF_Class():
             y = self.EFF_maglimit.flatten()
             z = self.EFF_dzdmag
 
-#==============================================================================
+# ==============================================================================
 #             f2d_EFF = interp2d(x, y, z, kind = 'linear',
-#                                 copy = True, bounds_error = True)            
+#                                 copy = True, bounds_error = True)
 #             interpEFF_dzdmag = f2d_EFF(xnew, ynew)
-#==============================================================================
+# ==============================================================================
 
-            interpXinds = np.digitize(xnew, x, right = True) - 1
+            interpXinds = np.digitize(xnew, x, right=True) - 1
             interpXinds = np.maximum(interpXinds, 0)
 
-            interpYinds = np.digitize(ynew, y, right = True) - 1
+            interpYinds = np.digitize(ynew, y, right=True) - 1
             interpYinds = np.maximum(interpYinds, 0)
 
             interpXYgridInds = np.meshgrid(interpXinds, interpYinds)
 
             self.interpEFF_dzdmag = z[interpXYgridInds[1],
-                                       interpXYgridInds[0]]
+                                      interpXYgridInds[0]]
 
             # QLF
             x = self.QLF_zlimit.flatten()
             y = self.QLF_maglimit.flatten()
             z = self.QLF_Ndzdmag
 
-            f2d_QLF = interp2d(x, y, z, kind = 'linear',
-                                copy = True, bounds_error = True)
+            f2d_QLF = interp2d(x, y, z, kind='linear',
+                               copy=True, bounds_error=True)
 
             interpQLF_Ndzdmag = f2d_QLF(xnew, ynew)
 
             interpQLF_dNdzdmag = np.copy(interpQLF_Ndzdmag)
-            interpQLF_dNdzdmag[:, 1 :] -= \
+            interpQLF_dNdzdmag[:, 1:] -= \
                 np.copy(interpQLF_dNdzdmag[:, : -1])
-            interpQLF_dNdzdmag[1 :, :] -= \
+            interpQLF_dNdzdmag[1:, :] -= \
                 np.copy(interpQLF_dNdzdmag[: -1, :])
 
             self.interpQLF_dNdzdmag = interpQLF_dNdzdmag
@@ -262,41 +263,41 @@ class PredCountsFromQLF_Class():
             assert(np.max(maglimit) <= np.max(ynew))
 
             interpQLF_EFF_Ndzdmag = np.cumsum(np.cumsum(
-                self.interpQLF_EFF_dNdzdmag, axis = 0), axis = 1)
+                self.interpQLF_EFF_dNdzdmag, axis=0), axis=1)
 
             f2d_QLF_EFF = interp2d(xnew, ynew, interpQLF_EFF_Ndzdmag,
-                                    kind = 'linear', copy = True,
-                                    bounds_error = True)
+                                   kind='linear', copy=True,
+                                   bounds_error=True)
 
             QLF_EFF4Compl_Ndzdmag = f2d_QLF_EFF(zlimit, maglimit)
 
             QLF_EFF4Compl_dNdzdmag = np.copy(QLF_EFF4Compl_Ndzdmag)
-            QLF_EFF4Compl_dNdzdmag[:, 1 :] -= \
-                np.copy(QLF_EFF4Compl_dNdzdmag[:, : -1])
-            QLF_EFF4Compl_dNdzdmag[1 :, :] -= \
-                np.copy(QLF_EFF4Compl_dNdzdmag[: -1, :])
+            QLF_EFF4Compl_dNdzdmag[:, 1:] -= \
+                np.copy(QLF_EFF4Compl_dNdzdmag[:, :-1])
+            QLF_EFF4Compl_dNdzdmag[1:, :] -= \
+                np.copy(QLF_EFF4Compl_dNdzdmag[:-1, :])
 
             self.QLF_EFF4Compl_dNdzdmag = QLF_EFF4Compl_dNdzdmag
 
             # QLF
             interpQLF_Ndzdmag = np.cumsum(np.cumsum(
-                self.interpQLF_dNdzdmag, axis = 0), axis = 1)
+                self.interpQLF_dNdzdmag, axis=0), axis=1)
 
             f2d_QLF = interp2d(xnew, ynew, interpQLF_Ndzdmag,
-                                kind = 'linear', copy = True,
-                                bounds_error = True)
+                               kind='linear', copy=True,
+                               bounds_error=True)
 
             QLF4Compl_Ndzdmag = f2d_QLF(zlimit, maglimit)
 
             QLF4Compl_dNdzdmag = np.copy(QLF4Compl_Ndzdmag)
-            QLF4Compl_dNdzdmag[:, 1 :] -= \
-                np.copy(QLF4Compl_dNdzdmag[:, : -1])
-            QLF4Compl_dNdzdmag[1 :, :] -= \
-                np.copy(QLF4Compl_dNdzdmag[: -1, :])
+            QLF4Compl_dNdzdmag[:, 1:] -= \
+                np.copy(QLF4Compl_dNdzdmag[:, :-1])
+            QLF4Compl_dNdzdmag[1:, :] -= \
+                np.copy(QLF4Compl_dNdzdmag[:-1, :])
 
             self.QLF4Compl_dNdzdmag = QLF4Compl_dNdzdmag
 
-            self.Compl_dzdmag = self.QLF_EFF4Compl_dNdzdmag[1:,1:] / self.QLF4Compl_dNdzdmag[1:,1:]
+            self.Compl_dzdmag = self.QLF_EFF4Compl_dNdzdmag[1:, 1:] / self.QLF4Compl_dNdzdmag[1:, 1:]
             self.Compl_dzdmag[np.isnan(self.Compl_dzdmag)] = 0.
             self.Compl_dzdmag[np.isinf(self.Compl_dzdmag)] = 0.
 
@@ -308,11 +309,11 @@ class PredCountsFromQLF_Class():
 
         self.Eff4Compl_dzdmag = np.copy(self.Compl_dzdmag)
 
-        if True: # loi de poisson
-            self.EffVar4Compl_dzdmag = self.Eff4Compl_dzdmag * (1. -  self.Eff4Compl_dzdmag)        
+        if True:  # loi de poisson
+            self.EffVar4Compl_dzdmag = self.Eff4Compl_dzdmag * (1. - self.Eff4Compl_dzdmag)
             self.EffVar4Compl_dzdmag /= OBJ_QSO_dNdzdmag
             self.EffVar4Compl_dzdmag[OBJ_QSO_dNdzdmag == 0.] = 0.
-        else: # loi binomiale
+        else:  # loi binomiale
             self.Count4Complt_Ndzdmag = self.Eff4Compl_dzdmag * OBJ_QSO_dNdzdmag
             self.EffVar4Compl_dzdmag = OBJ_QSO_dNdzdmag - self.Count4Complt_Ndzdmag + 1.
             self.EffVar4Compl_dzdmag *= self.Count4Complt_Ndzdmag + 1.
@@ -323,10 +324,10 @@ class PredCountsFromQLF_Class():
 
     def ZRED_EffVarEvalFunc(self):
 
-        self.EffVar4Compl_dz = self.EffVar4Compl_dzdmag * (self.QLF4Compl_dNdzdmag[1:,1:])**2
+        self.EffVar4Compl_dz = self.EffVar4Compl_dzdmag * (self.QLF4Compl_dNdzdmag[1:, 1:])**2
 
-        self.EffVar4Compl_dz = np.sum(self.EffVar4Compl_dz, axis = 0)
-        tmp_var = np.sum(self.QLF4Compl_dNdzdmag[1:,1:], axis = 0)**2
+        self.EffVar4Compl_dz = np.sum(self.EffVar4Compl_dz, axis=0)
+        tmp_var = np.sum(self.QLF4Compl_dNdzdmag[1:, 1:], axis=0)**2
         self.EffVar4Compl_dz /= tmp_var
 
         self.EffVar4Compl_dz[tmp_var == 0.] = 0.
@@ -335,10 +336,10 @@ class PredCountsFromQLF_Class():
 
     def R_EffVarEvalFunc(self):
 
-        self.EffVar4Compl_dmag = self.EffVar4Compl_dzdmag * (self.QLF4Compl_dNdzdmag[1:,1:])**2
+        self.EffVar4Compl_dmag = self.EffVar4Compl_dzdmag * (self.QLF4Compl_dNdzdmag[1:, 1:])**2
 
-        self.EffVar4Compl_dmag = np.sum(self.EffVar4Compl_dmag, axis = 1)
-        tmp_var = np.sum(self.QLF4Compl_dNdzdmag[1:,1:], axis = 1)**2
+        self.EffVar4Compl_dmag = np.sum(self.EffVar4Compl_dmag, axis=1)
+        tmp_var = np.sum(self.QLF4Compl_dNdzdmag[1:, 1:], axis=1)**2
         self.EffVar4Compl_dmag /= tmp_var
 
         self.EffVar4Compl_dmag[tmp_var == 0.] = 0.

--- a/py/desitarget/train/train_test_RF/util/Scikit_RF_TO_DESI_RF.py
+++ b/py/desitarget/train/train_test_RF/util/Scikit_RF_TO_DESI_RF.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import joblib # VERSION 0.9.4 < 0.10.0 to get separate files
+import joblib  # VERSION 0.9.4 < 0.10.0 to get separate files
 from sklearn.externals import joblib as skljoblib
 from myRF import myRF
 
@@ -12,11 +12,11 @@ print(" Il faut utiliser l'environement export_RF : conda activate export_RF")
 VERSION = 2
 nTrees = 500
 
-fpn_SCIKIT_RFmodel =  "./WorkingDir/DR9s/RFmodel/DR9s_LOW/model_DR9s_LOW_z[0.0, 6.0]_MDepth30_MLNodes1000_nTrees500.pkl.gz"
+fpn_SCIKIT_RFmodel = "./WorkingDir/DR9s/RFmodel/DR9s_LOW/model_DR9s_LOW_z[0.0, 6.0]_MDepth30_MLNodes1000_nTrees500.pkl.gz"
 fpn_DESI_RFmodel = "./Res/rf_model_dr9s_test.npz"
 
-#fpn_SCIKIT_RFmodel =  "./WorkingDir/DR9s/RFmodel/DR9s_HighZ/model_DR9s_HighZ_z[3.2, 6.0]_MDepth28_MLNodes1000_nTrees500.pkl.gz"
-#fpn_DESI_RFmodel = "./Res/rf_model_dr9s_HighZ.npz"
+# fpn_SCIKIT_RFmodel = "./WorkingDir/DR9s/RFmodel/DR9s_HighZ/model_DR9s_HighZ_z[3.2, 6.0]_MDepth28_MLNodes1000_nTrees500.pkl.gz"
+# fpn_DESI_RFmodel = "./Res/rf_model_dr9s_HighZ.npz"
 
 dpn_DESI_RFmodel = "./tmpdir/"
 
@@ -25,10 +25,9 @@ RF = skljoblib.load(fpn_SCIKIT_RFmodel)
 print("\nLoading RF :", fpn_SCIKIT_RFmodel, "\n")
 
 # Sauvegarde du RF fragmenté en plusieurs fichiers accessibles par myRF
-s = joblib.dump(list(RF), dpn_DESI_RFmodel + "bdt.pkl", compress = False)
-
+s = joblib.dump(list(RF), dpn_DESI_RFmodel + "bdt.pkl", compress=False)
 
 # Conversion et sauvegarde du RF au format DESI
-data = np.array([ ]).astype(float)
-myrf = myRF(data, dpn_DESI_RFmodel, numberOfTrees = nTrees, version = VERSION)
+data = np.array([]).astype(float)
+myrf = myRF(data, dpn_DESI_RFmodel, numberOfTrees=nTrees, version=VERSION)
 myrf.saveForest(fpn_DESI_RFmodel)

--- a/py/desitarget/train/train_test_RF/util/funcs.py
+++ b/py/desitarget/train/train_test_RF/util/funcs.py
@@ -6,10 +6,10 @@ import operator
 import collections
 import numpy as np
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# ***Fonction qui produit un string formaté pour afficher une durée à partir
+# d'une quantité donnée en secondes***
 
-#***Fonction qui produit un string formaté pour afficher une durée à partir
-#   d'une quantité donnée en secondes***
 
 def Time2StrFunc(tm):
 
@@ -31,11 +31,10 @@ def Time2StrFunc(tm):
         tmStr.append("{:d} h".format(int(var_tm[0])))
 
     tmStr = tmStr[::-1]
-    tmStr = reduce(lambda a, b : a + ' - ' + b, tmStr)
+    tmStr = reduce(lambda a, b: a + ' - ' + b, tmStr)
 
     return tmStr
 
-#------------------------------------------------------------------------------
 
 def shift_photo_north(gflux=None, rflux=None, zflux=None):
     """Convert fluxes in the northern (BASS/MzLS) to the southern (DECaLS) system.
@@ -66,7 +65,6 @@ def shift_photo_north(gflux=None, rflux=None, zflux=None):
 
     return gshift, rshift, zshift
 
-#------------------------------------------------------------------------------
 
 def _Flux2MagFunc(OBJ_Data_flux, OBJ_Data_mw_transmission):
 
@@ -79,63 +77,60 @@ def _Flux2MagFunc(OBJ_Data_flux, OBJ_Data_mw_transmission):
 
     return OBJ_mag
 
-#------------------------------------------------------------------------------
 
 def Flux2MagFunc(dataArray):
 
-    gflux  = dataArray.FLUX_G[:]/dataArray.MW_TRANSMISSION_G[:]
-    rflux  = dataArray.FLUX_R[:]/dataArray.MW_TRANSMISSION_R[:]
-    zflux  = dataArray.FLUX_Z[:]/dataArray.MW_TRANSMISSION_Z[:]
+    gflux = dataArray.FLUX_G[:]/dataArray.MW_TRANSMISSION_G[:]
+    rflux = dataArray.FLUX_R[:]/dataArray.MW_TRANSMISSION_R[:]
+    zflux = dataArray.FLUX_Z[:]/dataArray.MW_TRANSMISSION_Z[:]
     W1flux = dataArray.FLUX_W1[:]/dataArray.MW_TRANSMISSION_W1[:]
     W2flux = dataArray.FLUX_W2[:]/dataArray.MW_TRANSMISSION_W2[:]
 
-    limitInf=1.e-04
+    limitInf = 1.e-04
     gflux = gflux.clip(limitInf)
     rflux = rflux.clip(limitInf)
     zflux = zflux.clip(limitInf)
     W1flux = W1flux.clip(limitInf)
     W2flux = W2flux.clip(limitInf)
 
-    g=np.where(gflux>limitInf,22.5-2.5*np.log10(gflux), 0.)
-    r=np.where(rflux>limitInf,22.5-2.5*np.log10(rflux), 0.)
-    z=np.where(zflux>limitInf,22.5-2.5*np.log10(zflux), 0.)
-    W1=np.where(W1flux>limitInf, 22.5-2.5*np.log10(W1flux), 0.)
-    W2=np.where(W2flux>limitInf, 22.5-2.5*np.log10(W2flux), 0.)
+    g = np.where(gflux > limitInf, 22.5-2.5*np.log10(gflux), 0.)
+    r = np.where(rflux > limitInf, 22.5-2.5*np.log10(rflux), 0.)
+    z = np.where(zflux > limitInf, 22.5-2.5*np.log10(zflux), 0.)
+    W1 = np.where(W1flux > limitInf, 22.5-2.5*np.log10(W1flux), 0.)
+    W2 = np.where(W2flux > limitInf, 22.5-2.5*np.log10(W2flux), 0.)
 
-    g[np.isnan(g)]=0.
-    g[np.isinf(g)]=0.
-    r[np.isnan(r)]=0.
-    r[np.isinf(r)]=0.
-    z[np.isnan(z)]=0.
-    z[np.isinf(z)]=0.
-    W1[np.isnan(W1)]=0.
-    W1[np.isinf(W1)]=0.
-    W2[np.isnan(W2)]=0.
-    W2[np.isinf(W2)]=0.
+    g[np.isnan(g)] = 0.
+    g[np.isinf(g)] = 0.
+    r[np.isnan(r)] = 0.
+    r[np.isinf(r)] = 0.
+    z[np.isnan(z)] = 0.
+    z[np.isinf(z)] = 0.
+    W1[np.isnan(W1)] = 0.
+    W1[np.isinf(W1)] = 0.
+    W2[np.isnan(W2)] = 0.
+    W2[np.isinf(W2)] = 0.
 
-    return g,r,z,W1,W2
+    return g, r, z, W1, W2
 
-#------------------------------------------------------------------------------
 
-def ColorsFunc(nbEntries,nfeatures,g,r,z,W1,W2):
+def ColorsFunc(nbEntries, nfeatures, g, r, z, W1, W2):
 
-    colors  = np.zeros((nbEntries,nfeatures))
+    colors = np.zeros((nbEntries, nfeatures))
 
-    colors[:,0]=g-r
-    colors[:,1]=r-z
-    colors[:,2]=g-z
-    colors[:,3]=g-W1
-    colors[:,4]=r-W1
-    colors[:,5]=z-W1
-    colors[:,6]=g-W2
-    colors[:,7]=r-W2
-    colors[:,8]=z-W2
-    colors[:,9]=W1-W2
-    colors[:,10]=r
+    colors[:, 0] = g-r
+    colors[:, 1] = r-z
+    colors[:, 2] = g-z
+    colors[:, 3] = g-W1
+    colors[:, 4] = r-W1
+    colors[:, 5] = z-W1
+    colors[:, 6] = g-W2
+    colors[:, 7] = r-W2
+    colors[:, 8] = z-W2
+    colors[:, 9] = W1-W2
+    colors[:, 10] = r
 
     return colors
 
-#------------------------------------------------------------------------------
 
 def GetColorsFunc(data, color_names):
 
@@ -143,55 +138,56 @@ def GetColorsFunc(data, color_names):
 
     for i, col_name in enumerate(color_names):
 
-        colors[:,i] = data[col_name]
+        colors[:, i] = data[col_name]
 
     return colors
 
-#------------------------------------------------------------------------------
 
 def AreaFunc(dec1, dec2, alpha1, alpha2):
     res = (alpha2 - alpha1) * (np.sin(dec2) - np.sin(dec1)) * (180. / np.pi)**2
     return res
 
-#------------------------------------------------------------------------------
 
-def RA_DEC_AreaFunc(OBJ_RA, OBJ_DEC, binVect_RA, binVect_DEC, N_OBJ_th = 2):
+def RA_DEC_AreaFunc(OBJ_RA, OBJ_DEC, binVect_RA, binVect_DEC, N_OBJ_th=2):
 
     RA_DEC_meshgrid = np.meshgrid(binVect_RA, binVect_DEC)
 
-    OBJ_dNdRAdDEC = np.histogram2d(x = OBJ_DEC, y = OBJ_RA,
-        bins = [binVect_DEC, binVect_RA])[0]
+    OBJ_dNdRAdDEC = np.histogram2d(x=OBJ_DEC, y=OBJ_RA,
+                                   bins=[binVect_DEC, binVect_RA])[0]
 
     med_OBJ_dNdRAdDEC = np.median(OBJ_dNdRAdDEC)
 
-    skyArea_meshgrid = AreaFunc(RA_DEC_meshgrid[1][0 : -1, 0 : -1] * np.pi / 180.,
-                                 RA_DEC_meshgrid[1][1 :   , 0 : -1] * np.pi / 180.,
-                                 RA_DEC_meshgrid[0][0 : -1, 0 : -1] * np.pi / 180.,
-                                 RA_DEC_meshgrid[0][0 : -1, 1 :   ] * np.pi / 180.)
+    skyArea_meshgrid = AreaFunc(RA_DEC_meshgrid[1][0:-1, 0:-1] * np.pi / 180.,
+                                RA_DEC_meshgrid[1][1:, 0: -1] * np.pi / 180.,
+                                RA_DEC_meshgrid[0][0:-1, 0: -1] * np.pi / 180.,
+                                RA_DEC_meshgrid[0][0:-1, 1:] * np.pi / 180.)
 
     area_OK = (OBJ_dNdRAdDEC) >= N_OBJ_th
     res_area = np.sum(skyArea_meshgrid[area_OK])
 
     return res_area, med_OBJ_dNdRAdDEC
 
-#------------------------------------------------------------------------------
 
 def getFromDict(dataDict, mapList):
     return reduce(operator.getitem, mapList, dataDict)
 
+
 def setInDict(dataDict, mapList, value):
     getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
+
 
 def speGetFromDict(dataDict, tag):
     mapList = tag.split(':')
     return getFromDict(dataDict, mapList)
 
+
 def speSetInDict(dataDict, tag, value):
     mapList = tag.split(':')
     getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
 
-# 'RecursiveHyParamDictExplorationFunc' = 'Tree2FlatHyParamDictConversionFunc'
+
 def RecHyParamDictExplFunc(hyParamDict):
+    # 'RecursiveHyParamDictExplorationFunc' = 'Tree2FlatHyParamDictConversionFunc'
 
     new_dict = collections.OrderedDict()
 
@@ -210,8 +206,9 @@ def RecHyParamDictExplFunc(hyParamDict):
 
     return new_dict
 
-# 'Flat2TreeHyParamDictConversionFunc'
+
 def Flat2TreeHyParamConvFunc(coords, hyParamDictTemplate, hyParamSpaceTags, hyParamSpaceItems):
+    # 'Flat2TreeHyParamDictConversionFunc'
 
     for it, indEl in enumerate(coords):
 
@@ -222,16 +219,14 @@ def Flat2TreeHyParamConvFunc(coords, hyParamDictTemplate, hyParamSpaceTags, hyPa
 
     return hyParamDictTemplate
 
-#------------------------------------------------------------------------------
 
-def proba_rmag_func(OBJ_rmag, proba_thold = 0.5,
-                     rmag_thold = [20.], slope = [0.05]) :
+def proba_rmag_func(OBJ_rmag, proba_thold=0.5, rmag_thold=[20.], slope=[0.05]):
 
     n_segments = len(rmag_thold)
     if n_segments > 1:
         test = np.array(rmag_thold)
         test = np.sort(test) == test
-        if not(np.all(test)) :
+        if not(np.all(test)):
             assert(False), "ATTENTION : rmag_thold non ordonné croissant"
 
     proba_thold_rmag = np.ones(OBJ_rmag.size) * proba_thold
@@ -239,7 +234,7 @@ def proba_rmag_func(OBJ_rmag, proba_thold = 0.5,
 
     for num_seg in range(n_segments):
 
-        test_rmag_thold  = OBJ_rmag > rmag_thold[num_seg]
+        test_rmag_thold = OBJ_rmag > rmag_thold[num_seg]
 
         if num_seg < (n_segments - 1):
 


### PR DESCRIPTION
This PR includes some necessary additions and (relatively minor) bug fixes that were discovered by going on-sky for SV using the DR9 imaging. It includes:

- The `MASKBITS` column is now passed forward for the GFAs.
- A few bug fixes necessitated by the target files potentially having a second extension, which was added in #641.
    * Most notably, not all of the shasums were being checked in the case of overlapping imaging when the exact same sweep filename appeared in both the North and the South.
- Some minor additional functionality for creating randoms.