### PR TITLE
General clean-up before running targets with the final DR9 imaging

### DIFF
--- a/bin/combine_randoms
+++ b/bin/combine_randoms
@@ -16,7 +16,7 @@ ap = ArgumentParser(
     description='Combine N random and "-outside-" catalogs into "-allsky-" catalogs. Make the data model ' +
     'resemble the random catalogs with zeros where the "-outside-" catalogs have no data. This can be easily '+  
     'batched in a slurm file, for example, one line in such a file might be: '+
-    'srun -N 1 ./make_comb_randoms /global/cfs/cdirs/desi/target/catalogs/dr9/0.48.0/randoms/resolve/ -s 1-13 &')
+    'srun -N 1 ./combine_randoms /global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/randoms/resolve/ -s 1-13 &')
 ap.add_argument("randir",
                 help='Full path to the DIRECTORY containing random files (e.g /global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/randoms/resolve).')
 ap.add_argument("-s", "--seedstring",

--- a/bin/make_comb_randoms
+++ b/bin/make_comb_randoms
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+import os, sys
+import numpy as np
+import fitsio
+from time import time
+start = time()
+import fitsio
+
+from desiutil.log import get_logger
+log = get_logger()
+from desitarget.io import write_in_chunks
+
+from argparse import ArgumentParser
+ap = ArgumentParser(
+    description='Combine N random and "-outside-" catalogs into "-allsky-" catalogs. Make the data model ' +
+    'resemble the random catalogs with zeros where the "-outside-" catalogs have no data. This can be easily '+  
+    'batched in a slurm file, for example, one line in such a file might be: '+
+    'srun -N 1 ./make_comb_randoms /global/cfs/cdirs/desi/target/catalogs/dr9/0.48.0/randoms/resolve/ -s 1-13 &')
+ap.add_argument("randir",
+                help='Full path to the DIRECTORY containing random files (e.g /global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/randoms/resolve).')
+ap.add_argument("-s", "--seedstring",
+                help='Part of the filename that corresponds to the unique seed(s) used to run the randoms. The (corresponding) catalogs should be called \
+                randoms-{seedstring}.fits and randoms-outside-{seedstring}.fits')
+ap.add_argument("-nc", "--nchunks", type=int,
+                help='Number of chunks to write the file in to save memory [10].',
+                default=10)
+
+ns = ap.parse_args()
+
+log.info(
+    "Working on file {}...t={:.1f}s".format(ns.seedstring, time()-start)
+)
+# ADM determine the file names for the supp and randoms files.
+rcfn = os.path.join(ns.randir, "randoms-{}.fits".format(ns.seedstring))
+suppfn = os.path.join(ns.randir, "randoms-outside-{}.fits".format(ns.seedstring))
+combfn = os.path.join(ns.randir, "randoms-allsky-{}.fits".format(ns.seedstring))
+
+# ADM read in the random catalog and it's header.
+tempins, hdr = fitsio.read(rcfn, header=True)
+# ADM read in the supp file.
+tempouts = fitsio.read(suppfn)
+log.info(
+    "Read in files {} inside, {} outside...t={:.1f}s".format(
+        len(tempins), len(tempouts), time()-start)
+)
+
+# ADM add zeros for the missing columns in the random catalog
+# ADM and make dtype uniform.
+dt=[('RA', '>f8'), ('DEC', '>f8'), ('BRICKNAME', '<U8'), ('BRICKID', '>i4'),
+    ('NOBS_G', '>i2'), ('NOBS_R', '>i2'), ('NOBS_Z', '>i2'),
+    ('PSFDEPTH_G', '>f4'), ('PSFDEPTH_R', '>f4'), ('PSFDEPTH_Z', '>f4'),
+    ('GALDEPTH_G', '>f4'), ('GALDEPTH_R', '>f4'), ('GALDEPTH_Z', '>f4'),
+    ('PSFDEPTH_W1', '>f4'), ('PSFDEPTH_W2', '>f4'),
+    ('PSFSIZE_G', '>f4'), ('PSFSIZE_R', '>f4'), ('PSFSIZE_Z', '>f4'),
+    ('APFLUX_G', '>f4'), ('APFLUX_R', '>f4'), ('APFLUX_Z', '>f4'),
+    ('APFLUX_IVAR_G', '>f4'), ('APFLUX_IVAR_R', '>f4'), ('APFLUX_IVAR_Z', '>f4'),
+    ('MASKBITS', '>i2'), ('WISEMASK_W1', 'u1'), ('WISEMASK_W2', 'u1'),
+    ('EBV', '>f4'), ('PHOTSYS', '<U1'), ('HPXPIXEL', '>i8')]
+
+inside = np.zeros(len(tempins), dtype=dt)
+outside = np.zeros(len(tempouts), dtype=dt)
+# ADM these are different because we are adding zerod colums to the
+# ADM outside files, but removing some columns from the inside files.
+for col in tempouts.dtype.names:
+    outside[col] = tempouts[col]
+for col in inside.dtype.names:
+    inside[col] = tempins[col]
+
+log.info("Populated zeros...t={:.1f}s".format(time()-start))
+
+# ADM combine the inside and outside randoms...
+rands = np.concatenate([outside, inside])
+# ADM ...shuffle them...
+nrands = len(rands)
+indexes = np.arange(nrands)
+np.random.seed(646)
+np.random.shuffle(indexes)
+
+log.info("Writing out file...t={:.1f}s".format(time()-start))
+# ADM ...and write them out.
+nchunks = ns.nchunks
+outy = fitsio.FITS(combfn, 'rw', clobber=True)
+# ADM write the chunks one-by-one.
+chunk = len(indexes)//nchunks
+for i in range(nchunks):
+    log.info("Writing chunk {}/{} from index {} to {}...t = {:.1f}s"
+             .format(i+1, nchunks, i*chunk, (i+1)*chunk-1, time()-start))
+    ichunk = indexes[i*chunk:(i+1)*chunk]
+    # ADM if this is the first chunk, write the data and header...
+    if i == 0:
+        outy.write(rands[ichunk], extname='RANDOMS', header=hdr)
+    # ADM ...otherwise just append to the existing file object.
+    else:
+        outy[-1].append(rands[ichunk])
+# ADM append any remaining data.
+ichunk = indexes[nchunks*chunk:]
+log.info("Writing final partial chunk from index {} to {}...t = {:.1f}s"
+         .format(nchunks*chunk, len(indexes)-1, time()-start))
+outy[-1].append(rands[ichunk])
+outy.close()
+
+log.info("Done...t={:.1f}s".format(time()-start))

--- a/bin/select_secondary
+++ b/bin/select_secondary
@@ -57,7 +57,7 @@ hdr['SEP'] = float(ns.separation)
 
 # ADM try to determine the Data Release from the priminfo file.
 try:
-    drint =ns. priminfodir.split('dr')[1].split('-')[0]
+    drint = ns.priminfodir.split('dr')[1].split('-')[0]
 except (ValueError, IndexError, AttributeError):
     drint = "X"
 

--- a/bin/supplement_randoms
+++ b/bin/supplement_randoms
@@ -27,7 +27,7 @@ ap.add_argument("dest",
 ap.add_argument("--density", type=int,
                 help='Number of points per sq. deg. to generate (defaults to the value of DENSITY in the header of the "randomcat" input file)',
                 default=None)
-ap.add_argument("--seed",
+ap.add_argument("--seed", type=int,
                 help='Force a particular seed to be used instead of reading from the header card "SEED"',
                 default=None)
 ap.add_argument("--numproc", type=int,
@@ -54,16 +54,25 @@ except OSError:
     sys.exit(1)
 
 # ADM determine the seed used for the existing random catalog.
-if ns.seed is None:
-    try:
-        seed = ranhead["SEED"]
-        log.info('read seed of {} from {}'.format(seed, ns.randomcat))
-    except KeyError:
-        seed = 1
-        log.info('defaulting to a SEED of {}'.format(seed))
-else:
-    seed = ns.seed
-    log.info('using a seed of 615 + {}' format(seed)
+try:
+    seed = ranhead["SEED"]
+    log.info('read original seed of {} from {}'.format(seed, ns.randomcat))
+except KeyError:
+    seed = 1
+    log.info('defaulting to an original SEED of {}'.format(seed))
+if ns.seed is not None:
+    # ADM if we enforced a new seed, store the original seed
+    # ADM but update to use the new seed.
+    origseed = seed
+    writeseed = ns.seed
+    batch = 20
+    if writeseed > batch-1:
+        log.error("Only set to batch 20 catalogs: Seed must be in range {}-{}"
+                  .format(0, writeseed-1))
+        raise IOError
+    seed = origseed*20 + writeseed
+    log.info('actually using a seed of {}*{}+{}={}'.format(
+        origseed, batch, writeseed, seed))
 
 # ADM grab the density used for the existing random catalog, if needed.
 if ns.density is None:
@@ -91,7 +100,11 @@ randoms = supplement_randoms(donebns, density=density, numproc=ns.numproc,
 
 # ADM extra header keywords for the output fits file.
 extra = {k: v for k, v in zip(["density", "seed"],
-                              [density, seed])}
+                              [density, writeseed])}
+# ADM if we enforced a new seed, also store the original seed
+# ADM that was used to make the original file of randoms.
+if ns.seed is not None:
+    extra["origseed"] = origseed
 
 # ADM write out the supplemental random catalog.
 nrands, outfile = io.write_randoms(ns.dest, randoms, indir=ns.randomcat,

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,16 @@ desitarget Change Log
 0.48.1 (unreleased)
 -------------------
 
-* No changes yet.
+* General clean-up for final DR9 imaging [`PR #670`_]. Includes:
+    * Shift Gaia-based morphological cuts to single function.
+    * Add or update wiki versions referenced in doc strings.
+    * Change cuts for bright, Main Survey standards to G > 16.
+    * Debug and streamline "outside-of-the-footprint" randoms.
+    * Read the actual RELEASE number for randoms from file headers.
+        * Previously, one RELEASE was adopted for each of North/South.
+    * Add new WD_BINARIES secondary program that is split by DARK/BRIGHT.
+
+.. _`PR #670`: https://github.com/desihub/desitarget/pull/670
 
 0.48.0 (2020-01-09)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,12 +6,16 @@ desitarget Change Log
 -------------------
 
 * General clean-up for final DR9 imaging [`PR #670`_]. Includes:
-    * Shift Gaia-based morphological cuts to single function.
+    * Debug primary-secondary cross-matching:
+        * remove duplicate secondaries that match two primaries...
+        * ...NOT duplicate primaries that match two secondaries.
+    * Catch if no Gaia sources are found when making Gaia-only standards.
+    * Shift Gaia-based morphological cuts to a single function.
     * Add or update wiki versions referenced in doc strings.
     * Change cuts for bright, Main Survey standards to G > 16.
     * Debug and streamline "outside-of-the-footprint" randoms.
     * Read the actual RELEASE number for randoms from file headers.
-        * Previously, one RELEASE was adopted for each of North/South.
+        * Rather than assuming a single, canonical North/South RELEASE.
     * Add new WD_BINARIES secondary program that is split by DARK/BRIGHT.
 
 .. _`PR #670`: https://github.com/desihub/desitarget/pull/670

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -34,7 +34,7 @@ from desitarget import io
 from desitarget.internal import sharedmem
 from desitarget.gaiamatch import match_gaia_to_primary, find_gaia_files_hp
 from desitarget.gaiamatch import pop_gaia_coords, pop_gaia_columns
-from desitarget.gaiamatch import gaia_dr_from_ref_cat, is_in_Galaxy
+from desitarget.gaiamatch import gaia_dr_from_ref_cat, is_in_Galaxy, gaia_psflike
 from desitarget.targets import finalize, resolve
 from desitarget.geomask import bundle_bricks, pixarea2nside, sweep_files_touch_hp
 from desitarget.geomask import box_area, hp_in_box, is_in_box, is_in_hp
@@ -198,10 +198,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
                       gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag)
 
     # ADM restrict to point sources.
-    ispsf = np.logical_or(
-        (gaiagmag <= 19.) * (gaiaaen < 10.**0.5),
-        (gaiagmag >= 19.) * (gaiaaen < 10.**(0.5 + 0.2*(gaiagmag - 19.)))
-    )
+    ispsf = gaia_psflike(gaiaaen, gaiagmag)
     std &= ispsf
 
     # ADM apply the Gaia color cuts for standards.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -254,7 +254,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
 
     # ADM add the brightness cuts in Gaia G-band.
     std_bright = std.copy()
-    std_bright &= gaiagmag >= 15
+    std_bright &= gaiagmag >= 16
     std_bright &= gaiagmag < 18
 
     std_faint = std.copy()
@@ -737,7 +737,7 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
 
     # ADM brightness cuts in Gaia G-band
     if bright:
-        gbright = 15.
+        gbright = 16.
         gfaint = 18.
     else:
         gbright = 16.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -168,7 +168,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
 
     Notes
     -----
-    - Current version (01/08/21) is version XXX on `the wiki`_.
+    - Current version (01/15/21) is version 236 on `the wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     if primary is None:
@@ -702,7 +702,7 @@ def isSTD(gflux=None, rflux=None, zflux=None, primary=None,
 
     Notes:
         - Gaia-based quantities are as in `the Gaia data model`_.
-        - Current version (08/01/18) is version 127 on `the wiki`_.
+        - Current version (01/15/21) is version 236 on `the wiki`_.
 
     """
     if primary is None:

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -112,6 +112,34 @@ def get_gaia_nside_brick(bricksize=0.25):
     return pixarea2nside(bricksize*bricksize)
 
 
+def gaia_psflike(aen, g):
+    """Whether an objects is PSF-like based on Gaia quantities.
+
+    Parameters
+    ----------
+    aen : :class:`array_like` or :class`float`
+        Gaia Astrometric Excess Noise.
+    g : :class:`array_like` or :class`float`
+        Gaia-based g MAGNITUDE (not Galactic-extinction-corrected).
+
+    Returns
+    -------
+    :class:`array_like` or :class`float`
+        A boolean that is ``True`` for objects that are psf-like
+        based on Gaia quantities.
+
+    Notes
+    -----
+        - Input quantities are the same as in `the Gaia data model`_.
+    """
+    psflike = np.logical_or(
+        (g <= 19.) * (aen < 10.**0.5),
+        (g >= 19.) * (aen < 10.**(0.5 + 0.2*(g - 19.)))
+    )
+
+    return psflike
+
+
 def is_in_Galaxy(objs, radec=False):
     """An (l, b) cut developed by Boris Gaensicke to avoid the Galaxy.
 

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -309,7 +309,7 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
         # ADM Gaia "00000" pixel file might not exist.
         dummyfile = find_gaia_files_hp(nside, pixlist[0],
                                        neighbors=False)[0]
-    dummygfas = np.array([], gaia_in_file(dummyfile).dtype)
+    dummygfas = np.array([], gaia_in_file(dummyfile, addparams=addparams).dtype)
 
     # ADM grab paths to Gaia files in the sky or the DESI footprint.
     if allsky:

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -20,7 +20,7 @@ import desitarget.io
 from desitarget.internal import sharedmem
 from desitarget.gaiamatch import read_gaia_file, find_gaia_files_beyond_gal_b
 from desitarget.gaiamatch import find_gaia_files_tiles, find_gaia_files_box
-from desitarget.gaiamatch import find_gaia_files_hp, _get_gaia_nside
+from desitarget.gaiamatch import find_gaia_files_hp, _get_gaia_nside, gaia_psflike
 from desitarget.uratmatch import match_to_urat
 from desitarget.targets import encode_targetid, resolve
 from desitarget.geomask import is_in_gal_box, is_in_box, is_in_hp
@@ -71,10 +71,7 @@ def gaia_morph(gaia):
     # ADM determine which objects are Gaia point sources.
     g = gaia['GAIA_PHOT_G_MEAN_MAG']
     aen = gaia['GAIA_ASTROMETRIC_EXCESS_NOISE']
-    psf = np.logical_or(
-        (g <= 19.) * (aen < 10.**0.5),
-        (g >= 19.) * (aen < 10.**(0.5 + 0.2*(g - 19.)))
-    )
+    psf = gaia_psflike(aen, g)
 
     # ADM populate morphological information.
     morph = np.zeros(len(gaia), dtype=gfadatamodel["TYPE"].dtype)

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -562,9 +562,11 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
         fnlist.append(tracfile)
         return fnlist
 
-    gen = iglob(os.path.join(drdir, "tractor", "*", "tractor*fits"))
+    # ADM populate the release number using a header from an nexp file.
+    fn = fileform.format(brickname, "nexp", '*', extn)
+    gen = iglob(fn)
     try:
-        release = fitsio.read(next(gen), columns="release", rows=0)[0]
+        release = fitsio.read_header(next(gen), extn_nb)["DRVERSIO"]
     # ADM if this isn't a standard DR structure, default to release=0.
     except StopIteration:
         release = 0

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1333,9 +1333,9 @@ def supplement_randoms(donebns, density=10000, numproc=32, dustdir=None,
         Number of random points per sq. deg. A typical brick is ~0.25 x
         0.25 sq. deg. so ~(0.0625*density) points will be returned.
     seed : :class:`int`, optional, defaults to 1
-        Random seed to use when shuffling across brick boundaries.
-        The actual np.random.seed defaults to 615+`seed`. Also see use
-        in :func:`~desitarget.randoms.randoms_in_a_brick_from_edges`.
+        See :func:`~desitarget.randoms.randoms_in_a_brick_from_edges`.
+        A seed of 615 + `seed` is also used to shuffle randoms across
+        brick boundaries.
 
     Returns
     -------

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -404,24 +404,7 @@ def add_primary_info(scxtargs, priminfodir):
     scxids = 1000 * scxtargs["SCND_ORDER"].astype('int64') + scxbitnum
     primids = 1000 * primtargs["SCND_ORDER"].astype('int64') + primbitnum
 
-    # ADM a primary (with the same TARGETID) could match TWO (or more)
-    # ADM secondaries. Resolve these on which matched a primary target
-    # ADM (rather than just a source from the sweeps) and then ALSO on
-    # ADM which has highest priority (via True/False * PRIORITY_INIT).
-    alldups = []
-    for _, dups in duplicates(primtargs['TARGETID']):
-        am = np.argmax(primtargs[dups]["PRIM_MATCH"]*primtargs[dups]["PRIORITY_INIT"])
-        dups = np.delete(dups, am)
-        alldups.append(dups)
-    # ADM catch cases where there are no duplicates.
-    if len(alldups) != 0:
-        alldups = np.hstack(alldups)
-        primtargs = np.delete(primtargs, alldups)
-        primids = np.delete(primids, alldups)
-    log.info("Discard {} cases where a primary matched multiple secondaries".
-             format(len(alldups)))
-
-    # ADM matches could also have occurred ACROSS HEALPixels, producing
+    # ADM matches could have occurred ACROSS HEALPixels, producing
     # ADM duplicated secondary targets with different TARGETIDs...
     alldups = []
     for _, dups in duplicates(primids):
@@ -437,7 +420,7 @@ def add_primary_info(scxtargs, priminfodir):
         alldups = np.hstack(alldups)
         primtargs = np.delete(primtargs, alldups)
         primids = np.delete(primids, alldups)
-    log.info("Remove {} other cases where a secondary matched several primaries".
+    log.info("Remove {} cases where a secondary matched several primaries".
              format(len(alldups)))
 
     # ADM we already know that all primaries match a secondary, so,
@@ -449,8 +432,6 @@ def add_primary_info(scxtargs, priminfodir):
 
     # ADM sort-to-match sxcid and primid.
     primii = np.zeros_like(primids)
-#    ii[np.argsort(origids)] = np.argsort(refids)
-#    assert np.all(refids[ii] == origids)
     primii[np.argsort(scxids[scxii])] = np.argsort(primids)
     assert np.all(primids[primii] == scxids[scxii])
 

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -371,6 +371,11 @@ def add_primary_info(scxtargs, priminfodir):
     :class:`~numpy.ndarray`
         The array of secondary targets, with the `TARGETID` column
         populated for matches to secondary targets
+
+    Notes
+    -----
+        - The input `scxtargs` is modified, so be careful to make
+          a copy if you want that variable to remain unchanged!
     """
     log.info("Begin matching primaries in {} to secondaries...t={:.1f}s"
              .format(priminfodir, time()-start))
@@ -621,7 +626,7 @@ def match_secondary(primtargs, scxdir, scndout, sep=1.,
     scxtargs["PRIM_MATCH"][mscx] = True
 
     # ADM now we're done matching the primary and secondary targets, also
-    # ADM match the secondary targets to sweep files, if passes, to find
+    # ADM match the secondary targets to sweep files, if passed, to find
     # ADM TARGETIDs.
     notid = scxtargs["TARGETID"] == -1
     if swfiles is not None and np.sum(notid) > 0:
@@ -737,6 +742,11 @@ def finalize_secondary(scxtargs, scnd_mask, survey='main', sep=1.,
         input `survey`. `RELEASE` is set to ((X-1)*100)+np.log2(scnd_bit)
         with X from the `survey` string survey=svX and scnd_bit from
         `SCND_TARGET`. For the main survey (survey="main") X-1 is 5.
+
+    Notes
+    -----
+        - The input `scxtargs` is modified, so be careful to make
+          a copy if you want that variable to remain unchanged!
     """
     # ADM assign new TARGETIDs to targets without a primary match.
     nomatch = scxtargs["TARGETID"] == -1

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -153,41 +153,42 @@ sv1_mws_mask:
 sv1_scnd_mask:
     - [VETO,                 0, "Never observe, even if a primary target bit is set",
         {obsconditions: DARK|GRAY|BRIGHT|POOR|TWILIGHT12|TWILIGHT18, filename: 'veto'}]
-    - [UDG,                  1, "See $SCND_DIR/UDG.txt",                {obsconditions: DARK,        filename: 'UDG'}]
-    - [FIRST_MALS,           2, "See $SCND_DIR/FIRST_MALS.txt",         {obsconditions: DARK,        filename: 'FIRST_MALS'}]
-    - [WD_BINARIES,          3, "See $SCND_DIR/WD_BINARIES.txt",        {obsconditions: BRIGHT|DARK, filename: 'WD_BINARIES'}]
-    - [LBG_TOMOG,            4, "See $SCND_DIR/LBG_TOMOG.txt",          {obsconditions: DARK,        filename: 'LBG_TOMOG'}]
-    - [QSO_RED,              5, "See $SCND_DIR/QSO_RED.ipynb",          {obsconditions: DARK,        filename: 'QSO_RED'}]
-    - [M31_KNOWN,            6, "See $SCND_DIR/M31_KNOWN.txt",          {obsconditions: DARK,        filename: 'M31_KNOWN'}]
-    - [M31_QSO,              7, "See $SCND_DIR/M31_QSO.txt.",           {obsconditions: DARK,        filename: 'M31_QSO'}]
-    - [M31_STAR,             8, "See $SCND_DIR/M31_STAR.txt",           {obsconditions: DARK,        filename: 'M31_STAR'}]
+    - [UDG,                  1, "See $SCND_DIR/sv1/docs/UDG.txt",                {obsconditions: DARK,        filename: 'UDG'}]
+    - [FIRST_MALS,           2, "See $SCND_DIR/sv1/docs/FIRST_MALS.txt",         {obsconditions: DARK,        filename: 'FIRST_MALS'}]
+# ADM the WD_BINARIES class was part of 0.48.0 but was then deprecated in favor of WD_BINARIES_DARK and WD_BINARIES_BRIGHT.
+#   - [WD_BINARIES,          3, "See $SCND_DIR/sv1/docs/WD_BINARIES.txt",        {obsconditions: BRIGHT|DARK, filename: 'WD_BINARIES'}]
+    - [LBG_TOMOG,            4, "See $SCND_DIR/sv1/docs/LBG_TOMOG.txt",          {obsconditions: DARK,        filename: 'LBG_TOMOG'}]
+    - [QSO_RED,              5, "See $SCND_DIR/sv1/docs/QSO_RED.ipynb",          {obsconditions: DARK,        filename: 'QSO_RED'}]
+    - [M31_KNOWN,            6, "See $SCND_DIR/sv1/docs/M31_KNOWN.txt",          {obsconditions: DARK,        filename: 'M31_KNOWN'}]
+    - [M31_QSO,              7, "See $SCND_DIR/sv1/docs/M31_QSO.txt.",           {obsconditions: DARK,        filename: 'M31_QSO'}]
+    - [M31_STAR,             8, "See $SCND_DIR/sv1/docs/M31_STAR.txt",           {obsconditions: DARK,        filename: 'M31_STAR'}]
 #   - [MWS_DDOGIANTS,        9, "See $SCND_DIR",                        {obsconditions: BRIGHT,      filename: 'MWS_DDOGIANTS'}]
-    - [MWS_CLUS_GAL_DEEP,   10, "See $SCND_DIR/MWS_CLUS_GAL_DEEP.txt",  {obsconditions: DARK,        filename: 'MWS_CLUS_GAL_DEEP'}]
-    - [LOW_MASS_AGN,        11, "See $SCND_DIR/LOW_MASS_AGN.txt",       {obsconditions: DARK,        filename: 'LOW_MASS_AGN'}]
-    - [FAINT_HPM,           12, "See $SCND_DIR/FAINT_HPM.txt",          {obsconditions: DARK,        filename: 'FAINT_HPM'}]
-    - [GW190412,            13, "See $SCND_DIR/GW190412.ipynb",         {obsconditions: BRIGHT|DARK, filename: 'GW190412'}]
-    - [IC134191,            14, "See $SCND_DIR/IC134191.ipynb",         {obsconditions: BRIGHT|DARK, filename: 'IC134191'}]
-    - [PV_BRIGHT,           15, "See $SCND_DIR/PV_BRIGHT.ipynb",        {obsconditions: BRIGHT,      filename: 'PV_BRIGHT'}]
-    - [PV_DARK,             16, "See $SCND_DIR/PV_DARK.ipynb",          {obsconditions: DARK,        filename: 'PV_DARK'}]
-    - [LOW_Z,               17, "See $SCND_DIR/LOW_Z.ipynb",            {obsconditions: DARK,        filename: 'LOW_Z'}]
-    - [BHB,                 18, "See $SCND_DIR/BHB.txt",                {obsconditions: DARK,        filename: 'BHB'}]
-    - [SPCV,                19, "See $SCND_DIR/SPCV.txt",               {obsconditions: DARK,        filename: 'SPCV'}]
-    - [DC3R2_GAMA,          20, "See $SCND_DIR/DC3R2_GAMA.ipynb",       {obsconditions: DARK,        filename: 'DC3R2_GAMA'}]
-    - [UNWISE_BLUE,         21, "See $SCND_DIR/UNWISE_BLUE.txt",        {obsconditions: DARK,        filename: 'UNWISE_BLUE'}]
-    - [UNWISE_GREEN,        22, "See $SCND_DIR/UNWISE_GREEN.txt",       {obsconditions: DARK,        filename: 'UNWISE_GREEN'}]
-    - [HETDEX_MAIN,         23, "See $SCND_DIR/HETDEX_MAIN.txt",        {obsconditions: DARK,        filename: 'HETDEX_MAIN'}]
-    - [HETDEX_HP,           24, "See $SCND_DIR/HETDEX_HP.txt",          {obsconditions: DARK,        filename: 'HETDEX_HP'}]
+    - [MWS_CLUS_GAL_DEEP,   10, "See $SCND_DIR/sv1/docs/MWS_CLUS_GAL_DEEP.txt",  {obsconditions: DARK,        filename: 'MWS_CLUS_GAL_DEEP'}]
+    - [LOW_MASS_AGN,        11, "See $SCND_DIR/sv1/docs/LOW_MASS_AGN.txt",       {obsconditions: DARK,        filename: 'LOW_MASS_AGN'}]
+    - [FAINT_HPM,           12, "See $SCND_DIR/sv1/docs/FAINT_HPM.txt",          {obsconditions: DARK,        filename: 'FAINT_HPM'}]
+    - [GW190412,            13, "See $SCND_DIR/sv1/docs/GW190412.ipynb",         {obsconditions: BRIGHT|DARK, filename: 'GW190412'}]
+    - [IC134191,            14, "See $SCND_DIR/sv1/docs/IC134191.ipynb",         {obsconditions: BRIGHT|DARK, filename: 'IC134191'}]
+    - [PV_BRIGHT,           15, "See $SCND_DIR/sv1/docs/PV_BRIGHT.ipynb",        {obsconditions: BRIGHT,      filename: 'PV_BRIGHT'}]
+    - [PV_DARK,             16, "See $SCND_DIR/sv1/docs/PV_DARK.ipynb",          {obsconditions: DARK,        filename: 'PV_DARK'}]
+    - [LOW_Z,               17, "See $SCND_DIR/sv1/docs/LOW_Z.ipynb",            {obsconditions: DARK,        filename: 'LOW_Z'}]
+    - [BHB,                 18, "See $SCND_DIR/sv1/docs/BHB.txt",                {obsconditions: DARK,        filename: 'BHB'}]
+    - [SPCV,                19, "See $SCND_DIR/sv1/docs/SPCV.txt",               {obsconditions: DARK,        filename: 'SPCV'}]
+    - [DC3R2_GAMA,          20, "See $SCND_DIR/sv1/docs/DC3R2_GAMA.ipynb",       {obsconditions: DARK,        filename: 'DC3R2_GAMA'}]
+    - [UNWISE_BLUE,         21, "See $SCND_DIR/sv1/docs/UNWISE_BLUE.txt",        {obsconditions: DARK,        filename: 'UNWISE_BLUE'}]
+    - [UNWISE_GREEN,        22, "See $SCND_DIR/sv1/docs/UNWISE_GREEN.txt",       {obsconditions: DARK,        filename: 'UNWISE_GREEN'}]
+    - [HETDEX_MAIN,         23, "See $SCND_DIR/sv1/docs/HETDEX_MAIN.txt",        {obsconditions: DARK,        filename: 'HETDEX_MAIN'}]
+    - [HETDEX_HP,           24, "See $SCND_DIR/sv1/docs/HETDEX_HP.txt",          {obsconditions: DARK,        filename: 'HETDEX_HP'}]
 #   - [PSF_OUT_BRIGHT,      25, "See $SCND_DIR",                        {obsconditions: BRIGHT,      filename: 'PSF_OUT_BRIGHT'}]
 #   - [PSF_OUT_DARK,        26, "See $SCND_DIR",                        {obsconditions: DARK,        filename: 'PSF_OUT_DARK'}]
-    - [HPM_SOUM,            27, "See $SCND_DIR/HPM_SOUM.txt",           {obsconditions: DARK,        filename: 'HPM_SOUM'}]
-    - [SN_HOSTS,            28, "See $SCND_DIR/SN_HOSTS.txt",           {obsconditions: DARK,        filename: 'SN_HOSTS'}]
-    - [GAL_CLUS_BCG,        29, "See $SCND_DIR/GAL_CLUS_BCG.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_BCG'}]
-    - [GAL_CLUS_2ND,        30, "See $SCND_DIR/GAL_CLUS_2ND.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_2ND'}]
-    - [GAL_CLUS_SAT,        31, "See $SCND_DIR/GAL_CLUS_SAT.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_SAT'}]
-    - [HSC_HIZ_SNE,         32, "See $SCND_DIR/HSC_HIZ_SNE.txt",        {obsconditions: DARK,        filename: 'HSC_HIZ_SNE'}]
-    - [ISM_CGM_QGP,         33, "See $SCND_DIR/ISM_CGM_QGP.txt",        {obsconditions: DARK,        filename: 'ISM_CGM_QGP'}]
-    - [STRONG_LENS,         34, "See $SCND_DIR/STRONG_LENS.txt",        {obsconditions: DARK,        filename: 'STRONG_LENS'}]
-    - [WISE_VAR_QSO,        35, "See $SCND_DIR/WISE_VAR_QSO.txt",       {obsconditions: DARK,        filename: 'WISE_VAR_QSO'}]
+    - [HPM_SOUM,            27, "See $SCND_DIR/sv1/docs/HPM_SOUM.txt",           {obsconditions: DARK,        filename: 'HPM_SOUM'}]
+    - [SN_HOSTS,            28, "See $SCND_DIR/sv1/docs/SN_HOSTS.txt",           {obsconditions: DARK,        filename: 'SN_HOSTS'}]
+    - [GAL_CLUS_BCG,        29, "See $SCND_DIR/sv1/docs/GAL_CLUS_BCG.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_BCG'}]
+    - [GAL_CLUS_2ND,        30, "See $SCND_DIR/sv1/docs/GAL_CLUS_2ND.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_2ND'}]
+    - [GAL_CLUS_SAT,        31, "See $SCND_DIR/sv1/docs/GAL_CLUS_SAT.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_SAT'}]
+    - [HSC_HIZ_SNE,         32, "See $SCND_DIR/sv1/docs/HSC_HIZ_SNE.txt",        {obsconditions: DARK,        filename: 'HSC_HIZ_SNE'}]
+    - [ISM_CGM_QGP,         33, "See $SCND_DIR/sv1/docs/ISM_CGM_QGP.txt",        {obsconditions: DARK,        filename: 'ISM_CGM_QGP'}]
+    - [STRONG_LENS,         34, "See $SCND_DIR/sv1/docs/STRONG_LENS.txt",        {obsconditions: DARK,        filename: 'STRONG_LENS'}]
+    - [WISE_VAR_QSO,        35, "See $SCND_DIR/sv1/docs/WISE_VAR_QSO.txt",       {obsconditions: DARK,        filename: 'WISE_VAR_QSO'}]
     - [MWS_CALIB,           36, "Stars with APOGEE/BOSS/GALAH/GAIAESO spectra",
         {obsconditions: DARK|GRAY|BRIGHT, filename: 'MWS_CALIB'}]
     - [BACKUP_CALIB,        37, "Very bright stars with APOGEE/BOSS/GALAH/GAIAESO spectra",
@@ -196,7 +197,9 @@ sv1_scnd_mask:
         {obsconditions: DARK|GRAY|BRIGHT, filename: 'MWS_MAIN_CLUSTER_SV'}]
     - [MWS_RRLYR,           39, "Main survey halo tracers (RR Lyrae)",
         {obsconditions: DARK|GRAY|BRIGHT, filename: 'MWS_RRLYR'}]
-    - [BRIGHT_HPM,          40, "See $SCND_DIR/BRIGHT_HPM.txt",         {obsconditions: BRIGHT,      filename: 'BRIGHT_HPM'}]
+    - [BRIGHT_HPM,          40, "See $SCND_DIR/sv1/docs/BRIGHT_HPM.txt",         {obsconditions: BRIGHT,      filename: 'BRIGHT_HPM'}]
+    - [WD_BINARIES_BRIGHT,  41, "See $SCND_DIR/sv1/docs/WD_BINARIES_BRIGHT.txt", {obsconditions: BRIGHT,      filename: 'WD_BINARIES_BRIGHT'}]
+    - [WD_BINARIES_DARK,    42, "See $SCND_DIR/sv1/docs/WD_BINARIES_DARK.txt",   {obsconditions: DARK,        filename: 'WD_BINARIES_DARK'}]
 
 #- Observation State
 #- if a target passes more than one target bit, it is possible that one bit
@@ -350,7 +353,7 @@ priorities:
         VETO:                  {UNOBS:  0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
         UDG:                   {UNOBS: 1900, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
         FIRST_MALS:            {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        WD_BINARIES:           {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+#       WD_BINARIES:           {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
         LBG_TOMOG:             {UNOBS: 1800, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
         QSO_RED:               {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         M31_KNOWN:             SAME_AS_LBG_TOMOG
@@ -388,6 +391,8 @@ priorities:
         MWS_MAIN_CLUSTER_SV:   {UNOBS: 1450, DONE:  400, OBS: 1, DONOTOBSERVE: 0}
         MWS_RRLYR:             {UNOBS: 1450, DONE:  400, OBS: 1, DONOTOBSERVE: 0}
         BRIGHT_HPM:            SAME_AS_LOW_MASS_AGN
+        WD_BINARIES_BRIGHT:    {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        WD_BINARIES_DARK:      {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
 
 # ADM INITIAL number of observations (NUMOBS) for each target bit
 # ADM SAME_AS_XXX means to use the NUMOBS for bitname XXX
@@ -512,7 +517,7 @@ numobs:
         VETO:                     1
         UDG:                    100
         FIRST_MALS:             100
-        WD_BINARIES:            100
+#       WD_BINARIES:            100
         LBG_TOMOG:              100
         QSO_RED:                100
         M31_KNOWN:              100
@@ -550,3 +555,5 @@ numobs:
         MWS_RRLYR:              100
         BACKUP_CALIB:           SAME_AS_MWS_CALIB
         BRIGHT_HPM:             100
+        WD_BINARIES_BRIGHT:     100
+        WD_BINARIES_DARK:       100

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -64,7 +64,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
     Notes
     -----
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
-    - Current version (01/08/21) is version XXX on `the SV wiki`_.
+    - Current version (01/15/21) is version 151 on `the SV wiki`_.
     """
     if primary is None:
         primary = np.ones_like(gaiagmag, dtype='?')

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -25,7 +25,7 @@ from astropy.coordinates import SkyCoord
 
 from desitarget.cuts import _getColors, _psflike, _check_BGS_targtype_sv
 from desitarget.cuts import shift_photo_north
-from desitarget.gaiamatch import is_in_Galaxy, find_gaia_files_hp
+from desitarget.gaiamatch import is_in_Galaxy, find_gaia_files_hp, gaia_psflike
 from desitarget.geomask import imaging_mask
 
 # ADM set up the DESI default logger
@@ -93,10 +93,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
                       gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag)
 
     # ADM restrict to point sources.
-    ispsf = np.logical_or(
-        (gaiagmag <= 19.) * (gaiaaen < 10.**0.5),
-        (gaiagmag >= 19.) * (gaiaaen < 10.**(0.5 + 0.2*(gaiagmag - 19.)))
-    )
+    ispsf = gaia_psflike(gaiaaen, gaiagmag)
     std &= ispsf
 
     # ADM apply the Gaia color cuts for standards.


### PR DESCRIPTION
Includes:
- Debug the cross-matching of primary and secondary targets.
  * Previously, the code was removing duplicate primaries if they matched multiple secondaries. 
  * This meant that some of the primary information was not updated for all of the secondary targets.
  * The result was that the primary `TARGETID` was not being included for all secondary targets that matched a primary.
- Catch a corner-case when constructing outside-of-the-footprint standards (and no Gaia sources are found).
- Shift Gaia-based morphological cuts to a single function now that they are used in multiple places in the codebase.
- Add or update the wiki versions that are referenced in the doc strings of recently changed "cuts" functions.
- Change the bright-end cuts for Main Survey (`BRIGHT`) standards to `G > 16`.
- Debug and streamline the creation of the "outside-of-the-footprint" randoms.
  * In particular, write files in a fashion that better reflects the adopted data model.
- Read the `RELEASE` number when constructing randoms from the file headers instead of assuming a single, canonical "North"/"South" `RELEASE`.
  * This is necessary because, in DR9, different bricks in the "South" can have different `RELEASE` numbers.
- Replace the `WD_BINARIES` secondary program with a new version that is split by `DARK`/`BRIGHT`.