### PR TITLE
New secondary bits for the COSMOS dedicated programs and for unusual point sources.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.51.1 (unreleased)
 -------------------
 
+* New secondary bits for COSMOS/unusual point sources [`PR #682`_].
 * Add formalism to make ledger for BACKUP targets [`PR #681`_].
 * New QSO target selection in SV2 [`PR #680`_] for validation:
     * RF file (dr9_final) trained with significance > 10 and SV QSOs.
@@ -24,6 +25,7 @@ desitarget Change Log
 .. _`PR #679`: https://github.com/desihub/desitarget/pull/679
 .. _`PR #680`: https://github.com/desihub/desitarget/pull/680
 .. _`PR #681`: https://github.com/desihub/desitarget/pull/681
+.. _`PR #682`: https://github.com/desihub/desitarget/pull/682
 
 
 0.51.0 (2021-03-07)

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -153,67 +153,73 @@ sv1_mws_mask:
 #- ADM downsample is the fraction of targets to read from the input file
 #- ADM i.e. downsample: 0.13 means "read first 13% of targets from file."
 sv1_scnd_mask:
-    - [VETO,                   0, "Never observe, even if a primary target bit is set",
+    - [VETO,                    0, "Never observe, even if a primary target bit is set",
         {obsconditions: DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18, filename: 'veto', flavor: 'SPARE', downsample: 1}]
-    - [UDG,                    1, "See $SCND_DIR/sv1/docs/UDG.txt",                {obsconditions: DARK,        filename: 'UDG',                flavor: 'SPARE',      downsample: 1}]
-    - [FIRST_MALS,             2, "See $SCND_DIR/sv1/docs/FIRST_MALS.txt",         {obsconditions: DARK,        filename: 'FIRST_MALS',         flavor: 'SPARE',      downsample: 1}]
+    - [UDG,                     1, "See $SCND_DIR/sv1/docs/UDG.txt",                {obsconditions: DARK,        filename: 'UDG',                flavor: 'SPARE',      downsample: 1}]
+    - [FIRST_MALS,              2, "See $SCND_DIR/sv1/docs/FIRST_MALS.txt",         {obsconditions: DARK,        filename: 'FIRST_MALS',         flavor: 'SPARE',      downsample: 1}]
 # ADM the WD_BINARIES class was part of 0.48.0 but was then deprecated in favor of WD_BINARIES_DARK and WD_BINARIES_BRIGHT.
-#   - [WD_BINARIES,            3, "See $SCND_DIR/sv1/docs/WD_BINARIES.txt",        {obsconditions: BRIGHT|DARK, filename: 'WD_BINARIES',        flavor: 'SPARE',      downsample: 1}]
-    - [LBG_TOMOG,              4, "See $SCND_DIR/sv1/docs/LBG_TOMOG.txt",          {obsconditions: DARK,        filename: 'LBG_TOMOG',          flavor: 'DEDICATED',  downsample: 1}]
-    - [QSO_RED,                5, "See $SCND_DIR/sv1/docs/QSO_RED.ipynb",          {obsconditions: DARK,        filename: 'QSO_RED',            flavor: 'QSO',        downsample: 1}]
-    - [M31_KNOWN,              6, "See $SCND_DIR/sv1/docs/M31_KNOWN.txt",          {obsconditions: DARK,        filename: 'M31_KNOWN',          flavor: 'DEDICATED',  downsample: 1}]
-    - [M31_QSO,                7, "See $SCND_DIR/sv1/docs/M31_QSO.txt.",           {obsconditions: DARK,        filename: 'M31_QSO',            flavor: 'DEDICATED',  downsample: 1}]
-    - [M31_STAR,               8, "See $SCND_DIR/sv1/docs/M31_STAR.txt",           {obsconditions: DARK,        filename: 'M31_STAR',           flavor: 'DEDICATED',  downsample: 1}]
-#   - [MWS_DDOGIANTS,          9, "See $SCND_DIR",                                 {obsconditions: BRIGHT,      filename: 'MWS_DDOGIANTS',      flavor: 'SPARE',      downsample: 1}]
-    - [MWS_CLUS_GAL_DEEP,     10, "See $SCND_DIR/sv1/docs/MWS_CLUS_GAL_DEEP.txt",  {obsconditions: DARK,        filename: 'MWS_CLUS_GAL_DEEP',  flavor: 'DEDICATED',  downsample: 1}]
-    - [LOW_MASS_AGN,          11, "See $SCND_DIR/sv1/docs/LOW_MASS_AGN.txt",       {obsconditions: DARK,        filename: 'LOW_MASS_AGN',       flavor: 'SPARE',      downsample: 1}]
-    - [FAINT_HPM,             12, "See $SCND_DIR/sv1/docs/FAINT_HPM.txt",          {obsconditions: DARK,        filename: 'FAINT_HPM',          flavor: 'SPARE',      downsample: 1}]
+#   - [WD_BINARIES,             3, "See $SCND_DIR/sv1/docs/WD_BINARIES.txt",        {obsconditions: BRIGHT|DARK, filename: 'WD_BINARIES',        flavor: 'SPARE',      downsample: 1}]
+# ADM deprecated by individual LBG_TOMOG_XMM, LBG_TOMOG_COSMOS, LBG_TOMOG_W3 bits.
+#    - [LBG_TOMOG,              4, "See $SCND_DIR/sv1/docs/LBG_TOMOG.txt",          {obsconditions: DARK,        filename: 'LBG_TOMOG',          flavor: 'DEDICATED',  downsample: 1}]
+    - [QSO_RED,                 5, "See $SCND_DIR/sv1/docs/QSO_RED.ipynb",          {obsconditions: DARK,        filename: 'QSO_RED',            flavor: 'QSO',        downsample: 1}]
+    - [M31_KNOWN,               6, "See $SCND_DIR/sv1/docs/M31_KNOWN.txt",          {obsconditions: DARK,        filename: 'M31_KNOWN',          flavor: 'DEDICATED',  downsample: 1}]
+    - [M31_QSO,                 7, "See $SCND_DIR/sv1/docs/M31_QSO.txt.",           {obsconditions: DARK,        filename: 'M31_QSO',            flavor: 'DEDICATED',  downsample: 1}]
+    - [M31_STAR,                8, "See $SCND_DIR/sv1/docs/M31_STAR.txt",           {obsconditions: DARK,        filename: 'M31_STAR',           flavor: 'DEDICATED',  downsample: 1}]
+#   - [MWS_DDOGIANTS,           9, "See $SCND_DIR",                                 {obsconditions: BRIGHT,      filename: 'MWS_DDOGIANTS',      flavor: 'SPARE',      downsample: 1}]
+    - [MWS_CLUS_GAL_DEEP,      10, "See $SCND_DIR/sv1/docs/MWS_CLUS_GAL_DEEP.txt",  {obsconditions: DARK,        filename: 'MWS_CLUS_GAL_DEEP',  flavor: 'DEDICATED',  downsample: 1}]
+    - [LOW_MASS_AGN,           11, "See $SCND_DIR/sv1/docs/LOW_MASS_AGN.txt",       {obsconditions: DARK,        filename: 'LOW_MASS_AGN',       flavor: 'SPARE',      downsample: 1}]
+    - [FAINT_HPM,              12, "See $SCND_DIR/sv1/docs/FAINT_HPM.txt",          {obsconditions: DARK,        filename: 'FAINT_HPM',          flavor: 'SPARE',      downsample: 1}]
 # ADM the TOO files were handled separately as of version 0.50.0 of the code.
 #    - [GW190412,              13, "See $SCND_DIR/sv1/docs/GW190412.ipynb",         {obsconditions: BRIGHT|DARK, filename: 'GW190412',           flavor: 'TOO',        downsample: 1}]
 #    - [IC134191,              14, "See $SCND_DIR/sv1/docs/IC134191.ipynb",         {obsconditions: BRIGHT|DARK, filename: 'IC134191',           flavor: 'TOO',        downsample: 1}]
-    - [PV_BRIGHT,             15, "See $SCND_DIR/sv1/docs/PV_BRIGHT.ipynb",        {obsconditions: BRIGHT,      filename: 'PV_BRIGHT',          flavor: 'SPARE',      downsample: 1}]
-    - [PV_DARK,               16, "See $SCND_DIR/sv1/docs/PV_DARK.ipynb",          {obsconditions: DARK,        filename: 'PV_DARK',            flavor: 'SPARE',      downsample: 1}]
-    - [LOW_Z,                 17, "See $SCND_DIR/sv1/docs/LOW_Z.ipynb",            {obsconditions: DARK,        filename: 'LOW_Z',              flavor: 'SPARE',      downsample: 1}]
-    - [BHB,                   18, "See $SCND_DIR/sv1/docs/BHB.txt",                {obsconditions: DARK,        filename: 'BHB',                flavor: 'SPARE',      downsample: 1}]
-    - [SPCV,                  19, "See $SCND_DIR/sv1/docs/SPCV.txt",               {obsconditions: DARK,        filename: 'SPCV',               flavor: 'SPARE',      downsample: 1}]
-    - [DC3R2_GAMA,            20, "See $SCND_DIR/sv1/docs/DC3R2_GAMA.ipynb",       {obsconditions: DARK,        filename: 'DC3R2_GAMA',         flavor: 'SPARE',      downsample: 0.02}]
-    - [UNWISE_BLUE,           21, "See $SCND_DIR/sv1/docs/UNWISE_BLUE.txt",        {obsconditions: DARK,        filename: 'UNWISE_BLUE',        flavor: 'DEDICATED',  downsample: 1}]
-    - [UNWISE_GREEN,          22, "See $SCND_DIR/sv1/docs/UNWISE_GREEN.txt",       {obsconditions: DARK,        filename: 'UNWISE_GREEN',       flavor: 'DEDICATED',  downsample: 1}]
-    - [HETDEX_MAIN,           23, "See $SCND_DIR/sv1/docs/HETDEX_MAIN.txt",        {obsconditions: DARK,        filename: 'HETDEX_MAIN',        flavor: 'DEDICATED',  downsample: 1}]
-    - [HETDEX_HP,             24, "See $SCND_DIR/sv1/docs/HETDEX_HP.txt",          {obsconditions: DARK,        filename: 'HETDEX_HP',          flavor: 'DEDICATED',  downsample: 1}]
-#   - [PSF_OUT_BRIGHT,        25, "See $SCND_DIR",                                 {obsconditions: BRIGHT,      filename: 'PSF_OUT_BRIGHT',     flavor: 'SPARE',      downsample: 1}]
-#   - [PSF_OUT_DARK,          26, "See $SCND_DIR",                                 {obsconditions: DARK,        filename: 'PSF_OUT_DARK',       flavor: 'SPARE',      downsample: 1}]
-    - [HPM_SOUM,              27, "See $SCND_DIR/sv1/docs/HPM_SOUM.txt",           {obsconditions: DARK,        filename: 'HPM_SOUM',           flavor: 'SPARE',      downsample: 1}]
-    - [SN_HOSTS,              28, "See $SCND_DIR/sv1/docs/SN_HOSTS.txt",           {obsconditions: DARK,        filename: 'SN_HOSTS',           flavor: 'SPARE',      downsample: 1}]
-    - [GAL_CLUS_BCG,          29, "See $SCND_DIR/sv1/docs/GAL_CLUS_BCG.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_BCG',       flavor: 'SPARE',      downsample: 1}]
-    - [GAL_CLUS_2ND,          30, "See $SCND_DIR/sv1/docs/GAL_CLUS_2ND.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_2ND',       flavor: 'SPARE',      downsample: 1}]
-    - [GAL_CLUS_SAT,          31, "See $SCND_DIR/sv1/docs/GAL_CLUS_SAT.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_SAT',       flavor: 'SPARE',      downsample: 1}]
-    - [HSC_HIZ_SNE,           32, "See $SCND_DIR/sv1/docs/HSC_HIZ_SNE.txt",        {obsconditions: DARK,        filename: 'HSC_HIZ_SNE',        flavor: 'DEDICATED',  downsample: 1}]
-    - [ISM_CGM_QGP,           33, "See $SCND_DIR/sv1/docs/ISM_CGM_QGP.txt",        {obsconditions: DARK,        filename: 'ISM_CGM_QGP',        flavor: 'DEDICATED',  downsample: 1}]
-    - [STRONG_LENS,           34, "See $SCND_DIR/sv1/docs/STRONG_LENS.txt",        {obsconditions: DARK,        filename: 'STRONG_LENS',        flavor: 'SPARE',      downsample: 1}]
-    - [WISE_VAR_QSO,          35, "See $SCND_DIR/sv1/docs/WISE_VAR_QSO.txt",       {obsconditions: DARK,        filename: 'WISE_VAR_QSO',       flavor: 'QSO',        downsample: 1}]
-    - [MWS_CALIB,             36, "Stars with APOGEE/BOSS/GALAH/GAIAESO spectra",
+    - [PV_BRIGHT,              15, "See $SCND_DIR/sv1/docs/PV_BRIGHT.ipynb",        {obsconditions: BRIGHT,      filename: 'PV_BRIGHT',          flavor: 'SPARE',      downsample: 1}]
+    - [PV_DARK,                16, "See $SCND_DIR/sv1/docs/PV_DARK.ipynb",          {obsconditions: DARK,        filename: 'PV_DARK',            flavor: 'SPARE',      downsample: 1}]
+    - [LOW_Z,                  17, "See $SCND_DIR/sv1/docs/LOW_Z.ipynb",            {obsconditions: DARK,        filename: 'LOW_Z',              flavor: 'SPARE',      downsample: 1}]
+    - [BHB,                    18, "See $SCND_DIR/sv1/docs/BHB.txt",                {obsconditions: DARK,        filename: 'BHB',                flavor: 'SPARE',      downsample: 1}]
+    - [SPCV,                   19, "See $SCND_DIR/sv1/docs/SPCV.txt",               {obsconditions: DARK,        filename: 'SPCV',               flavor: 'SPARE',      downsample: 1}]
+    - [DC3R2_GAMA,             20, "See $SCND_DIR/sv1/docs/DC3R2_GAMA.ipynb",       {obsconditions: DARK,        filename: 'DC3R2_GAMA',         flavor: 'SPARE',      downsample: 0.02}]
+    - [UNWISE_BLUE,            21, "See $SCND_DIR/sv1/docs/UNWISE_BLUE.txt",        {obsconditions: DARK,        filename: 'UNWISE_BLUE',        flavor: 'DEDICATED',  downsample: 1}]
+    - [UNWISE_GREEN,           22, "See $SCND_DIR/sv1/docs/UNWISE_GREEN.txt",       {obsconditions: DARK,        filename: 'UNWISE_GREEN',       flavor: 'DEDICATED',  downsample: 1}]
+    - [HETDEX_MAIN,            23, "See $SCND_DIR/sv1/docs/HETDEX_MAIN.txt",        {obsconditions: DARK,        filename: 'HETDEX_MAIN',        flavor: 'DEDICATED',  downsample: 1}]
+    - [HETDEX_HP,              24, "See $SCND_DIR/sv1/docs/HETDEX_HP.txt",          {obsconditions: DARK,        filename: 'HETDEX_HP',          flavor: 'DEDICATED',  downsample: 1}]
+    - [PSF_OUT_BRIGHT,         25, "See $SCND_DIR/sv1/docs/PSF_OUT_BRIGHT.txt",     {obsconditions: BRIGHT,      filename: 'PSF_OUT_BRIGHT',     flavor: 'SPARE',      downsample: 1}]
+    - [PSF_OUT_DARK,           26, "See $SCND_DIR/sv1/docs/PSF_OUT_DARK.txt",       {obsconditions: DARK,        filename: 'PSF_OUT_DARK',       flavor: 'SPARE',      downsample: 1}]
+    - [HPM_SOUM,               27, "See $SCND_DIR/sv1/docs/HPM_SOUM.txt",           {obsconditions: DARK,        filename: 'HPM_SOUM',           flavor: 'SPARE',      downsample: 1}]
+    - [SN_HOSTS,               28, "See $SCND_DIR/sv1/docs/SN_HOSTS.txt",           {obsconditions: DARK,        filename: 'SN_HOSTS',           flavor: 'SPARE',      downsample: 1}]
+    - [GAL_CLUS_BCG,           29, "See $SCND_DIR/sv1/docs/GAL_CLUS_BCG.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_BCG',       flavor: 'SPARE',      downsample: 1}]
+    - [GAL_CLUS_2ND,           30, "See $SCND_DIR/sv1/docs/GAL_CLUS_2ND.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_2ND',       flavor: 'SPARE',      downsample: 1}]
+    - [GAL_CLUS_SAT,           31, "See $SCND_DIR/sv1/docs/GAL_CLUS_SAT.txt",       {obsconditions: DARK,        filename: 'GAL_CLUS_SAT',       flavor: 'SPARE',      downsample: 1}]
+    - [HSC_HIZ_SNE,            32, "See $SCND_DIR/sv1/docs/HSC_HIZ_SNE.txt",        {obsconditions: DARK,        filename: 'HSC_HIZ_SNE',        flavor: 'DEDICATED',  downsample: 1}]
+    - [ISM_CGM_QGP,            33, "See $SCND_DIR/sv1/docs/ISM_CGM_QGP.txt",        {obsconditions: DARK,        filename: 'ISM_CGM_QGP',        flavor: 'DEDICATED',  downsample: 1}]
+    - [STRONG_LENS,            34, "See $SCND_DIR/sv1/docs/STRONG_LENS.txt",        {obsconditions: DARK,        filename: 'STRONG_LENS',        flavor: 'SPARE',      downsample: 1}]
+    - [WISE_VAR_QSO,           35, "See $SCND_DIR/sv1/docs/WISE_VAR_QSO.txt",       {obsconditions: DARK,        filename: 'WISE_VAR_QSO',       flavor: 'QSO',        downsample: 1}]
+    - [MWS_CALIB,              36, "Stars with APOGEE/BOSS/GALAH/GAIAESO spectra",
         {obsconditions: DARK|GRAY|BRIGHT, filename: 'MWS_CALIB', flavor: 'SSV', downsample: 1}]
-    - [BACKUP_CALIB,          37, "Very bright stars with APOGEE/BOSS/GALAH/GAIAESO spectra",
+    - [BACKUP_CALIB,           37, "Very bright stars with APOGEE/BOSS/GALAH/GAIAESO spectra",
         {obsconditions: BACKUP|TWILIGHT12|TWILIGHT18, filename: 'BACKUP_CALIB', flavor: 'SSV', downsample: 1}]
-    - [MWS_MAIN_CLUSTER_SV,   38, "Main survey low mass and metal poor stars (OC/GC/dwarf/stream members)",
+    - [MWS_MAIN_CLUSTER_SV,    38, "Main survey low mass and metal poor stars (OC/GC/dwarf/stream members)",
         {obsconditions: DARK|GRAY|BRIGHT, filename: 'MWS_MAIN_CLUSTER_SV', flavor: 'SSV', downsample: 1}]
-    - [MWS_RRLYR,             39, "Main survey halo tracers (RR Lyrae)",
+    - [MWS_RRLYR,              39, "Main survey halo tracers (RR Lyrae)",
         {obsconditions: DARK|GRAY|BRIGHT, filename: 'MWS_RRLYR', flavor: 'SSV', downsample: 1}]
-    - [BRIGHT_HPM,            40, "See $SCND_DIR/sv1/docs/BRIGHT_HPM.txt",            {obsconditions: BRIGHT,      filename: 'BRIGHT_HPM',            flavor: 'SPARE',      downsample: 1}]
-    - [WD_BINARIES_BRIGHT,    41, "See $SCND_DIR/sv1/docs/WD_BINARIES_BRIGHT.txt",    {obsconditions: BRIGHT,      filename: 'WD_BINARIES_BRIGHT',    flavor: 'SPARE',      downsample: 1}]
-    - [WD_BINARIES_DARK,      42, "See $SCND_DIR/sv1/docs/WD_BINARIES_DARK.txt",      {obsconditions: DARK,        filename: 'WD_BINARIES_DARK',      flavor: 'SPARE',      downsample: 1}]
-    - [DESILBG,               43, "See $SCND_DIR/sv1/docs/DESILBG.txt",               {obsconditions: DARK,        filename: 'DESILBG',               flavor: 'DEDICATED',  downsample: 1}]
-    - [LBG_TOMOG_XMM,         44, "See $SCND_DIR/sv1/docs/LBG_TOMOG_XMM.txt",         {obsconditions: DARK,        filename: 'LBG_TOMOG_XMM',         flavor: 'DEDICATED',  downsample: 1}]
-    - [LBG_TOMOG_COSMOS,      45, "See $SCND_DIR/sv1/docs/LBG_TOMOG_COSMOS.txt",      {obsconditions: DARK,        filename: 'LBG_TOMOG_COSMOS',      flavor: 'DEDICATED',  downsample: 1}]
-    - [LBG_TOMOG_W3,          46, "See $SCND_DIR/sv1/docs/LBG_TOMOG_W3.txt",          {obsconditions: DARK,        filename: 'LBG_TOMOG_W3',          flavor: 'DEDICATED',  downsample: 1}]
-    - [UNWISE_GREEN_II_3700,  47, "See $SCND_DIR/sv1/docs/UNWISE_GREEN_II_3700.txt",  {obsconditions: DARK,        filename: 'UNWISE_GREEN_II_3700',  flavor: 'DEDICATED',  downsample: 1}]
-    - [UNWISE_GREEN_II_3800,  48, "See $SCND_DIR/sv1/docs/UNWISE_GREEN_II_3800.txt",  {obsconditions: DARK,        filename: 'UNWISE_GREEN_II_3800',  flavor: 'DEDICATED',  downsample: 1}]
-    - [UNWISE_GREEN_II_3900,  49, "See $SCND_DIR/sv1/docs/UNWISE_GREEN_II_3900.txt",  {obsconditions: DARK,        filename: 'UNWISE_GREEN_II_3900',  flavor: 'DEDICATED',  downsample: 1}]
-    - [UNWISE_GREEN_II_4000,  50, "See $SCND_DIR/sv1/docs/UNWISE_GREEN_II_4000.txt",  {obsconditions: DARK,        filename: 'UNWISE_GREEN_II_4000',  flavor: 'DEDICATED',  downsample: 1}]
-    - [UNWISE_BLUE_FAINT_II,  51, "See $SCND_DIR/sv1/docs/UNWISE_BLUE_FAINT_II.txt",  {obsconditions: DARK,        filename: 'UNWISE_BLUE_FAINT_II',  flavor: 'DEDICATED',  downsample: 1}]
-    - [UNWISE_BLUE_BRIGHT_II, 52, "See $SCND_DIR/sv1/docs/UNWISE_BLUE_BRIGHT_II.txt", {obsconditions: DARK,        filename: 'UNWISE_BLUE_BRIGHT_II', flavor: 'DEDICATED',  downsample: 1}]
-
+    - [BRIGHT_HPM,             40, "See $SCND_DIR/sv1/docs/BRIGHT_HPM.txt",             {obsconditions: BRIGHT,    filename: 'BRIGHT_HPM',             flavor: 'SPARE',      downsample: 1}]
+    - [WD_BINARIES_BRIGHT,     41, "See $SCND_DIR/sv1/docs/WD_BINARIES_BRIGHT.txt",     {obsconditions: BRIGHT,    filename: 'WD_BINARIES_BRIGHT',     flavor: 'SPARE',      downsample: 1}]
+    - [WD_BINARIES_DARK,       42, "See $SCND_DIR/sv1/docs/WD_BINARIES_DARK.txt",       {obsconditions: DARK,      filename: 'WD_BINARIES_DARK',       flavor: 'SPARE',      downsample: 1}]
+# ADM deprecated by individual DESILBG_TMG_FINAL, DESILBG_G_FINAL, DESILBG_BXU_FINAL bits.
+#   - [DESILBG,                43, "See $SCND_DIR/sv1/docs/DESILBG.txt",                {obsconditions: DARK,      filename: 'DESILBG',                flavor: 'DEDICATED',  downsample: 1}]
+    - [LBG_TOMOG_XMM,          44, "See $SCND_DIR/sv1/docs/LBG_TOMOG_XMM.txt",          {obsconditions: DARK,      filename: 'LBG_TOMOG_XMM',          flavor: 'DEDICATED',  downsample: 1}]
+# ADM deprecated by LBG_TOMOG_COSMOS_FINAL
+#    - [LBG_TOMOG_COSMOS,      45, "See $SCND_DIR/sv1/docs/LBG_TOMOG_COSMOS.txt",       {obsconditions: DARK,      filename: 'LBG_TOMOG_COSMOS',       flavor: 'DEDICATED',  downsample: 1}]
+    - [LBG_TOMOG_W3,           46, "See $SCND_DIR/sv1/docs/LBG_TOMOG_W3.txt",           {obsconditions: DARK,      filename: 'LBG_TOMOG_W3',           flavor: 'DEDICATED',  downsample: 1}]
+    - [UNWISE_GREEN_II_3700,   47, "See $SCND_DIR/sv1/docs/UNWISE_GREEN_II_3700.txt",   {obsconditions: DARK,      filename: 'UNWISE_GREEN_II_3700',   flavor: 'DEDICATED',  downsample: 1}]
+    - [UNWISE_GREEN_II_3800,   48, "See $SCND_DIR/sv1/docs/UNWISE_GREEN_II_3800.txt",   {obsconditions: DARK,      filename: 'UNWISE_GREEN_II_3800',   flavor: 'DEDICATED',  downsample: 1}]
+    - [UNWISE_GREEN_II_3900,   49, "See $SCND_DIR/sv1/docs/UNWISE_GREEN_II_3900.txt",   {obsconditions: DARK,      filename: 'UNWISE_GREEN_II_3900',   flavor: 'DEDICATED',  downsample: 1}]
+    - [UNWISE_GREEN_II_4000,   50, "See $SCND_DIR/sv1/docs/UNWISE_GREEN_II_4000.txt",   {obsconditions: DARK,      filename: 'UNWISE_GREEN_II_4000',   flavor: 'DEDICATED',  downsample: 1}]
+    - [UNWISE_BLUE_FAINT_II,   51, "See $SCND_DIR/sv1/docs/UNWISE_BLUE_FAINT_II.txt",   {obsconditions: DARK,      filename: 'UNWISE_BLUE_FAINT_II',   flavor: 'DEDICATED',  downsample: 1}]
+    - [UNWISE_BLUE_BRIGHT_II,  52, "See $SCND_DIR/sv1/docs/UNWISE_BLUE_BRIGHT_II.txt",  {obsconditions: DARK,      filename: 'UNWISE_BLUE_BRIGHT_II',  flavor: 'DEDICATED',  downsample: 1}]
+    - [DESILBG_TMG_FINAL,      53, "See $SCND_DIR/sv1/docs/DESILBG_TMG_FINAL.txt",      {obsconditions: DARK,      filename: 'DESILBG_TMG_FINAL',      flavor: 'DEDICATED',  downsample: 1}]
+    - [DESILBG_G_FINAL,        54, "See $SCND_DIR/sv1/docs/DESILBG_G_FINAL.txt",        {obsconditions: DARK,      filename: 'DESILBG_G_FINAL',        flavor: 'DEDICATED',  downsample: 1}]
+    - [DESILBG_BXU_FINAL,      55, "See $SCND_DIR/sv1/docs/DESILBG_BXU_FINAL.txt",      {obsconditions: DARK,      filename: 'DESILBG_BXU_FINAL',      flavor: 'DEDICATED',  downsample: 1}]
+    - [LBG_TOMOG_COSMOS_FINAL, 56, "See $SCND_DIR/sv1/docs/LBG_TOMOG_COSMOS_FINAL.txt", {obsconditions: DARK,      filename: 'LBG_TOMOG_COSMOS_FINAL', flavor: 'DEDICATED',  downsample: 1}]
 
 # ADM reserve 60/61 in scnd_mask for Targets of Opportunity in both SV and the Main Survey.
     - [BRIGHT_TOO,    60, "Targets of Opportunity from rolling ledger",   {obsconditions: BRIGHT, flavor: 'TOO'}]
@@ -371,63 +377,67 @@ priorities:
 
     # ADM secondary target priorities. Probably all have very low UNOBS
     sv1_scnd_mask:
-        VETO:                  {UNOBS:  0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
-        UDG:                   {UNOBS: 1900, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        FIRST_MALS:            {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-#       WD_BINARIES:           {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        LBG_TOMOG:             {UNOBS: 1800, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        QSO_RED:               {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-# ADM LBG_TOMOG is the first dedicated program to be listed.
-# ADM Other dedicated programs will have a similar priority to LBG_TOMOG.
-        M31_KNOWN:             SAME_AS_LBG_TOMOG
-        M31_QSO:               SAME_AS_LBG_TOMOG
-        M31_STAR:              SAME_AS_LBG_TOMOG
-#       MWS_DDOGIANTS:         {UNOBS: 1450, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_CLUS_GAL_DEEP:     SAME_AS_LBG_TOMOG
-        LOW_MASS_AGN:          {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        FAINT_HPM:             SAME_AS_LOW_MASS_AGN
+        VETO:                   {UNOBS:  0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
+        UDG:                    {UNOBS: 1900, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        FIRST_MALS:             {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+#       WD_BINARIES:            {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+#       LBG_TOMOG:              {UNOBS: 1800, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        QSO_RED:                {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+# ADM M31_KNOWN is the first dedicated program to be listed.
+# ADM Other dedicated programs will have a similar priority to M31_KNOWN.
+        M31_KNOWN:              {UNOBS: 1800, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        M31_QSO:                SAME_AS_M31_KNOWN
+        M31_STAR:               SAME_AS_M31_KNOWN
+#       MWS_DDOGIANTS:          {UNOBS: 1450, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        MWS_CLUS_GAL_DEEP:      SAME_AS_M31_KNOWN
+        LOW_MASS_AGN:           {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        FAINT_HPM:              SAME_AS_LOW_MASS_AGN
 #        GW190412:              {UNOBS: 5000, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
 #        IC134191:              SAME_AS_GW190412
-        PV_BRIGHT:             {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        PV_DARK:               {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        LOW_Z:                 {UNOBS: 80, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        BHB:                   {UNOBS: 1950, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        SPCV:                  SAME_AS_LOW_MASS_AGN
-        DC3R2_GAMA:            {UNOBS: 1010, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        UNWISE_BLUE:           SAME_AS_LBG_TOMOG
-        UNWISE_GREEN:          SAME_AS_LBG_TOMOG
-        HETDEX_MAIN:           SAME_AS_LBG_TOMOG
-        HETDEX_HP:             SAME_AS_LBG_TOMOG
-#       PSF_OUT_BRIGHT:        {UNOBS: 90, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-#       PSF_OUT_DARK:          SAME_AS_PSF_OUT_BRIGHT
-        HPM_SOUM:              SAME_AS_LOW_MASS_AGN
-        SN_HOSTS:              SAME_AS_BHB
-        GAL_CLUS_BCG:          {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        GAL_CLUS_2ND:          {UNOBS: 1020, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        GAL_CLUS_SAT:          {UNOBS: 200,  DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        HSC_HIZ_SNE:           SAME_AS_LBG_TOMOG
-        ISM_CGM_QGP:           {UNOBS: 4100, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        STRONG_LENS:           {UNOBS: 4000, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        WISE_VAR_QSO:          SAME_AS_QSO_RED
-        MWS_CALIB:             {UNOBS: 2995, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        BACKUP_CALIB:          SAME_AS_MWS_CALIB
-        MWS_MAIN_CLUSTER_SV:   {UNOBS: 1450, DONE:  400, OBS: 1, DONOTOBSERVE: 0}
-        MWS_RRLYR:             {UNOBS: 1450, DONE:  400, OBS: 1, DONOTOBSERVE: 0}
-        BRIGHT_HPM:            SAME_AS_LOW_MASS_AGN
-        WD_BINARIES_BRIGHT:    {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        WD_BINARIES_DARK:      {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        DESILBG:               SAME_AS_LBG_TOMOG
-        LBG_TOMOG_XMM:         SAME_AS_LBG_TOMOG
-        LBG_TOMOG_COSMOS:      SAME_AS_LBG_TOMOG
-        LBG_TOMOG_W3:          SAME_AS_LBG_TOMOG
-        UNWISE_GREEN_II_3700:  {UNOBS: 1500, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        UNWISE_GREEN_II_3800:  {UNOBS: 1600, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        UNWISE_GREEN_II_3900:  {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        UNWISE_GREEN_II_4000:  {UNOBS: 1800, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        UNWISE_BLUE_FAINT_II:  {UNOBS: 1490, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        UNWISE_BLUE_BRIGHT_II: {UNOBS: 1480, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        BRIGHT_TOO:            {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        DARK_TOO:              SAME_AS_BRIGHT_TOO
+        PV_BRIGHT:              {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        PV_DARK:                {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        LOW_Z:                  {UNOBS: 80, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        BHB:                    {UNOBS: 1950, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        SPCV:                   SAME_AS_LOW_MASS_AGN
+        DC3R2_GAMA:             {UNOBS: 1010, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        UNWISE_BLUE:            SAME_AS_M31_KNOWN
+        UNWISE_GREEN:           SAME_AS_M31_KNOWN
+        HETDEX_MAIN:            SAME_AS_M31_KNOWN
+        HETDEX_HP:              SAME_AS_M31_KNOWN
+        PSF_OUT_BRIGHT:         {UNOBS: 90, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        PSF_OUT_DARK:           SAME_AS_PSF_OUT_BRIGHT
+        HPM_SOUM:               SAME_AS_LOW_MASS_AGN
+        SN_HOSTS:               SAME_AS_BHB
+        GAL_CLUS_BCG:           {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        GAL_CLUS_2ND:           {UNOBS: 1020, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        GAL_CLUS_SAT:           {UNOBS: 200,  DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        HSC_HIZ_SNE:            SAME_AS_M31_KNOWN
+        ISM_CGM_QGP:            {UNOBS: 4100, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        STRONG_LENS:            {UNOBS: 4000, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        WISE_VAR_QSO:           SAME_AS_QSO_RED
+        MWS_CALIB:              {UNOBS: 2995, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_CALIB:           SAME_AS_MWS_CALIB
+        MWS_MAIN_CLUSTER_SV:    {UNOBS: 1450, DONE:  400, OBS: 1, DONOTOBSERVE: 0}
+        MWS_RRLYR:              {UNOBS: 1450, DONE:  400, OBS: 1, DONOTOBSERVE: 0}
+        BRIGHT_HPM:             SAME_AS_LOW_MASS_AGN
+        WD_BINARIES_BRIGHT:     {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        WD_BINARIES_DARK:       {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+#        DESILBG:               SAME_AS_M31_KNOWN
+        LBG_TOMOG_XMM:          SAME_AS_M31_KNOWN
+#        LBG_TOMOG_COSMOS:      SAME_AS_M31_KNOWN
+        LBG_TOMOG_W3:           SAME_AS_M31_KNOWN
+        UNWISE_GREEN_II_3700:   {UNOBS: 1500, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        UNWISE_GREEN_II_3800:   {UNOBS: 1600, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        UNWISE_GREEN_II_3900:   {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        UNWISE_GREEN_II_4000:   {UNOBS: 1800, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        UNWISE_BLUE_FAINT_II:   {UNOBS: 1490, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        UNWISE_BLUE_BRIGHT_II:  {UNOBS: 1480, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        BRIGHT_TOO:             {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        DARK_TOO:               SAME_AS_BRIGHT_TOO
+        DESILBG_TMG_FINAL:      SAME_AS_M31_KNOWN
+        DESILBG_G_FINAL:        SAME_AS_M31_KNOWN
+        DESILBG_BXU_FINAL:      SAME_AS_M31_KNOWN
+        LBG_TOMOG_COSMOS_FINAL: SAME_AS_M31_KNOWN
 
 # ADM INITIAL number of observations (NUMOBS) for each target bit
 # ADM SAME_AS_XXX means to use the NUMOBS for bitname XXX
@@ -553,7 +563,7 @@ numobs:
         UDG:                    100
         FIRST_MALS:             100
 #       WD_BINARIES:            100
-        LBG_TOMOG:              100
+#       LBG_TOMOG:              100
         QSO_RED:                100
         M31_KNOWN:              100
         M31_QSO:                100
@@ -574,8 +584,8 @@ numobs:
         UNWISE_GREEN:           100
         HETDEX_MAIN:            100
         HETDEX_HP:              100
-#       PSF_OUT_BRIGHT:         100
-#       PSF_OUT_DARK:           100
+        PSF_OUT_BRIGHT:         100
+        PSF_OUT_DARK:           100
         HPM_SOUM:               100
         SN_HOSTS:               100
         GAL_CLUS_BCG:           100
@@ -592,9 +602,9 @@ numobs:
         BRIGHT_HPM:             100
         WD_BINARIES_BRIGHT:     100
         WD_BINARIES_DARK:       100
-        DESILBG:                1
+#       DESILBG:                1
         LBG_TOMOG_XMM:          1
-        LBG_TOMOG_COSMOS:       1
+#       LBG_TOMOG_COSMOS:       1
         LBG_TOMOG_W3:           1
         UNWISE_GREEN_II_3800:   1
         UNWISE_GREEN_II_3700:   1
@@ -604,3 +614,7 @@ numobs:
         UNWISE_BLUE_BRIGHT_II:  1
         BRIGHT_TOO:             1
         DARK_TOO:               SAME_AS_BRIGHT_TOO
+        DESILBG_TMG_FINAL:      1
+        DESILBG_G_FINAL:        1
+        DESILBG_BXU_FINAL:      1
+        LBG_TOMOG_COSMOS_FINAL: 1


### PR DESCRIPTION
This PR:

- updates the SV1 secondary targeting bits with the latest (final) versions for the dedicated programs in COSMOS.  
- deprecates some earlier bits for those COSMOS programs which correspond to defunct selections.
- adds the bits for the unusual point sources secondary program (`PSF_OUT_BRIGHT`, `PSF_OUT_DARK`).

There is no new code, other than updating bit-masks, so I'll merge as soon as tests pass to make a new tag for the new secondary targets.