### PR TITLE
Implement the full loop for MTL

### DIFF
--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+from desitarget.mtl import loop_ledger
+from desiutil.log import get_logger
+log = get_logger()
+
+# ADM default survey to run.
+survey = "main"
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Make an initial HEALPixel-split ledger for a Merged Target List based on a directory of targets')
+ap.add_argument("obscon",
+                help="String matching ONE obscondition in the bitmask yaml file \
+                (e.g. 'BRIGHT'). Controls priorities when merging targets,      \
+                which tiles to process, etc.")
+ap.add_argument("-s", "--survey",
+                help="Flavor of survey to run. Defaults to [{}]".format(survey),
+                default=survey)
+ap.add_argument('--zcatdir',
+                help="Full path to the directory that hosts the redshift        \
+                catalogs. Default is to use the $ZCAT_DIR environment variable",
+                default=None)
+ap.add_argument('--mtldir',
+                help="Full path to the directory that hosts the MTL ledgers.    \
+                Default is to use the $ZCAT_DIR environment variable",
+                default=None)
+ap.add_argument('--tilefn',
+                help="Full path to the name of the tile file.                   \
+                Default is to use the $TILE_FN environment variable",
+                default=None)
+ap.add_argument("-n", "--numobsfromzcat", action='store_true',
+                help="If passed, the zcat includes a meaningfule NUMOBS.        \
+                Otherwise, NUMOBS is looked up from the ledger itself")
+
+ns = ap.parse_args()
+
+numobs_from_ledger = not(ns.numobsfromzcat)
+
+hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
+    ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
+    tilefn=ns.tilefn, numobs_from_ledger=numobs_from_ledger)
+
+log.info("MTL ledger directory: {}".format(hpdirname))
+log.info("MTL tile file: {}".format(mtltilefn))
+log.info("Tile file: {}".format(tilefn))
+log.info("Processed {} new tiles, which are: {}".format(len(tiles), tiles))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,15 @@ desitarget Change Log
 0.52.0 (2021-03-13)
 -------------------
 
+* Implement full MTL loop [`PR #684`_]. Includes:
+    * Modify ledgers based on any new tiles in a ``zcat`` directory.
+    * An MTL tile file to track which tiles have been processed by MTL.
+    * Read standard tile file to get observing conditions for each tile.
+        * Only update ledgers for tiles with the appropriate conditions.
+    * Option to use the ledgers themselves to updated ``NUMOBS``
+        * instead of expecting ``NUMOBS`` to be in the ``zcat``.
+    * A command-line script to execute the full loop.
+        * Input directories and files can be environment variables.
 * New secondary bits for COSMOS/unusual point sources [`PR #682`_].
 * Add formalism to make ledger for BACKUP targets [`PR #681`_].
 * New QSO target selection in SV2 [`PR #680`_] for validation:
@@ -31,6 +40,7 @@ desitarget Change Log
 .. _`PR #680`: https://github.com/desihub/desitarget/pull/680
 .. _`PR #681`: https://github.com/desihub/desitarget/pull/681
 .. _`PR #682`: https://github.com/desihub/desitarget/pull/682
+.. _`PR #684`: https://github.com/desihub/desitarget/pull/684
 
 
 0.51.0 (2021-03-07)

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -253,9 +253,9 @@ priorities:
         MWS_MAIN_RED:                 SAME_AS_MWS_MAIN_BLUE
         MWS_MAIN_RED_NORTH:           SAME_AS_MWS_BROAD_NORTH
         MWS_MAIN_RED_SOUTH:           SAME_AS_MWS_BROAD_NORTH
-        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 9, OBS: 9, DONOTOBSERVE: 0}
-        BACKUP_FAINT:                 {UNOBS: 8, DONE: 8, OBS: 8, DONOTOBSERVE: 0}
-        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 7, OBS: 7, DONOTOBSERVE: 0}
+        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_FAINT:                 {UNOBS: 8, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         # ADM Standards are special; priorities don't apply.
         GAIA_STD_FAINT:  -1
         GAIA_STD_WD:  -1

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2317,6 +2317,8 @@ def find_target_files(targdir, dr='X', flavor="targets", survey="main",
 
     # ADM the generic directory structure beneath $TARG_DIR or $MTL_DIR.
     fn = os.path.join(targdir, drstr, version, flavor)
+    if flavor == "mtl":
+        fn = targdir
 
     # ADM masks are a special case beneath $MASK_DIR.
     if flavor == "masks":
@@ -2422,10 +2424,11 @@ def write_mtl_tile_file(filename, data):
         ascii.write(data, f, format='no_header')
         f.close()
     else:
-        # ADM we need to make the file.
+        # ADM if the file doesn't exist we may need to make the directory.
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
         write_with_units(filename, data, extname='MTLTILE', ecsv=True)
 
-    return(len(data), filename)
+    return len(data), filename
 
 
 def read_mtl_ledger(filename, unique=True):

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2397,7 +2397,7 @@ def write_mtl_tile_file(filename, data):
     Parameters
     ----------
     filename : :class:`str`
-        The full path to the MTL tile file. If this doesn't exist, then 
+        The full path to the MTL tile file. If this doesn't exist, then
         a new file is begun.
     data : :class`~numpy.ndarray`
         The data to append to the end of the MTL tile file, which should
@@ -2419,7 +2419,7 @@ def write_mtl_tile_file(filename, data):
         raise IOError(msg)
 
     if os.path.isfile(filename):
-       # ADM as we're working with .ecsv, simply append to the end.
+        # ADM as we're working with .ecsv, simply append to the end.
         f = open(filename, "a")
         ascii.write(data, f, format='no_header')
         f.close()

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -12,6 +12,7 @@ import numpy as np
 # import pandas as pd
 import fitsio
 from astropy.table import Table
+from astropy.io import ascii
 import os
 import re
 from . import __version__ as desitarget_version
@@ -430,8 +431,10 @@ def write_with_units(filename, data, extname=None, header=None, ecsv=False):
 
     # ADM write the file for either ecsv or fits..
     if ecsv:
-        data.meta = dict(header)
-        data.meta['EXTNAME'] = extname
+        if header is not None:
+            data.meta = dict(header)
+        if extname is not None:
+            data.meta['EXTNAME'] = extname
         data.write(filename+'.tmp', format='ascii.ecsv', overwrite=True)
     else:
         fitsio.write(filename+'.tmp', data, units=units, extname=extname,
@@ -702,7 +705,7 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
         Written to output file header as the keyword `SURVEY`.
     obscon : :class:`str`, optional
         Name of the `OBSCONDITIONS` used to make the file (e.g. DARK).
-    nsidefile : :class:`int`, optional, defaults to `mtl.get_mtl_dir()`
+    nsidefile : :class:`int`, optional
         Passed to indicate in the output file header that the targets
         have been limited to only certain HEALPixels at a given
         nside. Used in conjunction with `hpxlist`.
@@ -2363,6 +2366,66 @@ def find_target_files(targdir, dr='X', flavor="targets", survey="main",
             fn = os.path.join(os.path.dirname(fn), justfn)
 
     return fn
+
+
+def read_mtl_tile_file(filename):
+    """Read which tiles have been processed by MTL from the tile file.
+
+    Parameters
+    ----------
+    filename : :class:`str`
+        The full path to the MTL tile file.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        A structured numpy array of the MTL tile file.
+    """
+    from desitarget.mtl import mtltilefiledm as dm
+    dt = dm.dtype
+    mtltiles = Table.read(filename, comment="#", delimiter=" ",
+                          format='pandas.csv', dtype=dt)
+
+    return mtltiles
+
+
+def write_mtl_tile_file(filename, data):
+    """Append new tiles to the end of the MTL tile file.
+
+    Parameters
+    ----------
+    filename : :class:`str`
+        The full path to the MTL tile file. If this doesn't exist, then 
+        a new file is begun.
+    data : :class`~numpy.ndarray`
+        The data to append to the end of the MTL tile file, which should
+        be in the format of desitarget.mtl.mtltilefiledm
+
+    Returns
+    -------
+    :class:`int`
+        The number of targets that were written to file.
+    :class:`str`
+        The name of the file to which targets were written.
+    """
+    from desitarget.mtl import mtltilefiledm as dm
+    dt = dm.dtype
+    if data.dtype != dt:
+        msg = "Data for MTL tile file formatted as {}. Should be {}".format(
+            data.dtype, dt)
+        log.error(msg)
+        raise IOError(msg)
+
+    if os.path.isfile(filename):
+       # ADM as we're working with .ecsv, simply append to the end.
+        f = open(filename, "a")
+        ascii.write(data, f, format='no_header')
+        f.close()
+    else:
+        # ADM we need to make the file.
+        write_with_units(filename, data, extname='MTLTILE', ecsv=True)
+
+    return(len(data), filename)
 
 
 def read_mtl_ledger(filename, unique=True):

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -841,7 +841,7 @@ def make_zcat_rr_backstop(zcatdir, tiles):
     Notes
     -----
     - How the `zcat` is constructed could certainly change once we have
-    the final schema in place.
+      the final schema in place.
     """
     # ADM for each tile, read in the spectroscopic and targeting info.
     allzs = []

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -42,27 +42,81 @@ mtldatamodel = np.array([], dtype=[
     ('TIMESTAMP', 'S19'), ('VERSION', 'S14'), ('TARGET_STATE', 'S16')
     ])
 
+mtltilefiledm = np.array([], dtype=[
+    ('TILEID', '>i4'), ('TIMESTAMP', 'S19'), ('VERSION', 'S14')
+    ])
+
+
 # ADM when using basic or csv ascii writes, specifying the formats of
 # ADM float32 columns can make things easier on the eye.
 mtlformatdict = {"PARALLAX": '%16.8f', 'PMRA': '%16.8f', 'PMDEC': '%16.8f'}
 
 
-def get_mtl_dir():
-    """Convenience function to grab the MTL_DIR environment variable.
+def get_mtl_dir(mtldir=None):
+    """Convenience function to grab the $MTL_DIR environment variable.
+
+    Parameters
+    ----------
+    mtldir : :class:`str`, optional, defaults to $MTL_DIR
+        If `mtldir` is passed, it is returned from this function. If it's
+        not passed, the $MTL_DIR environment variable is returned.
 
     Returns
     -------
     :class:`str`
-        The directory stored in the $MTL_DIR environment variable.
+        If `mtldir` is passed, it is returned from this function. If it's
+        not passed, the directory stored in the $MTL_DIR environment
+        variable is returned.
     """
-    # ADM check that the $MTL_DIR environment variable is set.
-    mtldir = os.environ.get('MTL_DIR')
     if mtldir is None:
-        msg = "Set $MTL_DIR environment variable!"
-        log.critical(msg)
-        raise ValueError(msg)
+        mtldir = os.environ.get('MTL_DIR')
+        # ADM check that the $MTL_DIR environment variable is set.
+        if mtldir is None:
+            msg = "Pass mtldir or set $MTL_DIR environment variable!"
+            log.critical(msg)
+            raise ValueError(msg)
 
     return mtldir
+
+
+def get_zcat_dir(zcatdir=None):
+    """Convenience function to grab the $ZCAT_DIR environment variable.
+
+    Parameters
+    ----------
+    zcatdir : :class:`str`, optional, defaults to $ZCAT_DIR
+        If `zcatdir` is passed, it is returned from this function. If it's
+        not passed, the $ZCAT_DIR environment variable is returned.
+
+    Returns
+    -------
+    :class:`str`
+        If `zcatdir` is passed, it is returned from this function. If it's
+        not passed, the directory stored in the $ZCAT_DIR environment
+        variable is returned.
+    """
+    if zcatdir is None:
+        zcatdir = os.environ.get('ZCAT_DIR')
+        # ADM check that the $ZCAT_DIR environment variable is set.
+        if zcatdir is None:
+            msg = "Pass zcatdir or set $ZCAT_DIR environment variable!"
+            log.critical(msg)
+            raise ValueError(msg)
+
+    return zcatdir
+
+
+def get_tile_file_name():
+    """Convenience function to grab the name of the MTL tile file.
+
+    Returns
+    -------
+    :class:`str`
+        The name of the MTL tile file.
+    """
+    fn = "mtl-done-tiles.ecsv"
+
+    return fn
 
 
 def _get_mtl_nside():

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -921,7 +921,7 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     - Assumes all of the relevant ledgers have already been made by,
       e.g., `make_ledger()`.
     """
-    ## ADM first grab all of the relevant files.
+    # ADM first grab all of the relevant files.
     # ADM grab the MTL directory (in case we're relying on $MTL_DIR).
     mtldir = get_mtl_dir(mtldir)
     # ADM construct the full path to the mtl tile file.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -897,7 +897,8 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
         $MTL_DIR environment variable.
     tilefn : :class:`str`, optional, defaults to ``None``
         Full path to the name of the tile file. This file is used to link
-        TILEIDs to observing conditions.
+        TILEIDs to observing conditions. If passed as ``None``, looked up
+        from the $TILE_FN environment variable.
     numobs_from_ledger : :class:`bool`, optional, defaults to ``True``
         If ``True`` then inherit the number of observations so far from
         the ledger rather than expecting it to have a reasonable value
@@ -942,7 +943,7 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
 
     # ADM stop if there are no tiles to process.
     if len(tiles) == 0:
-        return hpdirname, mtltilefn, tiles
+        return hpdirname, mtltilefn, tilefn, tiles
 
     # ADM create the zcat: This will likely change, but for now let's
     # ADM just use redrock in the SV1-era format.

--- a/py/desitarget/sv1/data/sv1_targetmask.yaml
+++ b/py/desitarget/sv1/data/sv1_targetmask.yaml
@@ -367,9 +367,9 @@ priorities:
         MWS_MAIN_BROAD_SOUTH:            SAME_AS_MWS_MAIN_BROAD_NORTH
         MWS_MAIN_FAINT_NORTH:      {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
         MWS_MAIN_FAINT_SOUTH:      SAME_AS_MWS_MAIN_FAINT_NORTH
-        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 9, OBS: 9, DONOTOBSERVE: 0}
-        BACKUP_FAINT:                 {UNOBS: 8, DONE: 8, OBS: 8, DONOTOBSERVE: 0}
-        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 7, OBS: 7, DONOTOBSERVE: 0}
+        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_FAINT:                 {UNOBS: 8, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         # ADM Standards are special; priorities don't apply.
         GAIA_STD_FAINT:  -1
         GAIA_STD_WD:  -1

--- a/py/desitarget/sv2/data/sv2_targetmask.yaml
+++ b/py/desitarget/sv2/data/sv2_targetmask.yaml
@@ -221,9 +221,9 @@ priorities:
         MWS_MAIN_RED:                 SAME_AS_MWS_MAIN_BLUE
         MWS_MAIN_RED_NORTH:           SAME_AS_MWS_BROAD_NORTH
         MWS_MAIN_RED_SOUTH:           SAME_AS_MWS_BROAD_NORTH
-        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 9, OBS: 9, DONOTOBSERVE: 0}
-        BACKUP_FAINT:                 {UNOBS: 8, DONE: 8, OBS: 8, DONOTOBSERVE: 0}
-        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 7, OBS: 7, DONOTOBSERVE: 0}
+        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_FAINT:                 {UNOBS: 8, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         # ADM Standards are special; priorities don't apply.
         GAIA_STD_FAINT:  -1
         GAIA_STD_WD:  -1


### PR DESCRIPTION
This PR implements the full loop of constructing a `zcat` by reading "done" tiles from a specified directory, determining which "done" tiles are yet to be processed, updating ledgers, and creating and updating an "MTL tile file" to record which tiles have been processed through MTL. New features include:

- Modify the ledgers based on any new (i.e. previously unprocessed) tiles in a `zcat` directory.
- Create and update an "MTL tile file" which tracks which tiles have been processed by MTL.
- Read the "standard" tile file to determine the observing conditions for each tile, and only process a given tile for the appropriate observing conditions.
  * This should also only process tiles if they are in the appropriate tile file for a given survey flavor (`sv2`, `main`, etc.).
- An option to use the ledgers themselves to update `NUMOBS` instead of expecting `NUMOBS` to be in the `zcat`.
  * Currently this option is turned on, but it will be easy to turn off if we decide to track `NUMOBS` (e.g. via `NUMTILE`) in the `zcat`. 
- A command-line script to execute the full loop. Each of the required input directories can be passed or can be environment variables.
  * An example is: `run_mtl_loop DARK --survey sv2 --zcatdir $ZCAT_DIR --mtldir $MTL_DIR --tilefn $TILE_FN`

A number of refinements are likely to be needed that build on this PR, as:
- We haven't yet converged on the data model and full directory path for the `zbest` files.
- Eleanor will eventually want to drop in a different `make_zcat()` function to replace my simple `make_zcat_rr_backstop()`.
- We haven't yet determined whether we will use `NUMTILE` from the spectroscopic pipeline outputs, or if we will let the ledger update `NUMOBS` itself.
- We will need to update priorities and `NUMOBS` more carefully [based on `ZWARN`](https://github.com/desihub/desispec/issues/1187)

But this is likely enough infrastructure to have a first crack at the 0.1% survey.
