### PR TITLE
Don't insist that ZTILEID has to be in the zcat passed to MTL

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,12 +5,16 @@ desitarget Change Log
 0.53.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Don't insist that ``ZTILEID`` has to be in the ``zcat`` [`PR #687`_].
+* Install the SV2-related data files [`PR #686`_].
+
+.. _`PR #686`: https://github.com/desihub/desitarget/pull/686
+.. _`PR #687`: https://github.com/desihub/desitarget/pull/687
 
 0.53.0 (2021-03-18)
 -------------------
 
-* Update the ELG selection for SV2 [`PR #685`_]
+* Update the ELG selection for SV2 [`PR #685`_].
 * Implement full MTL loop [`PR #684`_]. Includes:
     * Modify ledgers based on any new tiles in a ``zcat`` directory.
     * An MTL tile file to track which tiles have been processed by MTL.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -339,7 +339,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
                                     dtype=mtldatamodel["SCND_TARGET"].dtype)
 
     # ADM initialize columns to avoid zero-length/missing/format errors.
-    zcols = ["NUMOBS_MORE", "NUMOBS", "Z", "ZWARN", "ZTILEID"]
+    zcols = ["NUMOBS_MORE", "NUMOBS", "Z", "ZWARN"]
     for col in zcols + ["TARGET_STATE", "TIMESTAMP", "VERSION"]:
         mtl[col] = np.empty(len(mtl), dtype=mtldatamodel[col].dtype)
 
@@ -359,6 +359,12 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
     mtl['TARGET_STATE'][zmatcher] = target_state
     for col in zcols:
         mtl[col][zmatcher] = ztargets[col]
+    # ADM also add the ZTILEID column, if passed, otherwise we're likely
+    # ADM to be working with non-ledger-based mocks and can let it slide.
+    if "ZTILEID" in ztargets:
+        mtl["ZTILEID"][zmatcher] = ztargets["ZTILEID"]
+    else:
+        mtl["ZTILEID"] = -1
 
     # Filter out any targets marked as done.
     if trim:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -965,6 +965,14 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     # ADM create the zcat: This will likely change, but for now let's
     # ADM just use redrock in the SV1-era format.
     zcat = make_zcat_rr_backstop(zcatdir, tiles["TILEID"])
+    # ADM insist that for an MTL loop with real observations, the zcat
+    # ADM must conform to the data model. In particular, it must include
+    # ADM ZTILEID, which may not be needed for non-ledger simulations.
+    if zcat.dtype.descr != zcatdatamodel.dtype.descr:
+        msg = "zcat data model must be {} not {}!".format(
+            zcatdatamodel.dtype.descr, zcat.dtype.descr)
+        log.critical(msg)
+        raise ValueError(msg)
 
     # ADM update the appropriate ledger.
     update_ledger(hpdirname, zcat, obscon=obscon,


### PR DESCRIPTION
This PR fixes a potential backwards-compatibility issue with #684. In #684, we introduced tracking of which tile a set of redshift updates were associated with so that tiles could be "backed out" in a ledger, if needed, and MTL updates associated with a specific tile could be undone. This was achieved by tracking a `ZTILEID` through the `desitarget.mtl.make_mtl()` function.

But, the simulations don't currently pass `ZTILEID`, so would fail when using `make_mtl()` in the context of #684. This PR makes passing `ZTILEID` to `make_mtl()` (or not) more forgiving, while also enforcing that a `zcat` based on real observations must include `ZTILEID`.