### PR TITLE
Don't pass the Data Release when constructing MTL filenames

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,13 @@ desitarget Change Log
 0.53.1 (unreleased)
 -------------------
 
+* Don't pass the DR when constructing MTL filenames [`PR #688`_].
 * Don't insist that ``ZTILEID`` has to be in the ``zcat`` [`PR #687`_].
 * Install the SV2-related data files [`PR #686`_].
 
 .. _`PR #686`: https://github.com/desihub/desitarget/pull/686
 .. _`PR #687`: https://github.com/desihub/desitarget/pull/687
+.. _`PR #688`: https://github.com/desihub/desitarget/pull/688
 
 0.53.0 (2021-03-18)
 -------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2663,14 +2663,13 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False):
         - Should work for both .ecsv and .fits files.
     """
     # ADM grab information from the target directory.
-    dr = read_keyword_from_mtl_header(hpdirname, "DR")
     surv = read_keyword_from_mtl_header(hpdirname, "SURVEY")
     oc = read_keyword_from_mtl_header(hpdirname, "OBSCON")
     from desitarget.mtl import get_mtl_ledger_format
     ender = get_mtl_ledger_format()
 
     # ADM construct the full directory path.
-    hugefn = find_target_files(hpdirname, flavor="mtl", hp="{}", dr=dr,
+    hugefn = find_target_files(hpdirname, flavor="mtl", hp="{}",
                                survey=surv, ender=ender, obscon=oc)
     # ADM return the filename.
     fileform = os.path.join(hpdirname, os.path.basename(hugefn))


### PR DESCRIPTION
As part of #684, we changed the data model such that the directory path to MTL files no longer includes the Data Release. This broke the MTL-specific read routines, such as `desitarget.io.read_targets_in_tiles(..., mtl=True)` which were still expecting to need to pass around Data Release names.

This is a very minor PR to fix that bug.