### PR TITLE
Update ToO Ledgers to add a TOOID and HI/LO priority options

### DIFF
--- a/bin/select_too
+++ b/bin/select_too
@@ -2,6 +2,9 @@
 
 from desitarget.ToO import get_too_dir, ledger_to_targets
 
+# ADM default to the main survey.
+survey = "main"
+
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Make an initial ledger for Targets of Opportunity')
 ap.add_argument("-t", "--toodir",
@@ -11,9 +14,12 @@ ap.add_argument("-t", "--toodir",
 ap.add_argument("-o", "--outdir",
                 help="Output directory to which to write the file of targets. \
                 [defaults to the environment variable $TOO_DIR]")
+ap.add_argument("-s", "--survey",
+                help="Survey flavor (e.g. sv3). [defaults to {}]".format(survey),
+                default=survey)
 
 ns = ap.parse_args()
 
 toodir = get_too_dir(ns.toodir)
 
-_ = ledger_to_targets(toodir, outdir=ns.outdir)
+_ = ledger_to_targets(toodir, outdir=ns.outdir, survey=ns.survey)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.53.1 (unreleased)
 -------------------
 
+* Update ToO Ledger with TOOID and HI/LO priority options [`PR #690`_]
 * Add an ``sv3_cuts.py`` module and sv3 bitmask yaml file [`PR #689`_].
 * Don't pass the DR when constructing MTL filenames [`PR #688`_].
 * Don't insist that ``ZTILEID`` has to be in the ``zcat`` [`PR #687`_].
@@ -14,6 +15,7 @@ desitarget Change Log
 .. _`PR #687`: https://github.com/desihub/desitarget/pull/687
 .. _`PR #688`: https://github.com/desihub/desitarget/pull/688
 .. _`PR #689`: https://github.com/desihub/desitarget/pull/689
+.. _`PR #690`: https://github.com/desihub/desitarget/pull/690
 
 0.53.0 (2021-03-18)
 -------------------

--- a/py/desitarget/ToO.py
+++ b/py/desitarget/ToO.py
@@ -23,10 +23,10 @@ outdtype = [tup for tup in outdatamodel.dtype.descr if "OVERRIDE" not in tup]
 # ADM ...and some extra columns are necessary.
 indatamodel = np.array([], dtype=indtype + [
     ('CHECKER', '>U3'), ('TOO_TYPE', '>U5'), ('OCLAYER', '>U6'),
-    ('MJD_BEGIN', '>f8'), ('MJD_END', '>f8')])
+    ('TOOID', '>i4'), ('MJD_BEGIN', '>f8'), ('MJD_END', '>f8')])
 outdatamodel = np.array([], dtype=outdtype + [
     ('CHECKER', '>U3'), ('TOO_TYPE', '>U5'), ('OCLAYER', '>U6'),
-    ('MJD_BEGIN', '>f8'), ('MJD_END', '>f8')])
+    ('TOOID', '>i4'), ('MJD_BEGIN', '>f8'), ('MJD_END', '>f8')])
 
 # ADM when using basic or csv ascii writes, specifying the formats of
 # ADM float32 columns can make things easier on the eye.

--- a/py/desitarget/ToO.py
+++ b/py/desitarget/ToO.py
@@ -349,6 +349,7 @@ def _check_ledger(inledger):
     # ADM check that the requested ToOs don't exceed allocations. There
     # ADM are different constraints for different types of observations.
     for tootype in "FIBER", "TILE":
+        log.info("Working on ToO observations of type {}".format(tootype))
         # ADM only restrict observations at higher-than-primary priority.
         ii = (inledger["TOO_TYPE"] == tootype) & (inledger["TOO_PRIO"] == "HI")
         # ADM work with discretized days that run from noon until noon
@@ -362,19 +363,20 @@ def _check_ledger(inledger):
             allowed = np.array(list(constraints[tootype].values()))
             # ADM check the total nights covered by the MJD ranges.
             fibers = max_integers_in_interval(jdbegin, jdend, nights)
-            log.info("Working on ToO observations of type {}".format(tootype))
             for fiber, night, allow in zip(fibers, nights, allowed):
                 log.info(
-                    "Maximum of {} fibers requested over {} nights ({} allowed)"
+                    "Max of {} HIP fibers requested over {} nights ({} allowed)"
                     .format(fiber, night, allow)
                     )
             excess = fibers > allowed
             if np.any(excess):
-                msg = "Allocation exceeded! "
-                msg += "{} fibers requested over {} nights ({} allowed)".format(
-                    fibers[excess], nights[excess], allowed[excess])
+                msg = "Allocation exceeded! Number of HIP fibers requested over"
+                msg += "{} nights is {} (but only {} are allowed)".format(
+                    nights[excess], fibers[excess], allowed[excess])
                 log.critical(msg)
                 raise ValueError(msg)
+        else:
+            log.info("No fibers requested")
 
     return
 

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -124,9 +124,11 @@ scnd_mask:
     - [DR16Q,       1, "Known quasars from the SDSS DR16Q catalog",
        {obsconditions: DARK|GRAY, filename: 'dr16q', downsample: 1}]
 
-# ADM reserve 60/61 in scnd_mask for Targets of Opportunity in both SV and the Main Survey.
-    - [BRIGHT_TOO,    60, "Targets of Opportunity from rolling ledger",   {obsconditions: BRIGHT, flavor: 'TOO'}]
-    - [DARK_TOO,      61, "Targets of Opportunity from rolling ledger",   {obsconditions: DARK,   flavor: 'TOO'}]
+# ADM reserve 59-62 in scnd_mask for Targets of Opportunity in both SV and the Main Survey.
+    - [BRIGHT_TOO_LOP,    59, "Targets of Opportunity from rolling ledger",   {obsconditions: BRIGHT|DARK, flavor: 'TOO'}]
+    - [BRIGHT_TOO_HIP,    60, "Targets of Opportunity from rolling ledger",   {obsconditions: BRIGHT|DARK, flavor: 'TOO'}]
+    - [DARK_TOO_LOP,      61, "Targets of Opportunity from rolling ledger",   {obsconditions: DARK,        flavor: 'TOO'}]
+    - [DARK_TOO_HIP,      62, "Targets of Opportunity from rolling ledger",   {obsconditions: DARK,        flavor: 'TOO'}]
 
 #- Observing conditions
 #- These are a bitmask to allow target bits to specify multiple conditions
@@ -264,10 +266,13 @@ priorities:
     # ADM secondary target priorities. Probably all have very low UNOBS...
     scnd_mask:
     # ADM ...except VETO, which is special and always takes precedence.
-        VETO:                         {UNOBS: 10000, DONE: 10000, OBS: 0, DONOTOBSERVE: 0}
-        DR16Q:                        {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BRIGHT_TOO:            {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        DARK_TOO:              SAME_AS_BRIGHT_TOO
+        VETO:                   {UNOBS: 10000, DONE: 10000, OBS: 0, DONOTOBSERVE: 0}
+        DR16Q:                  {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BRIGHT_TOO_LOP:         {UNOBS: 1000, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        BRIGHT_TOO_HIP:         {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        DARK_TOO_LOP:           SAME_AS_BRIGHT_TOO_LOP
+        DARK_TOO_HIP:           SAME_AS_BRIGHT_TOO_HIP
+
 
 # ADM INITIAL number of observations (NUMOBS_INIT) for each target bit
 # ADM SAME_AS_XXX means to use the NUMOBS_INIT for bitname XXX
@@ -346,5 +351,7 @@ numobs:
     scnd_mask:
         VETO:         1
         DR16Q:        1
-        BRIGHT_TOO:   1
-        DARK_TOO:     SAME_AS_BRIGHT_TOO
+        BRIGHT_TOO_LOP:         1
+        BRIGHT_TOO_HIP:         1
+        DARK_TOO_LOP:           1
+        DARK_TOO_HIP:           1

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -146,9 +146,11 @@ sv3_scnd_mask:
     - [WD_BINARIES_BRIGHT,     41, "See $SCND_DIR/sv3/docs/WD_BINARIES_BRIGHT.txt",   {obsconditions: BRIGHT,           filename: 'WD_BINARIES_BRIGHT',  flavor: 'SPARE',  downsample: 1}]
     - [WD_BINARIES_DARK,       42, "See $SCND_DIR/sv3/docs/WD_BINARIES_DARK.txt",     {obsconditions: DARK,             filename: 'WD_BINARIES_DARK',    flavor: 'SPARE',  downsample: 1}]
 
-# ADM reserve 60/61 in scnd_mask for Targets of Opportunity in both SV and the Main Survey.
-    - [BRIGHT_TOO,    60, "Targets of Opportunity from rolling ledger",   {obsconditions: BRIGHT, flavor: 'TOO'}]
-    - [DARK_TOO,      61, "Targets of Opportunity from rolling ledger",   {obsconditions: DARK,   flavor: 'TOO'}]
+# ADM reserve 59-62 in scnd_mask for Targets of Opportunity in both SV and the Main Survey.
+    - [BRIGHT_TOO_LOP,    59, "Targets of Opportunity from rolling ledger",   {obsconditions: BRIGHT|DARK, flavor: 'TOO'}]
+    - [BRIGHT_TOO_HIP,    60, "Targets of Opportunity from rolling ledger",   {obsconditions: BRIGHT|DARK, flavor: 'TOO'}]
+    - [DARK_TOO_LOP,      61, "Targets of Opportunity from rolling ledger",   {obsconditions: DARK,        flavor: 'TOO'}]
+    - [DARK_TOO_HIP,      62, "Targets of Opportunity from rolling ledger",   {obsconditions: DARK,        flavor: 'TOO'}]
 
 #- Observation State
 #- if a target passes more than one target bit, it is possible that one bit
@@ -284,8 +286,10 @@ priorities:
         BRIGHT_HPM:             SAME_AS_LOW_MASS_AGN
         WD_BINARIES_BRIGHT:     {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
         WD_BINARIES_DARK:       {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        BRIGHT_TOO:             {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        DARK_TOO:               SAME_AS_BRIGHT_TOO
+        BRIGHT_TOO_LOP:         {UNOBS: 1000, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        BRIGHT_TOO_HIP:         {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        DARK_TOO_LOP:           SAME_AS_BRIGHT_TOO_LOP
+        DARK_TOO_HIP:           SAME_AS_BRIGHT_TOO_HIP
 
 # ADM INITIAL number of observations (NUMOBS_INIT) for each target bit
 # ADM SAME_AS_XXX means to use the NUMOBS_INIT for bitname XXX
@@ -389,5 +393,7 @@ numobs:
         BRIGHT_HPM:             100
         WD_BINARIES_BRIGHT:     100
         WD_BINARIES_DARK:       100
-        BRIGHT_TOO:               1
-        DARK_TOO:               SAME_AS_BRIGHT_TOO
+        BRIGHT_TOO_LOP:         1
+        BRIGHT_TOO_HIP:         1
+        DARK_TOO_LOP:           1
+        DARK_TOO_HIP:           1


### PR DESCRIPTION
This PR updates the Target of Opportunity (ToO) functionality to: 

- Include a `TOOID` that can be used to track the same source across different sets of ToO observations. 
- Allow `DARK` and `BRIGHT` observations to be split across two priorities: 
  * `LO` (or `LOP`) which will always be at a sufficiently low priority to never interfere with primary targets.
  * `HI` (or `HIP`) which will always be at a sufficiently high priority to trump all other targets.
- Interpret `BRIGHT` ToO observations as observations that can be taken in either `BRIGHT|DARK` observing conditions.