### PR TITLE
Some clean-up for the 1% Survey

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,12 @@ desitarget Change Log
 0.53.1 (unreleased)
 -------------------
 
+* Some clean-up for the 1% Survey [`PR #691`_]. Includes:
+    * Don't allow ``BGS_FAINT`` targets to be observed in ``DARK``.
+    * Warn about primary targets that might be too bright.
+    * Have a single function for calculating UTC time stamps.
+    * Functionality to read ledgers strictly before a certain UTC time.
+    * Centralize and speed up routines to match array on ``TARGETID``.
 * Update ToO Ledger with TOOID and HI/LO priority options [`PR #690`_]
 * Add an ``sv3_cuts.py`` module and sv3 bitmask yaml file [`PR #689`_].
 * Don't pass the DR when constructing MTL filenames [`PR #688`_].
@@ -16,6 +22,7 @@ desitarget Change Log
 .. _`PR #688`: https://github.com/desihub/desitarget/pull/688
 .. _`PR #689`: https://github.com/desihub/desitarget/pull/689
 .. _`PR #690`: https://github.com/desihub/desitarget/pull/690
+.. _`PR #691`: https://github.com/desihub/desitarget/pull/691
 
 0.53.0 (2021-03-18)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,7 +10,7 @@ desitarget Change Log
     * Warn about primary targets that might be too bright.
     * Have a single function for calculating UTC time stamps.
     * Functionality to read ledgers strictly before a certain UTC time.
-    * Centralize and speed up routines to match array on ``TARGETID``.
+    * Centralize and speed up routines to match arrays on ``TARGETID``.
 * Update ToO Ledger with TOOID and HI/LO priority options [`PR #690`_]
 * Add an ``sv3_cuts.py`` module and sv3 bitmask yaml file [`PR #689`_].
 * Don't pass the DR when constructing MTL filenames [`PR #688`_].

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -6,7 +6,6 @@ desitarget.QA
 
 Module dealing with Quality Assurance tests for Target Selection
 """
-from __future__ import (absolute_import, division)
 from time import time
 import numpy as np
 import fitsio
@@ -22,8 +21,6 @@ from collections import defaultdict
 from glob import glob, iglob
 from scipy.optimize import leastsq
 from scipy.spatial import ConvexHull
-from astropy import units as u
-from astropy.coordinates import SkyCoord
 from desiutil import brick
 from desiutil.log import get_logger
 from desitarget.internal import sharedmem

--- a/py/desitarget/brightmask.py
+++ b/py/desitarget/brightmask.py
@@ -19,9 +19,6 @@ from glob import glob
 import numpy as np
 import numpy.lib.recfunctions as rfn
 
-from astropy.coordinates import SkyCoord
-from astropy import units as u
-
 from matplotlib.patches import Polygon
 from matplotlib.collections import PatchCollection
 
@@ -587,6 +584,8 @@ def is_in_bright_mask(targs, sourcemask, inonly=False):
     used_near_mask = np.zeros(len(sourcemask), dtype=bool)
 
     # ADM turn the mask and target coordinates into SkyCoord objects.
+    from astropy.coordinates import SkyCoord
+    from astropy import units as u
     ctargs = SkyCoord(targs["RA"]*u.degree, targs["DEC"]*u.degree)
     cmask = SkyCoord(sourcemask["RA"]*u.degree, sourcemask["DEC"]*u.degree)
 

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -54,16 +54,16 @@ desi_mask:
 
 #- Bright Galaxy Survey
 bgs_mask:
-    - [BGS_FAINT,           0, "BGS faint targets",                     {obsconditions: BRIGHT|GRAY|DARK}]
+    - [BGS_FAINT,           0, "BGS faint targets",                     {obsconditions: BRIGHT}]
     - [BGS_BRIGHT,          1, "BGS bright targets",                    {obsconditions: BRIGHT}]
     - [BGS_WISE,            2, "BGS wise targets",                      {obsconditions: BRIGHT}]
     - [BGS_FAINT_HIP,       3, "BGS faint targets at bright priorty",   {obsconditions: BRIGHT}]
 
     #- BGS North vs. South selections
-    - [BGS_FAINT_NORTH,     8, "BGS faint cuts tuned for Bok/Mosaic",              {obsconditions: BRIGHT|GRAY|DARK}]
+    - [BGS_FAINT_NORTH,     8, "BGS faint cuts tuned for Bok/Mosaic",              {obsconditions: BRIGHT}]
     - [BGS_BRIGHT_NORTH,    9, "BGS bright cuts tuned for Bok/Mosaic",             {obsconditions: BRIGHT}]
     - [BGS_WISE_NORTH,      10, "BGS WISE cuts tuned for Bok/Mosaic",              {obsconditions: BRIGHT}]
-    - [BGS_FAINT_SOUTH,     16, "BGS faint cuts tuned for DECam",                  {obsconditions: BRIGHT|GRAY|DARK}]
+    - [BGS_FAINT_SOUTH,     16, "BGS faint cuts tuned for DECam",                  {obsconditions: BRIGHT}]
     - [BGS_BRIGHT_SOUTH,    17, "BGS bright cuts tuned for DECam",                 {obsconditions: BRIGHT}]
     - [BGS_WISE_SOUTH,      18, "BGS WISE cuts tuned for DECam",                   {obsconditions: BRIGHT}]
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -84,6 +84,8 @@ def match(A, B):
     -----
     - Result should be such that for Aii, Bii = match(A, B)
       np.all(A[Aii] == B[Bii]) is True.
+    - Only works if there is a unique mapping from A->B, i.e
+      if A and B do NOT contain duplicates.
     - h/t Anand Raichoor `by way of Stack Overflow`_.
     """
     # AR sorting A,B

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2509,8 +2509,14 @@ def read_mtl_ledger(filename, unique=True, isodate=None):
 
     # ADM restrict to dates before isodate, if requested.
     if isodate is not None:
-        ii = mtl["TIMESTAMP"] < isodate
-        mtl = mtl[ii]
+        # ADM try a couple of choices to guard against byte-type versus
+        # string-type errors.
+        try:
+            ii = mtl["TIMESTAMP"] < isodate
+            mtl = mtl[ii]
+        except TypeError:
+            ii = mtl["TIMESTAMP"] < isodate.encode()
+            mtl = mtl[ii]
 
     if unique:
         # ADM the reverse is because np.unique retains the FIRST unique

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -22,6 +22,7 @@ from desitarget.targetmask import obsmask, obsconditions
 from desitarget.targets import calc_priority, calc_numobs_more
 from desitarget.targets import main_cmx_or_sv, switch_main_cmx_or_sv
 from desitarget.targets import set_obsconditions
+from desitarget.geomask import match, match_to
 from desitarget.internal import sharedmem
 from desitarget import io
 
@@ -294,11 +295,8 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
     # ADM if a redshift catalog was passed, order it to match the input targets
     # ADM catalog on 'TARGETID'.
     if zcat is not None:
-        # ADM there might be a quicker way to do this?
-        # ADM set up a dictionary of the indexes of each target id.
-        d = dict(tuple(zip(targets["TARGETID"], np.arange(n))))
-        # ADM loop through the zcat and look-up the index in the dictionary.
-        zmatcher = np.array([d[tid] for tid in zcat["TARGETID"]])
+        # ADM find where zcat matches target array.
+        zmatcher = match_to(targets["TARGETID"], zcat["TARGETID"])
         ztargets = zcat
         if ztargets.masked:
             unobs = ztargets['NUMOBS'].mask
@@ -640,12 +638,10 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
     # ADM if requested, use the previous values in the ledger to set
     # ADM NUMOBS in the zcat.
     if numobs_from_ledger:
-        lupd = dict(tuple(zip(targets["TARGETID"], np.arange(len(targets)))))
-        # ADM match zcat to targets on TARGETID.
-        inzcat = [tid in lupd for tid in zcat["TARGETID"]]
-        ii = np.array([lupd[tid] for tid in zcat["TARGETID"] if tid in lupd])
-        # ADM create NUMOBS for zcat based on previous ledger entry.
-        zcat["NUMOBS"][inzcat] = targets["NUMOBS"][ii] + 1
+        # ADM match the zcat to the targets.
+        tii, zii = match(targets["TARGETID"], zcat["TARGETID"])
+        # ADM update NUMOBS in the zcat for matches.
+        zcat["NUMOBS"][zii] = targets["NUMOBS"][tii] + 1
 
     # ADM run MTL, only returning the targets that are updated.
     mtl = make_mtl(targets, oc, zcat=zcat, trimtozcat=True, trimcols=True)
@@ -750,10 +746,8 @@ def inflate_ledger(mtl, hpdirname, columns=None, header=False, strictcols=False,
         targs, hdr = targs
 
     # ADM match the mtl back to the targets on TARGETID.
-    lupd = dict(tuple(zip(targs["TARGETID"], np.arange(len(targs)))))
-    ii = np.array([lupd[tid] for tid in mtl["TARGETID"]])
-
-    # ADM reorder targets to match MTL on TARGETID.
+    ii = match_to(targs["TARGETID"], mtl["TARGETID"])
+    # ADM extract just the targets that match the mtl.
     targs = targs[ii]
 
     # ADM create an array to contain the fuller set of target columns.
@@ -887,9 +881,7 @@ def make_zcat_rr_backstop(zcatdir, tiles):
     # ADM currently, the spectroscopic files aren't coadds, so aren't
     # ADM unique. We therefore need to look up (any) coordinates for
     # ADM each z in the fibermap.
-    d = dict(tuple(zip(fms["TARGETID"], np.arange(len(fms)))))
-    # ADM loop through the zs and look-up the index in the dictionary.
-    zid = np.array([d[tid] for tid in zs["TARGETID"]])
+    zid = match_to(fms["TARGETID"], zs["TARGETID"])
 
     # ADM write out the zcat as a file with the correct data model.
     zcat = Table(np.zeros(len(zs), dtype=zcatdatamodel.dtype))

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -72,7 +72,7 @@ def get_utc_date():
     Notes
     -----
     - This is spun off into its own function to have a consistent way to
-    record time across the entire desitarget package.
+      record time across the entire desitarget package.
     """
     return datetime.utcnow().isoformat(timespec='seconds')
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -60,6 +60,22 @@ mtltilefiledm = np.array([], dtype=[
 mtlformatdict = {"PARALLAX": '%16.8f', 'PMRA': '%16.8f', 'PMDEC': '%16.8f'}
 
 
+def get_utc_date():
+    """Convenience function to grab the UTC date.
+
+    Returns
+    -------
+    :class:`str`
+        The UTC data, appropriate to make a TIMESTAMP.
+
+    Notes
+    -----
+    - This is spun off into its own function to have a consistent way to
+    record time across the entire desitarget package.
+    """
+    return datetime.utcnow().isoformat(timespec='seconds')
+
+
 def get_mtl_dir(mtldir=None):
     """Convenience function to grab the $MTL_DIR environment variable.
 
@@ -349,8 +365,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
     mtl['PRIORITY'] = mtl['PRIORITY_INIT']
     mtl['TARGET_STATE'] = "UNOBS"
     # ADM add the time and version of the desitarget code that was run.
-    utc = datetime.utcnow().isoformat(timespec='seconds')
-    mtl["TIMESTAMP"] = utc
+    mtl["TIMESTAMP"] = get_utc_date()
     mtl["VERSION"] = dt_version
 
     # ADM now populate the new mtl columns with the updated information.
@@ -822,8 +837,7 @@ def tiles_to_be_processed(zcatdir, mtltilefn, tilefn, obscon):
     donetiles = np.zeros(len(tileids), dtype=mtltilefiledm.dtype)
     donetiles["TILEID"] = tileids
     # ADM look up the time.
-    utc = datetime.utcnow().isoformat(timespec='seconds')
-    donetiles["TIMESTAMP"] = utc
+    donetiles["TIMESTAMP"] = get_utc_date()
     # ADM add the version of desitarget.
     donetiles["VERSION"] = dt_version
     # ADM add the program/obscon.

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -43,8 +43,6 @@ import healpy as hp
 
 import numpy.lib.recfunctions as rfn
 
-import astropy.units as u
-from astropy.coordinates import SkyCoord
 from astropy.table import Table, Row
 
 from time import time
@@ -823,6 +821,8 @@ def finalize_secondary(scxtargs, scnd_mask, survey='main', sep=1.,
                  .format(len(scxtargs), time()-t0))
         # ADM use astropy for the matching. At NERSC, astropy matches
         # ADM ~20M objects to themselves in about 10 minutes.
+        import astropy.units as u
+        from astropy.coordinates import SkyCoord
         c = SkyCoord(scxtargs["RA"][w]*u.deg, scxtargs["DEC"][w]*u.deg)
         m1, m2, _, _ = c.search_around_sky(c, sep*u.arcsec)
         log.info("Done with matching...t={:.1f}s".format(time()-t0))

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -50,16 +50,16 @@ sv3_desi_mask:
 
 #- Bright Galaxy Survey
 sv3_bgs_mask:
-    - [BGS_FAINT,           0, "BGS faint targets",                     {obsconditions: BRIGHT|GRAY|DARK}]
+    - [BGS_FAINT,           0, "BGS faint targets",                     {obsconditions: BRIGHT}]
     - [BGS_BRIGHT,          1, "BGS bright targets",                    {obsconditions: BRIGHT}]
     - [BGS_WISE,            2, "BGS wise targets",                      {obsconditions: BRIGHT}]
     - [BGS_FAINT_HIP,       3, "BGS faint targets at bright priorty",   {obsconditions: BRIGHT}]
 
     #- BGS North vs. South selections
-    - [BGS_FAINT_NORTH,     8, "BGS faint cuts tuned for Bok/Mosaic",              {obsconditions: BRIGHT|GRAY|DARK}]
+    - [BGS_FAINT_NORTH,     8, "BGS faint cuts tuned for Bok/Mosaic",              {obsconditions: BRIGHT}]
     - [BGS_BRIGHT_NORTH,    9, "BGS bright cuts tuned for Bok/Mosaic",             {obsconditions: BRIGHT}]
     - [BGS_WISE_NORTH,      10, "BGS WISE cuts tuned for Bok/Mosaic",              {obsconditions: BRIGHT}]
-    - [BGS_FAINT_SOUTH,     16, "BGS faint cuts tuned for DECam",                  {obsconditions: BRIGHT|GRAY|DARK}]
+    - [BGS_FAINT_SOUTH,     16, "BGS faint cuts tuned for DECam",                  {obsconditions: BRIGHT}]
     - [BGS_BRIGHT_SOUTH,    17, "BGS bright cuts tuned for DECam",                 {obsconditions: BRIGHT}]
     - [BGS_WISE_SOUTH,      18, "BGS WISE cuts tuned for DECam",                   {obsconditions: BRIGHT}]
 

--- a/py/desitarget/test/test_brightmask.py
+++ b/py/desitarget/test/test_brightmask.py
@@ -8,8 +8,6 @@ import os
 import fitsio
 import numpy as np
 import numpy.lib.recfunctions as rfn
-from astropy.coordinates import SkyCoord
-from astropy import units as u
 from glob import glob
 import healpy as hp
 import tempfile
@@ -208,6 +206,8 @@ class TestBRIGHTMASK(unittest.TestCase):
         safes = targs[np.where(skybitset)]
         # ADM for each mask location check that every safe location is
         # ADM equidistant from the mask center.
+        from astropy.coordinates import SkyCoord
+        from astropy import units as u
         c = SkyCoord(safes["RA"]*u.deg, safes["DEC"]*u.deg)
         for i in range(2):
             cent = SkyCoord(self.mask[i]["RA"]*u.deg, self.mask[i]["DEC"]*u.deg)

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -89,16 +89,21 @@ class TestPriorities(unittest.TestCase):
             self.assertEqual(p[2], bgs_mask.BGS_FAINT.priorities['MORE_ZGOOD'])
             # BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2000, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
 
-            # ADM but in DARK conditions, BGS_FAINT should behave as
-            # ADM for other target classes.
             z = self.zcat.copy()
             z['NUMOBS'] = [0, 1, 1]
             z['ZWARN'] = [1, 1, 0]
             p = make_mtl(t, "DARK|GRAY", zcat=z)["PRIORITY"]
-
-            self.assertEqual(p[0], bgs_mask.BGS_FAINT.priorities['UNOBS'])
-            self.assertEqual(p[1], bgs_mask.BGS_FAINT.priorities['DONE'])
-            self.assertEqual(p[2], bgs_mask.BGS_FAINT.priorities['DONE'])
+            # ADM but in DARK conditions, BGS_FAINT should behave as
+            # ADM for other target classes as of SV1.
+            if prefix == "SV1_":
+                self.assertEqual(p[0], bgs_mask.BGS_FAINT.priorities['UNOBS'])
+                self.assertEqual(p[1], bgs_mask.BGS_FAINT.priorities['DONE'])
+                self.assertEqual(p[2], bgs_mask.BGS_FAINT.priorities['DONE'])
+            # ADM no BGS_FAINT allowed in Main Survey DARK conditions.
+            elif prefix == "":
+                self.assertEqual(p[0], 0)
+                self.assertEqual(p[1], 0)
+                self.assertEqual(p[2], 0)
 
             # ADM In BRIGHT conditions BGS BRIGHT targets are
             # ADM never DONE, only MORE_ZGOOD.

--- a/py/desitarget/tychomatch.py
+++ b/py/desitarget/tychomatch.py
@@ -23,6 +23,7 @@ from desitarget import io
 from desitarget.internal import sharedmem
 from desimodel.footprint import radec2pix
 from desitarget.geomask import add_hp_neighbors, radec_match_to, nside2nside
+from desitarget.mtl import get_utc_date
 
 # ADM set up the DESI default logger
 from desiutil.log import get_logger
@@ -133,9 +134,8 @@ def grab_tycho(cosmodir="/global/cfs/cdirs/cosmo/staging/tycho2/"):
             done[col] = objs[col]
 
     # ADM add some information to the header
-    copydate = datetime.utcnow().isoformat(timespec='seconds')
+    hdr["COPYDATE"] = get_utc_date()
     hdr["COSMODIR"] = cosmodir
-    hdr["COPYDATE"] = copydate
 
     # ADM write the data.
     fitsio.write(outfile, done, extname='TYCHOFITS', header=hdr)
@@ -205,7 +205,7 @@ def tycho_fits_to_healpix():
         hdr = dict(allhdr).copy()
         hdr["HPXNSIDE"] = nside
         hdr["HPXNEST"] = True
-        hdr["HPXDATE"] = datetime.utcnow().isoformat(timespec='seconds')
+        hdr["HPXDATE"] = get_utc_date()
 
         # ADM determine which objects are in this pixel and write out.
         done = objs[pix == pixnum]


### PR DESCRIPTION
This PR implements some recent changes decided on Target Selection and Operations meetings, and cleans up some code related to MTL for the 1% Survey. It includes:

- Don't allow `BGS_FAINT` targets in `DARK` observing conditions.
- Trigger a warning when primary targets are encountered that might be too bright (total fluxes or Gaia magnitudes in any band brighter than 16th mag).
- Have a single function for calculating UTC time stamps.
- Functionality to read the state of a ledger strictly before a certain UTC (ISO) time-stamp.
- Refactor and speed up routines to match arrays on ``TARGETID``.