### PR TITLE
Update MTL loop for new data model

### DIFF
--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -24,10 +24,6 @@ ap.add_argument('--mtldir',
                 help="Full path to the directory that hosts the MTL ledgers.    \
                 Default is to use the $ZCAT_DIR environment variable",
                 default=None)
-ap.add_argument('--tilefn',
-                help="Full path to the name of the tile file.                   \
-                Default is to use the $TILE_FN environment variable",
-                default=None)
 ap.add_argument("-n", "--numobsfromzcat", action='store_true',
                 help="If passed, the zcat includes a meaningfule NUMOBS.        \
                 Otherwise, NUMOBS is looked up from the ledger itself")
@@ -38,9 +34,9 @@ numobs_from_ledger = not(ns.numobsfromzcat)
 
 hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
     ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
-    tilefn=ns.tilefn, numobs_from_ledger=numobs_from_ledger)
+    numobs_from_ledger=numobs_from_ledger)
 
 log.info("MTL ledger directory: {}".format(hpdirname))
 log.info("MTL tile file: {}".format(mtltilefn))
-log.info("Tile file: {}".format(tilefn))
+log.info("Redshift tile file: {}".format(tilefn))
 log.info("Processed {} new tiles, which are: {}".format(len(tiles), tiles))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,15 @@ desitarget Change Log
 0.53.1 (unreleased)
 -------------------
 
+* Update MTL loop for new data model [`PR #693`_]. Includes:
+    * Functionality to make initial ledgers for secondary targets.
+    * Use the ``ZTILE`` file to look-up redshift "done-ness" (``zdone``)
+        * instead of relying on a "done" directory.
+    * Also derive the survey and program/obscon from the ``ZTILE`` file.
+    * Switch to reading the ``zbest`` files in the cumulative directory.
+    * Remove -ve ``TARGETIDs`` before matching.
+    * Add the date that redshifts were extracted to the mtl tiles file.
+    * Add the root redshift directory (``ZCAT_DIR``) to the manifest.
 * Some clean-up for the 1% Survey [`PR #691`_]. Includes:
     * Don't allow ``BGS_FAINT`` targets to be observed in ``DARK``.
     * Warn about primary targets that might be too bright.
@@ -23,6 +32,7 @@ desitarget Change Log
 .. _`PR #689`: https://github.com/desihub/desitarget/pull/689
 .. _`PR #690`: https://github.com/desihub/desitarget/pull/690
 .. _`PR #691`: https://github.com/desihub/desitarget/pull/691
+.. _`PR #693`: https://github.com/desihub/desitarget/pull/693
 
 0.53.0 (2021-03-18)
 -------------------

--- a/etc/desitarget.module
+++ b/etc/desitarget.module
@@ -86,3 +86,4 @@ setenv GAIA_DIR /global/cfs/cdirs/desi/target/gaia_dr2
 setenv URAT_DIR /global/cfs/cdirs/desi/target/urat_dr1
 setenv TYCHO_DIR /global/cfs/cdirs/desi/target/tycho_dr2
 setenv TOO_DIR /global/cfs/cdirs/desi/target/ToO
+setenv ZCAT_DIR /global/cfs/cdirs/desi/spectro/redux/daily

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -702,7 +702,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
     return ntargs, filename
 
 
-def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
+def write_mtl(mtldir, data, indir=None, survey="main", obscon=None, scnd=False,
               nsidefile=None, hpxlist=None, extra=None, ecsv=True, mixed=False):
     """Write Merged Target List ledgers or files.
 
@@ -719,6 +719,9 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
         Written to output file header as the keyword `SURVEY`.
     obscon : :class:`str`, optional
         Name of the `OBSCONDITIONS` used to make the file (e.g. DARK).
+    scnd : :class:`bool`, defaults to ``False``
+        If ``True`` then these are secondary targets. Write scnd=True to
+        the header and /secondary/ to the output directory structure.
     nsidefile : :class:`int`, optional
         Passed to indicate in the output file header that the targets
         have been limited to only certain HEALPixels at a given
@@ -746,7 +749,8 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
         The name of the file to which targets were written.
     """
     # ADM begin to construct a dictionary of header keys and values.
-    keys, vals = ["INDIR", "SURVEY", "OBSCON"], [indir, survey, obscon]
+    keys = ["INDIR", "SURVEY", "OBSCON", "SCND"]
+    vals = [indir, survey, obscon, scnd]
 
     # ADM hpxlist and nsidefile need to be passed together.
     if hpxlist is not None or nsidefile is not None:
@@ -765,8 +769,8 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
     # ADM determine the data release from a TARGETID.
     _, _, release, _, _, gaiadr = decode_targetid(data["TARGETID"])
 
-    # ADM if the mixed kwarg was sent, allow multiple data releases.
-    if mixed:
+    # ADM if the mixed or scnd kwargs were sent, allow multiple DRs.
+    if mixed or scnd:
         dr = np.atleast_1d(np.max(release//1000))
     else:
         dr = np.unique(release//1000)
@@ -793,10 +797,15 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None,
     if extra is not None:
         hdrdict = {**hdrdict, **extra}
 
+    # ADM resolve of None adds secondary to the output directory.
+    resolve=True
+    if scnd:
+        resolve=None
+
     # ADM set output format to ecsv if passed, or fits otherwise.
     form = 'ecsv'*ecsv + 'fits'*(not(ecsv))
     fn = find_target_files(mtldir, dr=drstring, flavor="mtl", survey=survey,
-                           obscon=obscon, hp=hpx, ender=form)
+                           resolve=resolve, obscon=obscon, hp=hpx, ender=form)
 
     ntargs = len(data)
     # ADM die if there are no targets to write.
@@ -2220,7 +2229,8 @@ def find_target_files(targdir, dr='X', flavor="targets", survey="main",
     resolve : :class:`bool`, optional, defaults to ``True``
         If ``True`` then find the `resolve` file. Otherwise find the
         `noresolve` file. Relevant if `flavor` is `targets` or `randoms`.
-        Pass ``None`` to substitute `resolve` with "secondary".
+        Pass ``None`` to substitute `resolve` with "secondary", which
+        also works if `flavor` is `mtl`.
     supp : :class:`bool`, optional, defaults to ``False``
         If ``True`` then find the supplemental/backup file. Overrides
         the `obscon` option.
@@ -2285,6 +2295,8 @@ def find_target_files(targdir, dr='X', flavor="targets", survey="main",
             res = "resolve"
     resdir = ""
     if flavor in ["targets", "randoms"]:
+        resdir = res
+    if flavor == "mtl" and resolve is None:
         resdir = res
     if isinstance(dr, int) or len(dr) == 1:
         drstr = "dr{}".format(dr)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -798,9 +798,9 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None, scnd=False,
         hdrdict = {**hdrdict, **extra}
 
     # ADM resolve of None adds secondary to the output directory.
-    resolve=True
+    resolve = True
     if scnd:
-        resolve=None
+        resolve = None
 
     # ADM set output format to ecsv if passed, or fits otherwise.
     form = 'ecsv'*ecsv + 'fits'*(not(ecsv))

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -353,7 +353,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
                                     dtype=mtldatamodel["SCND_TARGET"].dtype)
 
     # ADM initialize columns to avoid zero-length/missing/format errors.
-    zcols = ["NUMOBS_MORE", "NUMOBS", "Z", "ZWARN"]
+    zcols = ["NUMOBS_MORE", "NUMOBS", "Z", "ZWARN", "ZTILEID"]
     for col in zcols + ["TARGET_STATE", "TIMESTAMP", "VERSION"]:
         mtl[col] = np.empty(len(mtl), dtype=mtldatamodel[col].dtype)
 
@@ -374,7 +374,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
         mtl[col][zmatcher] = ztargets[col]
     # ADM also add the ZTILEID column, if passed, otherwise we're likely
     # ADM to be working with non-ledger-based mocks and can let it slide.
-    if "ZTILEID" in ztargets:
+    if "ZTILEID" in ztargets.dtype.names:
         mtl["ZTILEID"][zmatcher] = ztargets["ZTILEID"]
     else:
         mtl["ZTILEID"] = -1

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -555,7 +555,6 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK", numproc=1):
         misscols = set(neededcols) - set(cols)
         if len(misscols) > 0:
             # ADM the data type for the DESI_TARGET column.
-#            dtdt = mtldatamodel.dtype.fields["DESI_TARGET"][0].str
             dtdt = mtldatamodel["DESI_TARGET"].dtype
             zerod = [np.zeros(len(targs)), np.zeros(len(targs))]
             targs = rfn.append_fields(

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -41,7 +41,7 @@ mtldatamodel = np.array([], dtype=[
     ('SUBPRIORITY', '>f8'), ('OBSCONDITIONS', 'i4'),
     ('PRIORITY_INIT', '>i8'), ('NUMOBS_INIT', '>i8'), ('PRIORITY', '>i8'),
     ('NUMOBS', '>i8'), ('NUMOBS_MORE', '>i8'), ('Z', '>f8'), ('ZWARN', '>i8'),
-    ('TIMESTAMP', 'S19'), ('VERSION', 'S14'), ('TARGET_STATE', 'S16'),
+    ('TIMESTAMP', 'U19'), ('VERSION', 'U14'), ('TARGET_STATE', 'U16'),
     ('ZTILEID', '>i4')
     ])
 
@@ -51,8 +51,8 @@ zcatdatamodel = np.array([], dtype=[
     ])
 
 mtltilefiledm = np.array([], dtype=[
-    ('TILEID', '>i4'), ('TIMESTAMP', 'S19'),
-    ('VERSION', 'S14'), ('PROGRAM', 'S6')
+    ('TILEID', '>i4'), ('TIMESTAMP', 'U19'),
+    ('VERSION', 'U14'), ('PROGRAM', 'U6'), ('ZDATE', 'U8')
     ])
 
 
@@ -849,6 +849,8 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey):
     donetiles["VERSION"] = dt_version
     # ADM add the program/obscon.
     donetiles["PROGRAM"] = obscon
+    # ADM add a placeholder for the YYYYMMDD of tile redshifts.
+    donetiles["ZDATE"] = ""
 
     return donetiles
 
@@ -1002,7 +1004,9 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
 
     # ADM create the zcat: This will likely change, but for now let's
     # ADM just use redrock in the SV1-era format.
-    zcat = make_zcat_rr_backstop(zcatdir, tiles["TILEID"])
+    zcat, ymd = make_zcat_rr_backstop(zcatdir, tiles["TILEID"])
+    # ADM update the tiles table with the YYYYMMDD.
+    tiles["ZDATE"] = ymd
     # ADM insist that for an MTL loop with real observations, the zcat
     # ADM must conform to the data model. In particular, it must include
     # ADM ZTILEID, which may not be needed for non-ledger simulations.


### PR DESCRIPTION
This PR updates the MTL "loop" to adhere to the new directory structure for the spectroscopic pipeline. It includes:
- Functionality to make initial MTL ledgers for secondary targets.
- Use the new `ZTILE` file to look-up redshift "done-ness" (`zdone`) instead of relying on a "done" directory.
- Also derive the survey (`main/sv2`/etc.) and program/obscon (`DARK/BRIGHT/BACKUP`) from the new `ZTILE` file.
- Switch to reading the `zbest` files in the _cumulative_ directory.
- Remove negative `TARGETID`s before matching to ensure one-to-one matches.
- Add the `YYYYMMDD` date on which redshifts were extracted to the `mtl-done-tiles.ecsv` file.
- Add the root directory for looking up the redshift information (`ZCAT_DIR`) to the `etc/desitarget.module` file.
