### PR TITLE
Update the ELG selection for SV3

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,14 @@ desitarget Change Log
 0.54.1 (unreleased)
 -------------------
 
-* Update the LRG selection for SV3 (1% Survey):
+* Update the ELG selection for SV3 (1% Survey) [`PR #696`_]:
+    * Add functionality for low (LOP) and high (HIP) priority ELGs.
+* Update the LRG selection for SV3 (1% Survey) [`PR #694`_]:
     * Add fainter (and higher redshift) LRG targets
-    
+
+.. _`PR #694`: https://github.com/desihub/desitarget/pull/694
+.. _`PR #696`: https://github.com/desihub/desitarget/pull/696
+
 0.54.0 (2021-03-26)
 -------------------
 

--- a/py/desitarget/sv2/sv2_cuts.py
+++ b/py/desitarget/sv2/sv2_cuts.py
@@ -1840,7 +1840,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     - Gaia quantities have units as for `the Gaia data model`_.
     """
 
-    from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
+    from desitarget.sv2.sv2_targetmask import desi_mask, bgs_mask, mws_mask
 
     # ADM if resolvetargs is set, limit to only sending north/south objects
     # ADM through north/south cuts.

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -198,7 +198,7 @@ priorities:
 # ADM of 100 should only be higher than DONE (and secondary filler) targets.
         QSO: {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, MORE_MIDZQSO: 100, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         ELG_LOP: {UNOBS: 3000, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        ELG_HIP: {UNOBS: 3200, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        ELG_HIP: {UNOBS: 3100, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         # ADM don't prioritize a N/S target if it doesn't have other bits set
         LRG_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
         QSO_HIZ: SAME_AS_LRG_NORTH

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -52,7 +52,7 @@ sv3_desi_mask:
 sv3_bgs_mask:
     - [BGS_FAINT,           0, "BGS faint targets",                     {obsconditions: BRIGHT}]
     - [BGS_BRIGHT,          1, "BGS bright targets",                    {obsconditions: BRIGHT}]
-    - [BGS_WISE,            2, "BGS wise targets",                      {obsconditions: BRIGHT}]
+    - [BGS_WISE,            2, "BGS wise targets (AGN-like)",           {obsconditions: BRIGHT}]
     - [BGS_FAINT_HIP,       3, "BGS faint targets at bright priorty",   {obsconditions: BRIGHT}]
 
     #- BGS North vs. South selections

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -1,20 +1,28 @@
 #- sv3 primary survey targets bit mask: dark survey + calib +
 sv3_desi_mask:
     - [LRG,         0, "LRG", {obsconditions: DARK}]
-    - [ELG,         1, "ELG", {obsconditions: DARK|GRAY}]
+    - [ELG,         1, "ELG", {obsconditions: DARK}]
     - [QSO,         2, "QSO", {obsconditions: DARK}]
 
     #- ADM QSO sub-classes
     - [QSO_HIZ,     4, "QSO selected using high-redshift Random Forest (informational bit)", {obsconditions: DARK}]
 
-    #- North vs. South selections
-    - [LRG_NORTH,   8, "LRG cuts tuned for Bok/Mosaic data",  {obsconditions: DARK}]
-    - [ELG_NORTH,   9, "ELG cuts tuned for Bok/Mosaic data",  {obsconditions: DARK|GRAY}]
-    - [QSO_NORTH,   10, "QSO cuts tuned for Bok/Mosaic data", {obsconditions: DARK}]
+    # ADM ELG sub-classes
+    - [ELG_LOP,     5, "ELG at lower priority",  {obsconditions: DARK}]
+    - [ELG_HIP,     6, "ELG at higher priority", {obsconditions: DARK}]
 
-    - [LRG_SOUTH,   16, "LRG cuts tuned for DECam data",      {obsconditions: DARK}]
-    - [ELG_SOUTH,   17, "ELG cuts tuned for DECam data",      {obsconditions: DARK|GRAY}]
-    - [QSO_SOUTH,   18, "QSO cuts tuned for DECam data",      {obsconditions: DARK}]
+    #- North vs. South selections
+    - [LRG_NORTH,      8, "LRG cuts tuned for Bok/Mosaic data",               {obsconditions: DARK}]
+    - [ELG_NORTH,      9, "ELG cuts tuned for Bok/Mosaic data",               {obsconditions: DARK}]
+    - [QSO_NORTH,     10, "QSO cuts tuned for Bok/Mosaic data",               {obsconditions: DARK}]
+    - [ELG_LOP_NORTH, 11, "ELG at lower priority tuned for Bok/Mosaic data",  {obsconditions: DARK}]
+    - [ELG_HIP_NORTH, 12, "ELG at higher priority tuned for Bok/Mosaic data", {obsconditions: DARK}]
+
+    - [LRG_SOUTH,     16, "LRG cuts tuned for DECam data",                    {obsconditions: DARK}]
+    - [ELG_SOUTH,     17, "ELG cuts tuned for DECam data",                    {obsconditions: DARK}]
+    - [QSO_SOUTH,     18, "QSO cuts tuned for DECam data",                    {obsconditions: DARK}]
+    - [ELG_LOP_SOUTH, 19, "ELG at lower priority tuned for DECam data",       {obsconditions: DARK}]
+    - [ELG_HIP_SOUTH, 20, "ELG at higher priority tuned for DECam data",      {obsconditions: DARK}]
 
     #- Calibration targets
     - [SKY,         32, "Blank sky locations",
@@ -189,14 +197,20 @@ priorities:
 # ADM and Weiner et al. (0.7 < z < 2.1) to reobserve confirmed quasars where possible. The priority
 # ADM of 100 should only be higher than DONE (and secondary filler) targets.
         QSO: {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, MORE_MIDZQSO: 100, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        ELG_LOP: {UNOBS: 3000, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        ELG_HIP: {UNOBS: 3200, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         # ADM don't prioritize a N/S target if it doesn't have other bits set
         LRG_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
         QSO_HIZ: SAME_AS_LRG_NORTH
         ELG_NORTH: SAME_AS_LRG_NORTH
         QSO_NORTH: SAME_AS_LRG_NORTH
+        ELG_LOP_NORTH: SAME_AS_LRG_NORTH
+        ELG_HIP_NORTH: SAME_AS_LRG_NORTH
         LRG_SOUTH: SAME_AS_LRG_NORTH
         ELG_SOUTH: SAME_AS_LRG_NORTH
         QSO_SOUTH: SAME_AS_LRG_NORTH
+        ELG_LOP_SOUTH: SAME_AS_LRG_NORTH
+        ELG_HIP_SOUTH: SAME_AS_LRG_NORTH
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FAINT:  -1
@@ -300,13 +314,19 @@ numobs:
         ELG: 1
         LRG: 1
         QSO: 4
+        ELG_LOP: 1
+        ELG_HIP: 1
         # ADM don't observe a N/S target if it doesn't have other bits set
         LRG_NORTH: 0
         ELG_NORTH: 0
         QSO_NORTH: 0
+        ELG_LOP_NORTH: 0
+        ELG_HIP_NORTH: 0
         LRG_SOUTH: 0
         ELG_SOUTH: 0
         QSO_SOUTH: 0
+        ELG_LOP_SOUTH: 0
+        ELG_HIP_SOUTH: 0
         BAD_SKY: 0
         #- Standards and sky are treated specially; NUMOBS doesn't apply
         STD_FAINT:  -1

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -423,8 +423,9 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
 
-    nomask = notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
-                         gnobs=gnobs, rnobs=rnobs, znobs=znobs, primary=primary)
+    nomask = notinELG_mask(
+        maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+        gnobs=gnobs, rnobs=rnobs, znobs=znobs, primary=primary)
 
     elglop, elghip = isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux,
                                   w1flux=w1flux, w2flux=w2flux,

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -294,7 +294,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (03/20/21) is version 1 on `the SV3 wiki`_.
+    - Current version (03/27/21) is version 8 on `the SV3 wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # ADM LRG targets.
@@ -418,7 +418,7 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     (see :func:`~desitarget.cuts.set_target_bits` for parameters).
 
     Notes:
-    - Current version (03/20/21) is version 1 on `the SV3 wiki`_.
+    - Current version (03/27/21) is version 8 on `the SV3 wiki`_.
     """
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
@@ -1452,7 +1452,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
 
     Notes
     -----
-    - Current version (03/20/21) is version 1 on `the SV3 wiki`_.
+    - Current version (03/27/21) is version 8 on `the SV3 wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # ADM Primary (True for anything to initially consider as a possible target).

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -422,16 +422,16 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
     """
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
-    elg = primary.copy()
 
-    elg &= notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
+    nomask = notinELG_mask(maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
                          gnobs=gnobs, rnobs=rnobs, znobs=znobs, primary=primary)
 
-    elg &= isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
-                        w2flux=w2flux, gfiberflux=gfiberflux, south=south,
-                        primary=primary)
+    elglop, elghip = isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux,
+                                  w1flux=w1flux, w2flux=w2flux,
+                                  gfiberflux=gfiberflux, south=south,
+                                  primary=primary)
 
-    return elg
+    return elglop & nomask, elghip & nomask
 
 
 def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None,
@@ -475,7 +475,6 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
     elg &= g > 20                       # bright cut.
     elg &= r - z > 0.15                  # blue cut.
 #    elg &= r - z < 1.6                  # red cut.
-    elg &= g - r < -1.2*(r - z) + 1.6   # OII flux cut.
 
     # ADM cuts that are unique to the north or south. Identical for sv3
     # ADM but keep the north/south formalism in case we use it for sv3.
@@ -486,7 +485,17 @@ def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
         elg &= gfib < 24.1  # faint cut.
         elg &= g - r < 0.5*(r - z) + 0.1  # remove stars and low-z galaxies.
 
-    return elg
+    # ADM separate a high-priority and a regular (low-priority) sample.
+    elghip = elg.copy()
+
+    # ADM low-priority OII flux cut.
+    elg &= g - r < -1.2*(r - z) + 1.6
+    elg &= g - r >= -1.2*(r - z) + 1.3
+
+    # ADM high-priority OII flux cut.
+    elghip &= g - r < -1.2*(r - z) + 1.3
+
+    return elg, elghip
 
 
 def isSTD_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
@@ -1847,8 +1856,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     -----
     - Gaia quantities have units as for `the Gaia data model`_.
     """
-
-    from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
+    from desitarget.sv3.sv3_targetmask import desi_mask, bgs_mask, mws_mask
 
     # ADM if resolvetargs is set, limit to only sending north/south objects
     # ADM through north/south cuts.
@@ -1880,7 +1888,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # ADM initially set everything to arrays of False for the ELG selection
     # ADM the zeroth element stores the northern targets bits (south=False).
-    elg_classes = [tcfalse, tcfalse]
+    elg_classes = [[tcfalse, tcfalse], [tcfalse, tcfalse]]
     if "ELG" in tcnames:
         for south in south_cuts:
             elg_classes[int(south)] = isELG(
@@ -1889,10 +1897,15 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 gnobs=gnobs, rnobs=rnobs, znobs=znobs, maskbits=maskbits,
                 south=south
             )
-    elg_north, elg_south = elg_classes
+    elg_lop_north, elg_hip_north = elg_classes[0]
+    elg_lop_south, elg_hip_south = elg_classes[1]
 
     # ADM combine ELG target bits for an ELG target based on any imaging.
-    elg = (elg_north & photsys_north) | (elg_south & photsys_south)
+    elg_lop = (elg_lop_north & photsys_north) | (elg_lop_south & photsys_south)
+    elg_hip = (elg_hip_north & photsys_north) | (elg_hip_south & photsys_south)
+    elg_north = elg_lop_north | elg_hip_north
+    elg_south = elg_lop_south | elg_hip_south
+    elg = elg_lop | elg_hip
 
     # ADM initially set everything to arrays of False for the QSO selection
     # ADM the zeroth element stores the northern targets bits (south=False).
@@ -2056,16 +2069,22 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # Construct the targetflag bits for DECaLS (i.e. South).
     desi_target = lrg_south * desi_mask.LRG_SOUTH
     desi_target |= elg_south * desi_mask.ELG_SOUTH
+    desi_target |= elg_lop_south * desi_mask.ELG_LOP_SOUTH
+    desi_target |= elg_hip_south * desi_mask.ELG_HIP_SOUTH
     desi_target |= qso_south * desi_mask.QSO_SOUTH
 
     # Construct the targetflag bits for MzLS and BASS (i.e. North).
     desi_target |= lrg_north * desi_mask.LRG_NORTH
     desi_target |= elg_north * desi_mask.ELG_NORTH
+    desi_target |= elg_lop_north * desi_mask.ELG_LOP_NORTH
+    desi_target |= elg_hip_north * desi_mask.ELG_HIP_NORTH
     desi_target |= qso_north * desi_mask.QSO_NORTH
 
     # Construct the targetflag bits combining north and south.
     desi_target |= lrg * desi_mask.LRG
     desi_target |= elg * desi_mask.ELG
+    desi_target |= elg_lop * desi_mask.ELG_LOP
+    desi_target |= elg_hip * desi_mask.ELG_HIP
     desi_target |= qso * desi_mask.QSO
     desi_target |= qsohiz * desi_mask.QSO_HIZ
 


### PR DESCRIPTION
This PR updates the ELG selection for SV3 (i.e. the 1% survey). In particular, it adds two classes of ELGs, a low-priority class and a high-priority class.