### PR TITLE
Implement z-band fiber-total-magnitude bright cut for LRGs

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ desitarget Change Log
 
 * Update the LRG selection for SV3 (The 1% Survey) [`PR #699`_]:
     * Replace the zfiber>16 cut with a zfibertot>16 cut to reject shredded bright stars.
+.. _`PR #699`: https://github.com/desihub/desitarget/pull/699
 
 0.55.0 (2021-03-29)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ desitarget Change Log
 
 * Update the LRG selection for SV3 (The 1% Survey) [`PR #699`_]:
     * Replace the zfiber>16 cut with a zfibertot>16 cut to reject shredded bright stars.
+
 .. _`PR #699`: https://github.com/desihub/desitarget/pull/699
 
 0.55.0 (2021-03-29)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.55.1 (unreleased)
 -------------------
 
-* Update the LRG selection for SV3 (The 1% Survey) [`PR #694`_]:
+* Update the LRG selection for SV3 (The 1% Survey) [`PR #699`_]:
     * Replace the zfiber>16 cut with a zfibertot>16 cut to reject shredded bright stars.
 
 0.55.0 (2021-03-29)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desitarget Change Log
 0.55.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Update the LRG selection for SV3 (The 1% Survey) [`PR #694`_]:
+    * Replace the zfiber>16 cut with a zfibertot>16 cut to reject shredded bright stars.
 
 0.55.0 (2021-03-29)
 -------------------

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -278,7 +278,7 @@ def isBACKUP(ra=None, dec=None, gaiagmag=None, primary=None):
 def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
           zfiberflux=None, rfluxivar=None, zfluxivar=None, w1fluxivar=None,
           gaiagmag=None, gnobs=None, rnobs=None, znobs=None, maskbits=None,
-          primary=None, south=True):
+          zfibertotflux=None, primary=None, south=True):
     """
     Parameters
     ----------
@@ -307,7 +307,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         primary=primary, rflux=rflux, zflux=zflux, w1flux=w1flux,
         zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
         rfluxivar=rfluxivar, zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
-        gaiagmag=gaiagmag, maskbits=maskbits
+        gaiagmag=gaiagmag, maskbits=maskbits, zfibertotflux=zfibertotflux
     )
 
     # ADM color-based selection of LRGs.
@@ -322,7 +322,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
                   zfiberflux=None, gnobs=None, rnobs=None, znobs=None,
                   rfluxivar=None, zfluxivar=None, w1fluxivar=None,
-                  gaiagmag=None, maskbits=None):
+                  gaiagmag=None, maskbits=None, zfibertotflux=None):
     """See :func:`~desitarget.cuts.isLRG` for details.
 
     Returns
@@ -346,7 +346,7 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
     lrg &= (gaiagmag == 0) | (gaiagmag > 18)  # remove bright GAIA sources
 
     # remove bright stars with zfiber<16 that are missing from GAIA
-    lrg &= zfiberflux < 10**(-0.4*(16-22.5))
+    lrg &= zfibertotflux < 10**(-0.4*(16-22.5))
 
     # ADM observed in every band.
     lrg &= (gnobs > 0) & (rnobs > 0) & (znobs > 0)
@@ -1992,7 +1992,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
                 zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                 rfluxivar=rfluxivar, zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
-                gaiagmag=gaiagmag, maskbits=maskbits, south=south
+                gaiagmag=gaiagmag, zfibertotflux=zfibertotflux,
+                maskbits=maskbits, south=south
             )
     lrg_north, lrg_south = lrg_classes
 


### PR DESCRIPTION
This PR replaces the FIBERFLUX_Z bright cut with a FIBERTOTFLUX_Z bright cut to reject shredded bright stars.