### PR TITLE
Some bug fixes for SV3.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,15 @@ desitarget Change Log
 0.55.1 (unreleased)
 -------------------
 
+* Some bug fixes for SV3 [`PR #700`_]. Includes:
+    * Turn on the ``BGS_WISE`` bit, which had been deprecated.
+    * Correct behavior for ``ELG_HIP`` when making MTLs.
+        * Also change ``ELG_LOP`` to just ``ELG`` for simplicity.
 * Update the LRG selection for SV3 (The 1% Survey) [`PR #699`_]:
-    * Replace the zfiber>16 cut with a zfibertot>16 cut to reject shredded bright stars.
+    * Replace zfiber>16 with zfibertot>16 to reject bright star shreds.
 
 .. _`PR #699`: https://github.com/desihub/desitarget/pull/699
+.. _`PR #700`: https://github.com/desihub/desitarget/pull/700
 
 0.55.0 (2021-03-29)
 -------------------

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -8,6 +8,7 @@ sv3_desi_mask:
     - [QSO_HIZ,     4, "QSO selected using high-redshift Random Forest (informational bit)", {obsconditions: DARK}]
 
     # ADM ELG sub-classes
+    # ADM ELG_LOP was deprecated early in SV3. We just use "ELG" for the low-priority ELGs.
     - [ELG_LOP,     5, "ELG at lower priority",  {obsconditions: DARK}]
     - [ELG_HIP,     6, "ELG at higher priority", {obsconditions: DARK}]
 

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -2209,20 +2209,20 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     bgs_target = bgs_bright_south * bgs_mask.BGS_BRIGHT_SOUTH
     bgs_target |= bgs_faint_south * bgs_mask.BGS_FAINT_SOUTH
     # ADM turn off BGS_WISE until we're sure we'll use it.
-    # bgs_target |= bgs_wise_south * bgs_mask.BGS_WISE_SOUTH
+    bgs_target |= bgs_wise_south * bgs_mask.BGS_WISE_SOUTH
 
     # BGS targets, north.
     bgs_target |= bgs_bright_north * bgs_mask.BGS_BRIGHT_NORTH
     bgs_target |= bgs_faint_north * bgs_mask.BGS_FAINT_NORTH
     # ADM turn off BGS_WISE until we're sure we'll use it.
-    # bgs_target |= bgs_wise_north * bgs_mask.BGS_WISE_NORTH
+    bgs_target |= bgs_wise_north * bgs_mask.BGS_WISE_NORTH
 
     # BGS targets, combined.
     bgs_target |= bgs_bright * bgs_mask.BGS_BRIGHT
     bgs_target |= bgs_faint * bgs_mask.BGS_FAINT
     # ADM turn off BGS_WISE until we're sure we'll use it.
-    # bgs_target |= bgs_wise * bgs_mask.BGS_WISE
-    # ADM set 10% of the BGS_FAINT targets to BGS_FAINT_HIP.
+    bgs_target |= bgs_wise * bgs_mask.BGS_WISE
+    # ADM set a fraction of the BGS_FAINT targets to BGS_FAINT_HIP.
     if hip is not None:
         if hip is True:
             bgs_target |= bgs_mask.BGS_FAINT_HIP

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -427,12 +427,12 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
         gnobs=gnobs, rnobs=rnobs, znobs=znobs, primary=primary)
 
-    elglop, elghip = isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux,
-                                  w1flux=w1flux, w2flux=w2flux,
-                                  gfiberflux=gfiberflux, south=south,
-                                  primary=primary)
+    elg, elghip = isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux,
+                               w1flux=w1flux, w2flux=w2flux,
+                               gfiberflux=gfiberflux, south=south,
+                               primary=primary)
 
-    return elglop & nomask, elghip & nomask
+    return elg & nomask, elghip & nomask
 
 
 def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None,
@@ -2011,15 +2011,12 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 gnobs=gnobs, rnobs=rnobs, znobs=znobs, maskbits=maskbits,
                 south=south
             )
-    elg_lop_north, elg_hip_north = elg_classes[0]
-    elg_lop_south, elg_hip_south = elg_classes[1]
+    elg_north, elg_hip_north = elg_classes[0]
+    elg_south, elg_hip_south = elg_classes[1]
 
     # ADM combine ELG target bits for an ELG target based on any imaging.
-    elg_lop = (elg_lop_north & photsys_north) | (elg_lop_south & photsys_south)
+    elg = (elg_north & photsys_north) | (elg_south & photsys_south)
     elg_hip = (elg_hip_north & photsys_north) | (elg_hip_south & photsys_south)
-    elg_north = elg_lop_north | elg_hip_north
-    elg_south = elg_lop_south | elg_hip_south
-    elg = elg_lop | elg_hip
 
     # ADM initially set everything to arrays of False for the QSO selection
     # ADM the zeroth element stores the northern targets bits (south=False).
@@ -2181,21 +2178,18 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # Construct the targetflag bits for DECaLS (i.e. South).
     desi_target = lrg_south * desi_mask.LRG_SOUTH
     desi_target |= elg_south * desi_mask.ELG_SOUTH
-    desi_target |= elg_lop_south * desi_mask.ELG_LOP_SOUTH
     desi_target |= elg_hip_south * desi_mask.ELG_HIP_SOUTH
     desi_target |= qso_south * desi_mask.QSO_SOUTH
 
     # Construct the targetflag bits for MzLS and BASS (i.e. North).
     desi_target |= lrg_north * desi_mask.LRG_NORTH
     desi_target |= elg_north * desi_mask.ELG_NORTH
-    desi_target |= elg_lop_north * desi_mask.ELG_LOP_NORTH
     desi_target |= elg_hip_north * desi_mask.ELG_HIP_NORTH
     desi_target |= qso_north * desi_mask.QSO_NORTH
 
     # Construct the targetflag bits combining north and south.
     desi_target |= lrg * desi_mask.LRG
     desi_target |= elg * desi_mask.ELG
-    desi_target |= elg_lop * desi_mask.ELG_LOP
     desi_target |= elg_hip * desi_mask.ELG_HIP
     desi_target |= qso * desi_mask.QSO
     desi_target |= qsohiz * desi_mask.QSO_HIZ

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -622,8 +622,10 @@ def calc_priority(targets, zcat, obscon, state=False):
             # ADM 'LRG' is the guiding column in SV and the main survey
             # ADM (once, it was 'LRG_1PASS' and 'LRG_2PASS' in the MS).
             # names = ('ELG', 'LRG_1PASS', 'LRG_2PASS')
-            # if survey[0:2] == 'sv':
             names = ('ELG', 'LRG')
+            # ADM for sv3 the ELG guiding columns are ELG and ELG_HIP.
+            if survey == 'sv3':
+                names = ('ELG', 'ELG_HIP', 'LRG')
             for name in names:
                 # ADM only update priorities for passed observing conditions.
                 pricon = obsconditions.mask(desi_mask[name].obsconditions)


### PR DESCRIPTION
This PR fixes some bugs for SV3:

- The `BGS_WISE` bit had been turned off for a while. When we redefined the `BGS_WISE` selection to mean "AGN-like" targets, we didn't turn the `BGS_WISE` bit back on, so there were no `BGS_WISE` targets in the target files. `BGS_WISE` is turned on for `sv3` in this PR.
- The MTL decisions were still being driven by the `ELG` bit, meaning that `ELG_HIP` had zero effect on priorities after one run through MTL. The `make_mtl()` code will now understand the `ELG_HIP` bit for `sv3`.
  * To help fix this and to simplify bit-definitions, I've redefined `ELG` to mean "low-priority ELGs" and retained `ELG_HIP` to mean "high-priority ELGs". Previously I'd decided to use `ELG` to mean "either `ELG_LOP` or `ELG_HIP` (i.e. `ELG_LOP | ELG_HIP`). The `ELG_LOP` bit still exists, it just won't be turned on.