### PR TITLE
Revert ELG_LOP back to being its own target class for SV3

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 0.55.1 (unreleased)
 -------------------
 
+* Revert ``ELG_LOP`` back to being its own target class [`PR #701`_].
+    * But maintain the correct behavior for ``ELG_HIP`` when making MTLs.
 * Some bug fixes for SV3 [`PR #700`_]. Includes:
     * Turn on the ``BGS_WISE`` bit, which had been deprecated.
     * Correct behavior for ``ELG_HIP`` when making MTLs.
@@ -14,6 +16,7 @@ desitarget Change Log
 
 .. _`PR #699`: https://github.com/desihub/desitarget/pull/699
 .. _`PR #700`: https://github.com/desihub/desitarget/pull/700
+.. _`PR #701`: https://github.com/desihub/desitarget/pull/701
 
 0.55.0 (2021-03-29)
 -------------------

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -427,12 +427,12 @@ def isELG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         maskbits=maskbits, gsnr=gsnr, rsnr=rsnr, zsnr=zsnr,
         gnobs=gnobs, rnobs=rnobs, znobs=znobs, primary=primary)
 
-    elg, elghip = isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux,
-                               w1flux=w1flux, w2flux=w2flux,
-                               gfiberflux=gfiberflux, south=south,
-                               primary=primary)
+    elglop, elghip = isELG_colors(gflux=gflux, rflux=rflux, zflux=zflux,
+                                  w1flux=w1flux, w2flux=w2flux,
+                                  gfiberflux=gfiberflux, south=south,
+                                  primary=primary)
 
-    return elg & nomask, elghip & nomask
+    return elglop & nomask, elghip & nomask
 
 
 def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None,
@@ -2011,12 +2011,15 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 gnobs=gnobs, rnobs=rnobs, znobs=znobs, maskbits=maskbits,
                 south=south
             )
-    elg_north, elg_hip_north = elg_classes[0]
-    elg_south, elg_hip_south = elg_classes[1]
+    elg_lop_north, elg_hip_north = elg_classes[0]
+    elg_lop_south, elg_hip_south = elg_classes[1]
 
     # ADM combine ELG target bits for an ELG target based on any imaging.
-    elg = (elg_north & photsys_north) | (elg_south & photsys_south)
+    elg_lop = (elg_lop_north & photsys_north) | (elg_lop_south & photsys_south)
     elg_hip = (elg_hip_north & photsys_north) | (elg_hip_south & photsys_south)
+    elg_north = elg_lop_north | elg_hip_north
+    elg_south = elg_lop_south | elg_hip_south
+    elg = elg_lop | elg_hip
 
     # ADM initially set everything to arrays of False for the QSO selection
     # ADM the zeroth element stores the northern targets bits (south=False).
@@ -2178,18 +2181,21 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # Construct the targetflag bits for DECaLS (i.e. South).
     desi_target = lrg_south * desi_mask.LRG_SOUTH
     desi_target |= elg_south * desi_mask.ELG_SOUTH
+    desi_target |= elg_lop_south * desi_mask.ELG_LOP_SOUTH
     desi_target |= elg_hip_south * desi_mask.ELG_HIP_SOUTH
     desi_target |= qso_south * desi_mask.QSO_SOUTH
 
     # Construct the targetflag bits for MzLS and BASS (i.e. North).
     desi_target |= lrg_north * desi_mask.LRG_NORTH
     desi_target |= elg_north * desi_mask.ELG_NORTH
+    desi_target |= elg_lop_north * desi_mask.ELG_LOP_NORTH
     desi_target |= elg_hip_north * desi_mask.ELG_HIP_NORTH
     desi_target |= qso_north * desi_mask.QSO_NORTH
 
     # Construct the targetflag bits combining north and south.
     desi_target |= lrg * desi_mask.LRG
     desi_target |= elg * desi_mask.ELG
+    desi_target |= elg_lop * desi_mask.ELG_LOP
     desi_target |= elg_hip * desi_mask.ELG_HIP
     desi_target |= qso * desi_mask.QSO
     desi_target |= qsohiz * desi_mask.QSO_HIZ

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -625,7 +625,7 @@ def calc_priority(targets, zcat, obscon, state=False):
             names = ('ELG', 'LRG')
             # ADM for sv3 the ELG guiding columns are ELG and ELG_HIP.
             if survey == 'sv3':
-                names = ('ELG', 'ELG_HIP', 'LRG')
+                names = ('ELG_LOP', 'ELG_HIP', 'LRG')
             for name in names:
                 # ADM only update priorities for passed observing conditions.
                 pricon = obsconditions.mask(desi_mask[name].obsconditions)


### PR DESCRIPTION
@djschlegel and @araichoor pointed out that it was probably a bad idea to change the meaning of the ``ELG`` bit, as I did in #700. So, this PR reverts back to the old meanings for the ELGs. To be clear, as of now (and forevermore for the purposes of `sv3`):

- The bit `ELG_LOP` means a low-priority ELG.
- The bit `ELG_HIP` means a high-priority ELG.
- The bit `ELG` means either a low-priority ELG or a high-priority ELG (`ELG` is `ELG_LOP | ELG_HIP`).

To ensure the correct prioritization behavior, the MTL code (for `sv3`) now utilizes `ELG_LOP` and `ELG_HIP` and ignores `ELG` completely.

I'll run replacement targeting files soon and email desi-targets indicating the location of the new files.