### PR TITLE
Update the MTL loop to work for secondary ledgers for sv3.

### DIFF
--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -25,8 +25,11 @@ ap.add_argument('--mtldir',
                 Default is to use the $ZCAT_DIR environment variable",
                 default=None)
 ap.add_argument("-n", "--numobsfromzcat", action='store_true',
-                help="If passed, the zcat includes a meaningfule NUMOBS.        \
+                help="If passed, the zcat includes a meaningful NUMOBS.         \
                 Otherwise, NUMOBS is looked up from the ledger itself")
+ap.add_argument("-sec", "--secondary", action='store_true',
+                help="If passed, process the ledger of secondary targets        \
+                instead of the primaries")
 
 ns = ap.parse_args()
 
@@ -34,7 +37,7 @@ numobs_from_ledger = not(ns.numobsfromzcat)
 
 hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
     ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
-    numobs_from_ledger=numobs_from_ledger)
+    numobs_from_ledger=numobs_from_ledger, secondary=ns.secondary)
 
 log.info("MTL ledger directory: {}".format(hpdirname))
 log.info("MTL tile file: {}".format(mtltilefn))

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -27,17 +27,24 @@ ap.add_argument('--mtldir',
 ap.add_argument("-n", "--numobsfromzcat", action='store_true',
                 help="If passed, the zcat includes a meaningful NUMOBS.         \
                 Otherwise, NUMOBS is looked up from the ledger itself")
-ap.add_argument("-sec", "--secondary", action='store_true',
-                help="If passed, process the ledger of secondary targets        \
-                instead of the primaries")
+ap.add_argument("-nosec", "--nosecondary", action='store_true',
+                help="By default, we always process the ledger of secondaries   \
+                in addition to the primaries so they keep pace. Pass this if    \
+                there are no secondaries to process")
 
 ns = ap.parse_args()
 
 numobs_from_ledger = not(ns.numobsfromzcat)
 
+# ADM if nosecondary wasn't passed, also process the secondary ledger.
+if not(ns.nosecondary):
+    hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
+        ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
+        numobs_from_ledger=numobs_from_ledger, secondary=True)
+
 hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
     ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
-    numobs_from_ledger=numobs_from_ledger, secondary=ns.secondary)
+    numobs_from_ledger=numobs_from_ledger, secondary=False)
 
 log.info("MTL ledger directory: {}".format(hpdirname))
 log.info("MTL tile file: {}".format(mtltilefn))

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -36,17 +36,17 @@ ns = ap.parse_args()
 
 numobs_from_ledger = not(ns.numobsfromzcat)
 
+scndstates = [False]
 # ADM if nosecondary wasn't passed, also process the secondary ledger.
 if not(ns.nosecondary):
+    scndstates = [True, False]
+
+for secondary in scndstates:
     hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
         ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
-        numobs_from_ledger=numobs_from_ledger, secondary=True)
+        numobs_from_ledger=numobs_from_ledger, secondary=secondary)
 
-hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
-    ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
-    numobs_from_ledger=numobs_from_ledger, secondary=False)
-
-log.info("MTL ledger directory: {}".format(hpdirname))
-log.info("MTL tile file: {}".format(mtltilefn))
-log.info("Redshift tile file: {}".format(tilefn))
-log.info("Processed {} new tiles, which are: {}".format(len(tiles), tiles))
+    log.info("MTL ledger directory: {}".format(hpdirname))
+    log.info("MTL tile file: {}".format(mtltilefn))
+    log.info("Redshift tile file: {}".format(tilefn))
+    log.info("Processed {} new tiles, which are: {}".format(len(tiles), tiles))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,14 +5,15 @@ desitarget Change Log
 0.55.1 (unreleased)
 -------------------
 
-* Update the MTL loop to work for secondary ledgers for sv3 [`PR #701`_]:
-    * Tile file to check secondary processing keeps pace with primaries.
+* Update the MTL loop to work for secondary ledgers for sv3 [`PR #702`_]:
+    * Add tile file to check secondary processing tracks with primaries.
         * called ``scnd-mtl-done-tiles.ecsv``.
-    * Default to running secondary ledgers when the primaries are run.
+    * Default to running secondary ledgers whenever primaries are run.
         * i.e. specifically in the ``run_mtl_loop`` script.
-    * Catch some special cases in setting ``NUMOBS`` for secondaries.
-    * Set ``NUMOBS`` to sensible numbers for secondary targets.
-        * philosophically, they'll drop to the ``DONE`` priority.
+    * Catch some special cases for secondaries.
+        * e.g. secondary QSOs should update like primary QSOs.
+    * Set ``NUMOBS`` to more sensible numbers for secondary targets.
+        * let ``NUMOBS`` drop to zero and ``PRIORITY`` drop to ``DONE``.
 * Some bug fixes for SV3 [`PR #700`_]. Includes:
     * Turn on the ``BGS_WISE`` bit, which had been deprecated.
     * Correct behavior for ``ELG_HIP`` when making MTLs.
@@ -22,7 +23,7 @@ desitarget Change Log
 
 .. _`PR #699`: https://github.com/desihub/desitarget/pull/699
 .. _`PR #700`: https://github.com/desihub/desitarget/pull/700
-.. _`PR #701`: https://github.com/desihub/desitarget/pull/701
+.. _`PR #702`: https://github.com/desihub/desitarget/pull/702
 
 0.55.0 (2021-03-29)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,12 @@ desitarget Change Log
 0.55.1 (unreleased)
 -------------------
 
+* Update the MTL loop to work for secondary ledgers for sv3 [`PR #701`_]:
+    * Tile file to check secondary processing keeps pace with primaries.
+        * called ``scnd-mtl-done-tiles.ecsv``.
+    * Default to running secondary ledgers when the primaries are run.
+        * i.e. specifically in the ``run_mtl_loop`` script.
+    * Catch some special cases in setting ``NUMOBS`` for secondaries.
 * Some bug fixes for SV3 [`PR #700`_]. Includes:
     * Turn on the ``BGS_WISE`` bit, which had been deprecated.
     * Correct behavior for ``ELG_HIP`` when making MTLs.
@@ -14,6 +20,7 @@ desitarget Change Log
 
 .. _`PR #699`: https://github.com/desihub/desitarget/pull/699
 .. _`PR #700`: https://github.com/desihub/desitarget/pull/700
+.. _`PR #701`: https://github.com/desihub/desitarget/pull/701
 
 0.55.0 (2021-03-29)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,6 +11,8 @@ desitarget Change Log
     * Default to running secondary ledgers when the primaries are run.
         * i.e. specifically in the ``run_mtl_loop`` script.
     * Catch some special cases in setting ``NUMOBS`` for secondaries.
+    * Set ``NUMOBS`` to sensible numbers for secondary targets.
+        * philosophically, they'll drop to the ``DONE`` priority.
 * Some bug fixes for SV3 [`PR #700`_]. Includes:
     * Turn on the ``BGS_WISE`` bit, which had been deprecated.
     * Correct behavior for ``ELG_HIP`` when making MTLs.

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -119,10 +119,10 @@ mws_mask:
 #- ADM directory that corresponds to the $SECONDARY_DIR environment
 #- ADM variable, e.g. $SECONDARY_DIR/veto.fits for VETO targets.
 scnd_mask:
-    - [VETO,        0, "Never observe, even if a primary target bit is set",
-       {obsconditions: DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18, filename: 'veto', downsample: 1}]
+    - [VETO,                    0, "Never observe, even if a primary target bit is set",
+        {obsconditions: DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18, filename: 'veto', flavor: 'SPARE', downsample: 1}]
     - [DR16Q,       1, "Known quasars from the SDSS DR16Q catalog",
-       {obsconditions: DARK|GRAY, filename: 'dr16q', downsample: 1}]
+       {obsconditions: DARK|GRAY, filename: 'dr16q', flavor: 'SPARE', downsample: 1}]
 
 # ADM reserve 59-62 in scnd_mask for Targets of Opportunity in both SV and the Main Survey.
     - [BRIGHT_TOO_LOP,    59, "Targets of Opportunity from rolling ledger",   {obsconditions: BRIGHT|DARK, flavor: 'TOO'}]

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2141,7 +2141,14 @@ def check_hp_target_dir(hpdirname):
     pixdict = {}
     for fn in fns:
         hdr = read_targets_header(fn)
-        nside.append(hdr["FILENSID"])
+        # ADM if there's no directory structure, maybe a file was meant.
+        try:
+            nside.append(hdr["FILENSID"])
+        except KeyError:
+            msg = "You passed a directory containing {}.".format(fns)
+            msg += "Perhaps you meant to pass a file instead?"
+            log.error(msg)
+            raise KeyError
         pixels = hdr["FILEHPX"]
         # ADM hdr["FILEHPX"] could be a str, depending on fitsio version.
         if isinstance(pixels, str):

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -131,8 +131,14 @@ def get_zcat_dir(zcatdir=None):
     return zcatdir
 
 
-def get_mtl_tile_file_name():
+def get_mtl_tile_file_name(secondary=False):
     """Convenience function to grab the name of the MTL tile file.
+
+    Parameters
+    ----------
+    secondary : :class:`bool`, optional, defaults to ``False``
+        If ``True`` return the name of the MTL tile file for secondary
+        targets instead of the standard, primary MTL tile file.
 
     Returns
     -------
@@ -140,6 +146,8 @@ def get_mtl_tile_file_name():
         The name of the MTL tile file.
     """
     fn = "mtl-done-tiles.ecsv"
+    if secondary:
+        fn = "scnd-mtl-done-tiles.ecsv"
 
     return fn
 
@@ -916,6 +924,16 @@ def make_zcat_rr_backstop(zcatdir, tiles):
     zs = zs[zs["TARGETID"] >= 0]
     fms = fms[fms["TARGETID"] >= 0]
 
+    # ADM check the TARGETIDs are unique. If they aren't the likely
+    # ADM explanation is that overlapping tiles (which could include
+    # ADM duplicate targets) are being processed.
+    if len(zs) != len(set(zs["TARGETID"])):
+        msg = "a target is duplicated!!! You are likely trying to process "
+        msg += "overlapping tiles when one of these tiles should already have "
+        msg += "been processed and locked in mtl-done-tiles.ecsv"
+        log.critical(msg)
+        raise ValueError(msg)
+
     # ADM currently, the spectroscopic files aren't coadds, so aren't
     # ADM unique. We therefore need to look up (any) coordinates for
     # ADM each z in the fibermap.
@@ -985,14 +1003,18 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     # ADM grab the MTL directory (in case we're relying on $MTL_DIR).
     mtldir = get_mtl_dir(mtldir)
     # ADM construct the full path to the mtl tile file.
-    mtltilefn = os.path.join(mtldir, get_mtl_tile_file_name())
+    mtltilefn = os.path.join(mtldir, get_mtl_tile_file_name(secondary=secondary))
 
     # ADM construct the relevant sub-directory for this survey and
     # ADM set of observing conditions..
     form = get_mtl_ledger_format()
     resolve = True
+    msg = "running on {} ledger with obscon={} and survey={}"
     if secondary:
+        log.info(msg.format("SECONDARY", obscon, survey))
         resolve = None
+    else:
+        log.info(msg.format("PRIMARY", obscon, survey))
     hpdirname = io.find_target_files(mtldir, flavor="mtl", resolve=resolve,
                                      survey=survey, obscon=obscon, ender=form)
     # ADM grab the zcat directory (in case we're relying on $ZCAT_DIR).

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -206,6 +206,9 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
         Redshift catalog table with columns ``TARGETID``, ``NUMOBS``,
         ``Z``, ``ZWARN``, ``ZTILEID``.
     scnd : :class:`~numpy.array`, `~astropy.table.Table`, optional
+        TYPICALLY, we have a separate secondary targets (they have their
+        own "ledger"). So passing associated secondaries is DEPRECATED
+        (but still works). `scnd` is kept for backwards compatibility.
         A set of secondary targets associated with the `targets`. As with
         the `target` must include at least ``TARGETID``, ``NUMOBS_INIT``,
         ``PRIORITY_INIT`` or the corresponding SV columns.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -640,6 +640,7 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
         nside = _get_mtl_nside()
         theta, phi = np.radians(90-zcat["DEC"]), np.radians(zcat["RA"])
         pixnum = hp.ang2pix(nside, theta, phi, nest=True)
+        pixnum = list(set(pixnum))
         # ADM we'll read in too many targets, here, but that's OK as
         # ADM make_mtl(trimtozcat=True) only returns the updated targets.
         targets, fndict = io.read_mtl_in_hp(hpdirname, nside, pixnum,
@@ -931,7 +932,7 @@ def make_zcat_rr_backstop(zcatdir, tiles):
 
 
 def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
-                numobs_from_ledger=True):
+                numobs_from_ledger=True, secondary=False):
     """Execute full MTL loop, including reading files, updating ledgers.
 
     Parameters
@@ -956,6 +957,9 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
         If ``True`` then inherit the number of observations so far from
         the ledger rather than expecting it to have a reasonable value
         in the `zcat.`
+    secondary : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then process secondary targets instead of primaries
+        for passed `survey` and `obscon`.
 
     Returns
     -------
@@ -983,7 +987,10 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     # ADM construct the relevant sub-directory for this survey and
     # ADM set of observing conditions..
     form = get_mtl_ledger_format()
-    hpdirname = io.find_target_files(mtldir, flavor="mtl",
+    resolve = True
+    if secondary:
+        resolve = None
+    hpdirname = io.find_target_files(mtldir, flavor="mtl", resolve=resolve,
                                      survey=survey, obscon=obscon, ender=form)
     # ADM grab the zcat directory (in case we're relying on $ZCAT_DIR).
     zcatdir = get_zcat_dir(zcatdir)

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -284,7 +284,7 @@ priorities:
         VETO:                   {UNOBS:  0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
         UDG:                    {UNOBS: 1900, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
         FIRST_MALS:             {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        QSO_RED:                {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        QSO_RED:                {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, MORE_MIDZQSO: 100, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
 #       MWS_DDOGIANTS:          {UNOBS: 1450, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
         MWS_CLUS_GAL_DEEP:      {UNOBS: 1450, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
         LOW_MASS_AGN:           {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
@@ -423,7 +423,7 @@ numobs:
         GAL_CLUS_2ND:           1
         GAL_CLUS_SAT:           1
         STRONG_LENS:            1
-        WISE_VAR_QSO:           1
+        WISE_VAR_QSO:           4
         Z5_QSO:                 4
         MWS_MAIN_CLUSTER_SV:    1
         BRIGHT_HPM:             1

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -401,34 +401,34 @@ numobs:
 
     # ADM initial number of observations for secondary targets
     sv3_scnd_mask:
-        VETO:                     1
-        UDG:                    100
-        FIRST_MALS:             100
-        QSO_RED:                100
-#       MWS_DDOGIANTS:          100
-        MWS_CLUS_GAL_DEEP:      100
-        LOW_MASS_AGN:           100
-        FAINT_HPM:              100
-        LOW_Z_TIER1:            100
-        LOW_Z_TIER2:            100
-        LOW_Z_TIER3:            100
-        BHB:                    100
-        SPCV:                   100
-        DC3R2_GAMA:             100
-        PSF_OUT_BRIGHT:         100
-        PSF_OUT_DARK:           100
-        HPM_SOUM:               100
-        SN_HOSTS:               100
+        VETO:                   1
+        UDG:                    1
+        FIRST_MALS:             1
+        QSO_RED:                4
+#       MWS_DDOGIANTS:          1
+        MWS_CLUS_GAL_DEEP:      1
+        LOW_MASS_AGN:           1
+        FAINT_HPM:              1
+        LOW_Z_TIER1:            1
+        LOW_Z_TIER2:            1
+        LOW_Z_TIER3:            1
+        BHB:                    1
+        SPCV:                   1
+        DC3R2_GAMA:             1
+        PSF_OUT_BRIGHT:         1
+        PSF_OUT_DARK:           1
+        HPM_SOUM:               1
+        SN_HOSTS:               1
         GAL_CLUS_BCG:           2
         GAL_CLUS_2ND:           1
         GAL_CLUS_SAT:           1
-        STRONG_LENS:            100
-        WISE_VAR_QSO:           100
-        Z5_QSO:                 100
-        MWS_MAIN_CLUSTER_SV:    100
-        BRIGHT_HPM:             100
-        WD_BINARIES_BRIGHT:     100
-        WD_BINARIES_DARK:       100
+        STRONG_LENS:            1
+        WISE_VAR_QSO:           1
+        Z5_QSO:                 4
+        MWS_MAIN_CLUSTER_SV:    1
+        BRIGHT_HPM:             1
+        WD_BINARIES_BRIGHT:     1
+        WD_BINARIES_DARK:       1
         PV_BRIGHT_HIGH:         5
         PV_BRIGHT_MEDIUM:       1
         PV_BRIGHT_LOW:          1

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -659,7 +659,7 @@ def calc_priority(targets, zcat, obscon, state=False):
                 # ADM Mid-z QSOs require more observations at low
                 # ADM priority as requested by some secondary programs.
                 good_midz = (zgood & (zcat['Z'] >= midzcut) &
-                            (zcat['Z'] < zcut) & (zcat['ZWARN'] == 0))
+                             (zcat['Z'] < zcut) & (zcat['ZWARN'] == 0))
 
 # ADM useful to turn on if, for example, we want to get lots
 # ADM of QSO repeat observations during the 1% Survey:
@@ -754,7 +754,7 @@ def calc_priority(targets, zcat, obscon, state=False):
                     # ADM Mid-z QSOs require more observations at low
                     # ADM priority as requested by some secondary programs.
                     good_midz = (zgood & (zcat['Z'] >= midzcut) &
-                                (zcat['Z'] < zcut) & (zcat['ZWARN'] == 0))
+                                 (zcat['Z'] < zcut) & (zcat['ZWARN'] == 0))
                     # ADM secondary QSOs need processed like primary QSOs.
                     if scnd_mask[name].flavor == "QSO":
                         sbools = [unobs, done, good_hiz, good_midz,

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -659,7 +659,7 @@ def calc_priority(targets, zcat, obscon, state=False):
                 # ADM Mid-z QSOs require more observations at low
                 # ADM priority as requested by some secondary programs.
                 good_midz = (zgood & (zcat['Z'] >= midzcut) &
-                             (zcat['Z'] < zcut) & (zcat['ZWARN'] == 0))
+                            (zcat['Z'] < zcut) & (zcat['ZWARN'] == 0))
 
 # ADM useful to turn on if, for example, we want to get lots
 # ADM of QSO repeat observations during the 1% Survey:
@@ -729,8 +729,8 @@ def calc_priority(targets, zcat, obscon, state=False):
 
         # ADM Secondary targets.
         if scnd_target in targets.dtype.names:
-            # APC Secondary target bits only drive updates to targets with specific DESI_TARGET bits
-            # APC See https://github.com/desihub/desitarget/pull/530
+            # APC Secondaries only drive updates for specific DESI_TARGET
+            # APC bits (https://github.com/desihub/desitarget/pull/530).
             scnd_update = (targets[desi_target] & desi_mask['SCND_ANY']) != 0
             if np.any(scnd_update):
                 # APC Allow changes to primaries if the DESI_TARGET bitmask has any of the
@@ -748,10 +748,23 @@ def calc_priority(targets, zcat, obscon, state=False):
                 if (obsconditions.mask(obscon) & pricon) != 0:
                     ii = (targets[scnd_target] & scnd_mask[name]) != 0
                     ii &= scnd_update
-                    for sbool, sname in zip(
-                            [unobs, done, zgood, zwarn],
-                            ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_ZWARN"]
-                    ):
+                    # ADM LyA QSOs require more observations.
+                    # ADM (zcut is defined at the top of this module).
+                    good_hiz = zgood & (zcat['Z'] >= zcut) & (zcat['ZWARN'] == 0)
+                    # ADM Mid-z QSOs require more observations at low
+                    # ADM priority as requested by some secondary programs.
+                    good_midz = (zgood & (zcat['Z'] >= midzcut) &
+                                (zcat['Z'] < zcut) & (zcat['ZWARN'] == 0))
+                    # ADM secondary QSOs need processed like primary QSOs.
+                    if scnd_mask[name].flavor == "QSO":
+                        sbools = [unobs, done, good_hiz, good_midz,
+                                  ~good_hiz & ~good_midz, zwarn]
+                        snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_MIDZQSO",
+                                  "DONE", "MORE_ZWARN"]
+                    else:
+                        sbools = [unobs, done, zgood, zwarn]
+                        snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_ZWARN"]
+                    for sbool, sname in zip(sbools, snames):
                         # ADM update priorities and target states.
                         Mxp = scnd_mask[name].priorities[sname]
                         # ADM update states BEFORE changing priorities.

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -474,7 +474,8 @@ def calc_numobs_more(targets, zcat, obscon):
           survey, commissioning or SV and behave accordingly.
         - Most targets are updated to NUMOBS_MORE = NUMOBS_INIT-NUMOBS.
           Special cases include BGS targets which always get NUMOBS_MORE
-          of 1 in bright time and "tracer" targets at z < midzcut.
+          of 1 in bright time and "tracer" primary targets at z <
+          midzcut, which always get just one total observation.
     """
     # ADM check input arrays are sorted to match row-by-row on TARGETID.
     assert np.all(targets["TARGETID"] == zcat["TARGETID"])
@@ -501,9 +502,12 @@ def calc_numobs_more(targets, zcat, obscon):
     if survey == 'main':
         # ADM If a DARK layer target is confirmed to have a good redshift
         # ADM at z < midzcut it always needs just one total observation.
-        # ADM (midzcut is defined at the top of this module).
+        # ADM (midzcut is defined at the top of this module). Turn off
+        # ADM for secondaries.
         if (obsconditions.mask(obscon) & obsconditions.mask("DARK")) != 0:
-            ii = (zcat['ZWARN'] == 0)
+            # ADM standalone secondaries set JUST SCND_ANY in DESI_TARGET.
+            ii = targets[desi_target] != desi_mask.SCND_ANY
+            ii &= (zcat['ZWARN'] == 0)
             ii &= (zcat['Z'] < midzcut)
             ii &= (zcat['NUMOBS'] > 0)
             numobs_more[ii] = 0


### PR DESCRIPTION
This PR updates the end-to-end MTL loop for secondary ledgers, with a view to starting to use seconary ledgers during the 1% Survey. Features include:

- Adds a new "MTL tile file" called `scnd-mtl-done-tiles.ecsv`. This file can be used to check that updates to the secondary ledgers are keeping pace with updates to the primary ledgers, but doesn't control any survey behavior.
- Sets the default option in the `run_mtl_loop` script to running secondary ledgers whenever the primary ledgers are processed. This can be turned off by specifying `--nosec`.
- Catches some special cases for secondaries, such as making sure that secondary quasars have the same MTL behavior as primary quasars.
- Updates `NUMOBS` to more sensible numbers for secondary targets. For `sv1` secondaries had a high `NUMOBS` so they would always be available. For `sv3`, the plan is to let their `NUMOBS_MORE` drop to zero and their `PRIORITY` drop to `DONE`.