### PR TITLE
Further updates to the LRG selection for SV3.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,10 +6,10 @@ desitarget Change Log
 -------------------
 
 * Further updates to the LRG selection for SV3 [`PR #703`_]. Includes:
-    * Change bright end cut to zfibertot < 17.5 (instead of < 16).
+    * Change bright-end cut to ``zfibertot`` > 17.5 (instead of > 16).
     * Add low-density (600-per-sq.-deg.) LRG sample (``LRG_LOWDENS``).
         * Bit is informational as ``LRG_LOWDENS`` is a subset of ``LRG``.
-    * Update the intersphinx URLs to fix the online documenation builds.
+    * Update the intersphinx URLs to fix the online documentation builds.
 
 .. _`PR #703`: https://github.com/desihub/desitarget/pull/703
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,13 @@ desitarget Change Log
 0.56.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Further updates to the LRG selection for SV3 [`PR #703`_]. Includes:
+    * Change bright end cut to zfibertot < 17.5 (instead of < 16).
+    * Add low-density (600-per-sq.-deg.) LRG sample (``LRG_LOWDENS``).
+        * Bit is informational as ``LRG_LOWDENS`` is a subset of ``LRG``.
+    * Update the intersphinx URLs to fix the online documenation builds.
+
+.. _`PR #703`: https://github.com/desihub/desitarget/pull/703
 
 0.56.0 (2021-03-31)
 -------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,13 +52,12 @@ extensions = [
 
 # Configuration for intersphinx, copied from astropy.
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/', None),
-    # 'python3': ('http://docs.python.org/3/', path.abspath(path.join(path.dirname(__file__), 'local/python3links.inv'))),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
-    'matplotlib': ('http://matplotlib.org/', None),
-    'astropy': ('http://docs.astropy.org/en/stable/', None),
-    'h5py': ('http://docs.h5py.org/en/latest/', None)
+    'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'matplotlib': ('https://matplotlib.org/', None),
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
+    'h5py': ('https://docs.h5py.org/en/latest/', None)
     }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2066,8 +2066,11 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         The flux in nano-maggies of g, r, z, W1 and W2 bands.
         Corrected for Galactic extinction.
     gfiberflux, rfiberflux, zfiberflux : :class:`~numpy.ndarray`
-        Predicted fiber flux in 1 arcsecond seeing in g/r/z-band.
+        Predicted fiber flux from object in 1 arcsecond seeing in g/r/z.
         Corrected for Galactic extinction.
+    gfibertotflux, rfibertotflux, zfibertotflux : :class:`~numpy.ndarray`
+        Predicted fiber flux from ALL sources at object's location in 1
+        arcsecond seeing in g/r/z. NOT corrected for Galactic extinction.
     objtype, release : :class:`~numpy.ndarray`
         `The Legacy Surveys`_ imaging ``TYPE`` and ``RELEASE`` columns.
     gfluxivar, rfluxivar, zfluxivar, w1fluxivar: :class:`~numpy.ndarray`

--- a/py/desitarget/sv2/sv2_cuts.py
+++ b/py/desitarget/sv2/sv2_cuts.py
@@ -1765,8 +1765,11 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         The flux in nano-maggies of g, r, z, W1 and W2 bands.
         Corrected for Galactic extinction.
     gfiberflux, rfiberflux, zfiberflux : :class:`~numpy.ndarray`
-        Predicted fiber flux in 1 arcsecond seeing in g/r/z-band.
+        Predicted fiber flux from object in 1 arcsecond seeing in g/r/z.
         Corrected for Galactic extinction.
+    gfibertotflux, rfibertotflux, zfibertotflux : :class:`~numpy.ndarray`
+        Predicted fiber flux from ALL sources at object's location in 1
+        arcsecond seeing in g/r/z. NOT corrected for Galactic extinction.
     objtype, release : :class:`~numpy.ndarray`
         `The Legacy Surveys`_ imaging ``TYPE`` and ``RELEASE`` columns.
     gfluxivar, rfluxivar, zfluxivar, w1fluxivar: :class:`~numpy.ndarray`

--- a/py/desitarget/sv3/data/sv3_targetmask.yaml
+++ b/py/desitarget/sv3/data/sv3_targetmask.yaml
@@ -4,26 +4,30 @@ sv3_desi_mask:
     - [ELG,         1, "ELG", {obsconditions: DARK}]
     - [QSO,         2, "QSO", {obsconditions: DARK}]
 
+    #- ADM LRG sub-classes
+    - [LRG_LOWDENS, 3, "LRG selected using cuts that produce a lower (~600 per sq. deg.) target density", {obsconditions: DARK}]
+
     #- ADM QSO sub-classes
     - [QSO_HIZ,     4, "QSO selected using high-redshift Random Forest (informational bit)", {obsconditions: DARK}]
 
     # ADM ELG sub-classes
-    # ADM ELG_LOP was deprecated early in SV3. We just use "ELG" for the low-priority ELGs.
     - [ELG_LOP,     5, "ELG at lower priority",  {obsconditions: DARK}]
     - [ELG_HIP,     6, "ELG at higher priority", {obsconditions: DARK}]
 
     #- North vs. South selections
-    - [LRG_NORTH,      8, "LRG cuts tuned for Bok/Mosaic data",               {obsconditions: DARK}]
-    - [ELG_NORTH,      9, "ELG cuts tuned for Bok/Mosaic data",               {obsconditions: DARK}]
-    - [QSO_NORTH,     10, "QSO cuts tuned for Bok/Mosaic data",               {obsconditions: DARK}]
-    - [ELG_LOP_NORTH, 11, "ELG at lower priority tuned for Bok/Mosaic data",  {obsconditions: DARK}]
-    - [ELG_HIP_NORTH, 12, "ELG at higher priority tuned for Bok/Mosaic data", {obsconditions: DARK}]
+    - [LRG_NORTH,          8, "LRG cuts tuned for Bok/Mosaic data",                 {obsconditions: DARK}]
+    - [ELG_NORTH,          9, "ELG cuts tuned for Bok/Mosaic data",                 {obsconditions: DARK}]
+    - [QSO_NORTH,         10, "QSO cuts tuned for Bok/Mosaic data",                 {obsconditions: DARK}]
+    - [ELG_LOP_NORTH,     11, "ELG at lower priority tuned for Bok/Mosaic data",    {obsconditions: DARK}]
+    - [ELG_HIP_NORTH,     12, "ELG at higher priority tuned for Bok/Mosaic data",   {obsconditions: DARK}]
+    - [LRG_LOWDENS_NORTH, 13, "LRG cuts (lower density) tuned for Bok/Mosaic data", {obsconditions: DARK}]
 
-    - [LRG_SOUTH,     16, "LRG cuts tuned for DECam data",                    {obsconditions: DARK}]
-    - [ELG_SOUTH,     17, "ELG cuts tuned for DECam data",                    {obsconditions: DARK}]
-    - [QSO_SOUTH,     18, "QSO cuts tuned for DECam data",                    {obsconditions: DARK}]
-    - [ELG_LOP_SOUTH, 19, "ELG at lower priority tuned for DECam data",       {obsconditions: DARK}]
-    - [ELG_HIP_SOUTH, 20, "ELG at higher priority tuned for DECam data",      {obsconditions: DARK}]
+    - [LRG_SOUTH,         16, "LRG cuts tuned for DECam data",                      {obsconditions: DARK}]
+    - [ELG_SOUTH,         17, "ELG cuts tuned for DECam data",                      {obsconditions: DARK}]
+    - [QSO_SOUTH,         18, "QSO cuts tuned for DECam data",                      {obsconditions: DARK}]
+    - [ELG_LOP_SOUTH,     19, "ELG at lower priority tuned for DECam data",         {obsconditions: DARK}]
+    - [ELG_HIP_SOUTH,     20, "ELG at higher priority tuned for DECam data",        {obsconditions: DARK}]
+    - [LRG_LOWDENS_SOUTH, 21, "LRG cuts (lower density) tuned for DECam data",      {obsconditions: DARK}]
 
     #- Calibration targets
     - [SKY,         32, "Blank sky locations",
@@ -199,27 +203,31 @@ priorities:
 # ADM safest to set MORE_ZGOOD for ELGs/LRGs to DONE PROVIDED they have NUMOBS=1 as
 # ADM they can match QSO targets that require multiple observations and trump those
 # ADM QSOs with a higher priority. There is a unit test to check NUMOBS=1 for ELGs/LRGs.
-        ELG: {UNOBS: 3000, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        LRG: {UNOBS: 3200, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        ELG: {UNOBS: 3000, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        LRG: {UNOBS: 3200, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 # ADM The MORE_MIDZQSO priority is driven by secondary programs from Gontcho a Gontcho (1.4 < z < 2.1)
 # ADM and Weiner et al. (0.7 < z < 2.1) to reobserve confirmed quasars where possible. The priority
 # ADM of 100 should only be higher than DONE (and secondary filler) targets.
         QSO: {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, MORE_MIDZQSO: 100, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        ELG_LOP: {UNOBS: 3000, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        ELG_HIP: {UNOBS: 3100, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        ELG_LOP: {UNOBS: 3000, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        ELG_HIP: {UNOBS: 3100, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        # ADM Informational bits. Don't let them set priorities.
+        LRG_LOWDENS: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        QSO_HIZ: SAME_AS_LRG_LOWDENS
         # ADM don't prioritize a N/S target if it doesn't have other bits set
-        LRG_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
-        QSO_HIZ: SAME_AS_LRG_NORTH
+        LRG_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         ELG_NORTH: SAME_AS_LRG_NORTH
         QSO_NORTH: SAME_AS_LRG_NORTH
         ELG_LOP_NORTH: SAME_AS_LRG_NORTH
         ELG_HIP_NORTH: SAME_AS_LRG_NORTH
+        LRG_LOWDENS_NORTH: SAME_AS_LRG_NORTH
         LRG_SOUTH: SAME_AS_LRG_NORTH
         ELG_SOUTH: SAME_AS_LRG_NORTH
         QSO_SOUTH: SAME_AS_LRG_NORTH
         ELG_LOP_SOUTH: SAME_AS_LRG_NORTH
         ELG_HIP_SOUTH: SAME_AS_LRG_NORTH
-        BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
+        LRG_LOWDENS_SOUTH: SAME_AS_LRG_NORTH
+        BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, MORE_MIDZQSO: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FAINT:  -1
         STD_WD:     -1
@@ -242,12 +250,12 @@ priorities:
     # ADM reserve 2998 for MWS_WD (ensuring a priority below Dark Survey targets, just in case)
     #- reobserving successes has lower priority than MWS
     sv3_bgs_mask:
-        BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BGS_BRIGHT: {UNOBS: 2100, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BGS_WISE: {UNOBS: 2000, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BGS_FAINT_HIP: {UNOBS: 2100, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BGS_BRIGHT: {UNOBS: 2100, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BGS_WISE: {UNOBS: 2000, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BGS_FAINT_HIP: {UNOBS: 2100, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         # ADM don't prioritize a N/S target if it doesn't have other bits set
-        BGS_FAINT_SOUTH: {UNOBS: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
+        BGS_FAINT_SOUTH: {UNOBS: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         BGS_FAINT_NORTH: SAME_AS_BGS_FAINT_SOUTH
         BGS_BRIGHT_SOUTH: SAME_AS_BGS_FAINT_SOUTH
         BGS_BRIGHT_NORTH: SAME_AS_BGS_FAINT_SOUTH
@@ -257,23 +265,23 @@ priorities:
     #- Milky Way Survey: priorities 1000-1999
     # ADM WDs should be prioritized above BGS at 2998
     sv3_mws_mask: 
-        MWS_BROAD:                    {UNOBS: 1400, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_WD:                       {UNOBS: 2998, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_NEARBY:                   {UNOBS: 1600, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_BHB:                      {UNOBS: 1550, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        MWS_BROAD:                    {UNOBS: 1400, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_WD:                       {UNOBS: 2998, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_NEARBY:                   {UNOBS: 1600, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_BHB:                      {UNOBS: 1550, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 
         # ADM don't prioritize a N/S target if it doesn't have other bits set
-        MWS_BROAD_NORTH:              {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
+        MWS_BROAD_NORTH:              {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         MWS_BROAD_SOUTH:              SAME_AS_MWS_BROAD_NORTH
-        MWS_MAIN_BLUE:                {UNOBS: 1500, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        MWS_MAIN_BLUE:                {UNOBS: 1500, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         MWS_MAIN_BLUE_NORTH:          SAME_AS_MWS_BROAD_NORTH
         MWS_MAIN_BLUE_SOUTH:          SAME_AS_MWS_BROAD_NORTH
         MWS_MAIN_RED:                 SAME_AS_MWS_MAIN_BLUE
         MWS_MAIN_RED_NORTH:           SAME_AS_MWS_BROAD_NORTH
         MWS_MAIN_RED_SOUTH:           SAME_AS_MWS_BROAD_NORTH
-        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BACKUP_FAINT:                 {UNOBS: 8, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BACKUP_FAINT:                 {UNOBS: 8, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         # ADM Standards are special; priorities don't apply.
         GAIA_STD_FAINT:  -1
         GAIA_STD_WD:  -1
@@ -281,42 +289,42 @@ priorities:
 
     # ADM secondary target priorities.
     sv3_scnd_mask:
-        VETO:                   {UNOBS:  0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
-        UDG:                    {UNOBS: 1900, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        FIRST_MALS:             {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        VETO:                   {UNOBS:  0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        UDG:                    {UNOBS: 1900, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        FIRST_MALS:             {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         QSO_RED:                {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, MORE_MIDZQSO: 100, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-#       MWS_DDOGIANTS:          {UNOBS: 1450, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_CLUS_GAL_DEEP:      {UNOBS: 1450, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        LOW_MASS_AGN:           {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+#       MWS_DDOGIANTS:          {UNOBS: 1450, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_CLUS_GAL_DEEP:      {UNOBS: 1450, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        LOW_MASS_AGN:           {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         FAINT_HPM:              SAME_AS_LOW_MASS_AGN
-        LOW_Z_TIER1:            {UNOBS: 80, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        LOW_Z_TIER2:            {UNOBS: 70, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        LOW_Z_TIER3:            {UNOBS: 60, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        BHB:                    {UNOBS: 1950, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        LOW_Z_TIER1:            {UNOBS: 80, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        LOW_Z_TIER2:            {UNOBS: 70, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        LOW_Z_TIER3:            {UNOBS: 60, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BHB:                    {UNOBS: 1950, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         SPCV:                   SAME_AS_LOW_MASS_AGN
-        DC3R2_GAMA:             {UNOBS: 1010, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        PSF_OUT_BRIGHT:         {UNOBS: 90, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        DC3R2_GAMA:             {UNOBS: 1010, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        PSF_OUT_BRIGHT:         {UNOBS: 90, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         PSF_OUT_DARK:           SAME_AS_PSF_OUT_BRIGHT
         HPM_SOUM:               SAME_AS_LOW_MASS_AGN
         SN_HOSTS:               SAME_AS_BHB
-        GAL_CLUS_BCG:           {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        GAL_CLUS_2ND:           {UNOBS: 1020, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        GAL_CLUS_SAT:           {UNOBS: 200,  DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        STRONG_LENS:            {UNOBS: 4000, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        GAL_CLUS_BCG:           {UNOBS: 1025, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        GAL_CLUS_2ND:           {UNOBS: 1020, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        GAL_CLUS_SAT:           {UNOBS: 200,  DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        STRONG_LENS:            {UNOBS: 4000, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         WISE_VAR_QSO:           SAME_AS_QSO_RED
         Z5_QSO:                 SAME_AS_QSO_RED
-        MWS_MAIN_CLUSTER_SV:    {UNOBS: 1450, DONE:  400, OBS: 1, DONOTOBSERVE: 0}
+        MWS_MAIN_CLUSTER_SV:    {UNOBS: 1450, DONE:  400, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         BRIGHT_HPM:             SAME_AS_LOW_MASS_AGN
-        WD_BINARIES_BRIGHT:     {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        WD_BINARIES_DARK:       {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        PV_BRIGHT_HIGH:         {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        PV_BRIGHT_MEDIUM:       {UNOBS: 1010, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        PV_BRIGHT_LOW:          {UNOBS: 1005, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        PV_DARK_HIGH:           {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        PV_DARK_MEDIUM:         {UNOBS: 1010, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        PV_DARK_LOW:            {UNOBS: 1005, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        BRIGHT_TOO_LOP:         {UNOBS: 1000, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        BRIGHT_TOO_HIP:         {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        WD_BINARIES_BRIGHT:     {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        WD_BINARIES_DARK:       {UNOBS: 1998, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        PV_BRIGHT_HIGH:         {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        PV_BRIGHT_MEDIUM:       {UNOBS: 1010, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        PV_BRIGHT_LOW:          {UNOBS: 1005, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        PV_DARK_HIGH:           {UNOBS: 1700, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        PV_DARK_MEDIUM:         {UNOBS: 1010, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        PV_DARK_LOW:            {UNOBS: 1005, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BRIGHT_TOO_LOP:         {UNOBS: 1000, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BRIGHT_TOO_HIP:         {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         DARK_TOO_LOP:           SAME_AS_BRIGHT_TOO_LOP
         DARK_TOO_HIP:           SAME_AS_BRIGHT_TOO_HIP
 
@@ -331,17 +339,21 @@ numobs:
         QSO: 4
         ELG_LOP: 1
         ELG_HIP: 1
+        # ADM LRG_LOWDENS is a purely informational bit.
+        LRG_LOWDENS: 0
         # ADM don't observe a N/S target if it doesn't have other bits set
         LRG_NORTH: 0
         ELG_NORTH: 0
         QSO_NORTH: 0
         ELG_LOP_NORTH: 0
         ELG_HIP_NORTH: 0
+        LRG_LOWDENS_NORTH: 0
         LRG_SOUTH: 0
         ELG_SOUTH: 0
         QSO_SOUTH: 0
         ELG_LOP_SOUTH: 0
         ELG_HIP_SOUTH: 0
+        LRG_LOWDENS_SOUTH: 0
         BAD_SKY: 0
         #- Standards and sky are treated specially; NUMOBS doesn't apply
         STD_FAINT:  -1

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -2217,7 +2217,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # Construct the targetflag bits for DECaLS (i.e. South).
     desi_target = lrg_south * desi_mask.LRG_SOUTH
-    desi_target = lrg_south * desi_mask.LRG_LOWDENS_SOUTH
+    desi_target |= lrg_lowdens_south * desi_mask.LRG_LOWDENS_SOUTH
     desi_target |= elg_south * desi_mask.ELG_SOUTH
     desi_target |= elg_lop_south * desi_mask.ELG_LOP_SOUTH
     desi_target |= elg_hip_south * desi_mask.ELG_HIP_SOUTH
@@ -2225,7 +2225,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # Construct the targetflag bits for MzLS and BASS (i.e. North).
     desi_target |= lrg_north * desi_mask.LRG_NORTH
-    desi_target |= lrg_north * desi_mask.LRG_LOWDENS_NORTH
+    desi_target |= lrg_lowdens_north * desi_mask.LRG_LOWDENS_NORTH
     desi_target |= elg_north * desi_mask.ELG_NORTH
     desi_target |= elg_lop_north * desi_mask.ELG_LOP_NORTH
     desi_target |= elg_hip_north * desi_mask.ELG_HIP_NORTH
@@ -2233,7 +2233,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
 
     # Construct the targetflag bits combining north and south.
     desi_target |= lrg * desi_mask.LRG
-    desi_target |= lrg_north * desi_mask.LRG_LOWDENS
+    desi_target |= lrg_lowdens * desi_mask.LRG_LOWDENS
     desi_target |= elg * desi_mask.ELG
     desi_target |= elg_lop * desi_mask.ELG_LOP
     desi_target |= elg_hip * desi_mask.ELG_HIP

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -294,7 +294,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (03/27/21) is version 8 on `the SV3 wiki`_.
+    - Current version (03/31/21) is version 15 on `the SV3 wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # ADM LRG targets.
@@ -1209,7 +1209,7 @@ def isBGS(rfiberflux=None, gflux=None, rflux=None, zflux=None,
 
     Notes
     -----
-    - Current version (03/20/21) is version 1 on `the SV3 wiki`_.
+    - Current version (03/29/21) is version 13 on `the SV3 wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     _check_BGS_targtype(targtype)
@@ -1925,8 +1925,11 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         The flux in nano-maggies of g, r, z, W1 and W2 bands.
         Corrected for Galactic extinction.
     gfiberflux, rfiberflux, zfiberflux : :class:`~numpy.ndarray`
-        Predicted fiber flux in 1 arcsecond seeing in g/r/z-band.
+        Predicted fiber flux from object in 1 arcsecond seeing in g/r/z.
         Corrected for Galactic extinction.
+    gfibertotflux, rfibertotflux, zfibertotflux : :class:`~numpy.ndarray`
+        Predicted fiber flux from ALL sources at object's location in 1
+        arcsecond seeing in g/r/z. NOT corrected for Galactic extinction.
     objtype, release : :class:`~numpy.ndarray`
         `The Legacy Surveys`_ imaging ``TYPE`` and ``RELEASE`` columns.
     gfluxivar, rfluxivar, zfluxivar, w1fluxivar: :class:`~numpy.ndarray`


### PR DESCRIPTION
This PR focuses on additional updates to the LRG targets in preparation for the 1% Survey. It:

- Changes the bright-end cut for LRG targets from `zfibertot > 16` to `zfibertot > 17.5`.   
- Adds a low-density (600-per-sq.-deg.) LRG sample (denoted `LRG_LOWDENS`).
  * The `LRG_LOWDENS` bit is purely informational as the `LRG_LOWDENS` targets are a strict subset of the `LRG` targets.
- Also updates the intersphinx URLs to fix the online documentation builds.