### PR TITLE
Add a bright-end limit for MWS targets for SV3.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desitarget Change Log
 0.56.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Bright limit (GAIA_G > 15) AND (ZFIBERTOT > 15) for MWS [`PR #704`_].
+    * Applied to all MWS targets (``BROAD/NEARBY/WD/BHB``).
+
+.. _`PR #704`: https://github.com/desihub/desitarget/pull/704
 
 0.56.0 (2021-03-31)
 -------------------

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -65,7 +65,7 @@ def MWS_too_bright(gaiagmag=None, zfibertotflux=None):
 
     Notes
     -----
-    - Current version (04/02/21) is version 16 on `the SV3 wiki`_.
+    - Current version (04/02/21) is version 17 on `the SV3 wiki`_.
     """
     # ADM set up an array to store objects that is all True.
     too_bright = np.ones_like(gaiagmag, dtype='?')

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -2143,11 +2143,15 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     mws_classes = [[tcfalse, tcfalse, tcfalse], [tcfalse, tcfalse, tcfalse]]
     mws_nearby = tcfalse
     mws_bhb = tcfalse
+    # ADM this denotes a bright limit for all MWS sources.
+    too_bright = MWS_too_bright(gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
     if "MWS" in tcnames:
         mws_nearby = isMWS_nearby(
             gaia=gaia, gaiagmag=gaiagmag, parallax=parallax,
             parallaxerr=parallaxerr, paramssolved=gaiaparamssolved
         )
+        # ADM impose bright limits for all MWS_NEARBY targets.
+        mws_nearby &= ~too_bright
 
         mws_bhb = isMWS_bhb(
                     primary=primary,
@@ -2159,6 +2163,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
                     parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits
              )
+        # ADM impose bright limits for all MWS_BHB targets.
+        mws_bhb &= ~too_bright
 
         # ADM run the MWS target types for (potentially) both north and south.
         for south in south_cuts:
@@ -2170,6 +2176,9 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits,
                     paramssolved=gaiaparamssolved, primary=primary, south=south
             )
+            # ADM impose bright limits for all MWS_MAIN targets.
+            mws_classes[int(south)] &= ~too_bright
+
     mws_broad_n, mws_red_n, mws_blue_n = mws_classes[0]
     mws_broad_s, mws_red_s, mws_blue_s = mws_classes[1]
 
@@ -2184,6 +2193,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
             photbprpexcessfactor=gaiabprpfactor, astrometricsigma5dmax=gaiasigma5dmax,
             gaiagmag=gaiagmag, gaiabmag=gaiabmag, gaiarmag=gaiarmag
         )
+        # ADM impose bright limits for all MWS_WD targets.
+        mws_wd &= ~too_bright
 
     # ADM initially set everything to False for the standards.
     std_faint, std_bright, std_wd = tcfalse, tcfalse, tcfalse

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -46,6 +46,42 @@ log = get_logger()
 start = time()
 
 
+def MWS_too_bright(gaiagmag=None, zfibertotflux=None):
+    """Whether a target is too bright to include for MWS observations.
+
+    Parameters
+    ----------
+    gaiagmag : :class:`~numpy.ndarray`
+            Gaia-based g-band MAGNITUDE.
+    zfibertotflux : :class:`~numpy.ndarray`
+        Predicted fiber flux from ALL sources at object's location in 1
+        arcsecond seeing in z. NOT corrected for Galactic extinction.
+
+    Returns
+    -------
+    :class:`array_like`
+        ``True`` if and only if the object is FAINTER than the MWS
+        bright-cut limits.
+
+    Notes
+    -----
+    - Current version (04/02/21) is version 16 on `the SV3 wiki`_.
+    """
+    # ADM set up an array to store objects that is all True.
+    too_bright = np.ones_like(gaiagmag, dtype='?')
+
+    # ADM True if Gaia G is too bright.
+    # ADM remember that gaiagmag of 0 corresponds to missing sources.
+    too_bright &= (gaiagmag < 15) & (gaiagmag != 0)
+
+    # ADM or True if the Legacy Surveys zfibertot is too bright.
+    # ADM remember that zflux of 0 corresponds to missing sources.
+    zmag = 22.5-2.5*np.log10(zfibertotflux.clip(1e-7))
+    too_bright |= (zmag < 15) & (zfibertotflux != 0)
+
+    return too_bright
+
+
 def shift_photo_north(gflux=None, rflux=None, zflux=None):
     """Convert fluxes in the northern (BASS/MzLS) to the southern (DECaLS) system.
 


### PR DESCRIPTION
This PR adds a bright-end cut for all MWS targets for SV3:

- Targets are only retained if `GAIA_PHOT_G_MEAN_MAG > 15` AND `FIBERTOTMAG_Z > 15`.
- This is applied to all MWS targets (`BROAD/NEARBY/WD/BHB`).
- Very few targets end up being removed (~0.1%).