### PR TITLE
When making a zcat, update the ZWARN bit-mask using DELTACHI2 values

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ desitarget Change Log
 0.57.1 (unreleased)
 -------------------
 
-* No changes yet.
+* When making a zcat, update ``ZWARN`` using ``DELTACHI2`` [`PR #707`_]:
+    * Flag ``ZWARN`` for all targets with ``DELTACHI2 < 25``.
+    * Also flag ``BGS`` targets in bright-time with ``DELTACHI2 < 40``.
+
+.. _`PR #707`: https://github.com/desihub/desitarget/pull/707
 
 0.57.0 (2021-04-04)
 -------------------

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -175,7 +175,7 @@ targetid_mask:
     - [RESERVED,   62, "RIGHTMOST bit for left over bit space (encompasses bit 62 inclusive)",           {nbits: 1}]
 
 # ADM ZWARN mask (bits that can be set to warn that a redshift is bad).
-# ADM inherited from https://github.com/desihub/redrock/blob/8e33f642b6d8a762c4d71626fb3aca6377c976d4/py/redrock/zwarning.py
+# ADM inherited from https://github.com/desihub/redrock/blob/master/py/redrock/zwarning.py
 zwarn_mask:
     - [SKY,                0, "sky fiber"]
     - [LITTLE_COVERAGE,    1, "too little wavelength coverage"]
@@ -188,6 +188,9 @@ zwarn_mask:
     - [BAD_TARGET,         8, "catastrophically bad targeting data"]
     - [NODATA,             9, "No data for this fiber, e.g. because spectrograph was broken during this exposure (ivar=0 for all pixels)"]
     - [BAD_MINFIT,        10, "Bad parabola fit to the chi2 minimum"]
+    - [LOW_DEL_CHI2,      16, "DELTACHI2 is lower than 25 for a DESI SV3 target"]
+    - [LOW_DEL_CHI2_BGS,  17, "DELTACHI2 is lower than 40 for a DESI SV3 BGS target in bright time"]
+
 
 #- Priorities for each target bit
 #- Numerically larger priorities are higher priority to be observed first.


### PR DESCRIPTION
This PR updates the MTL function that constructs a "backstop" (i.e. redrock-only) redshift catalog (`zcat`) so that new values of `ZWARN` are flagged when the `zcat` is constructed. The specific changes are:

- Set a `ZWARN` bit for all targets that have `DELTACHI2 < 25`.
- Additionally set a different `ZWARN` bit for BGS targets that have `DELTACHI2 < 40` if they were observed as part of the bright program.