### PR TITLE
Late-breaking updates to MTL for SV3.

### DIFF
--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -37,9 +37,12 @@ ns = ap.parse_args()
 numobs_from_ledger = not(ns.numobsfromzcat)
 
 scndstates = [False]
-# ADM if nosecondary wasn't passed, also process the secondary ledger.
-if not(ns.nosecondary):
-    scndstates = [True, False]
+
+# ADM if nosecondary wasn't passed, also process the secondary ledger
+# ADM for programs that actually have secondary ledgers (BRIGHT/DARK).
+if ns.obscon in ["BRIGHT", "DARK"]:
+    if not(ns.nosecondary):
+        scndstates = [True, False]
 
 for secondary in scndstates:
     hpdirname, mtltilefn, tilefn, tiles = loop_ledger(

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,20 @@ desitarget Change Log
 0.57.1 (unreleased)
 -------------------
 
+* Late-breaking updates to MTL for SV3 [`PR #708`_]:
+    * Never run the secondary ledgers for ``BACKUP`` targets.
+        * Because they *have no* secondary ledgers.
+    * Force anything with ``NUMOBS_INIT`` = 9 to ``NUMOBS_INIT`` = 3.
+        * As we made a late decision to have 3 passes rather than 9.
+        * The first ledger row will reflect 9 to match the target files.
+	    * Subsequent rows will change to ``NUMOBS_INIT`` = 3.
+	    * And ``NUMOBS_MORE`` will appropriately drop to 2.
 * When making a zcat, update ``ZWARN`` using ``DELTACHI2`` [`PR #707`_]:
     * Flag ``ZWARN`` for all targets with ``DELTACHI2 < 25``.
     * Also flag ``BGS`` targets in bright-time with ``DELTACHI2 < 40``.
 
 .. _`PR #707`: https://github.com/desihub/desitarget/pull/707
+.. _`PR #708`: https://github.com/desihub/desitarget/pull/708
 
 0.57.0 (2021-04-04)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 0.57.1 (unreleased)
 -------------------
 
-* Late-breaking updates to MTL for SV3 [`PR #708`_]:
+* Late-breaking updates to MTL for SV3 [`PR #709`_]:
     * Never run the secondary ledgers for ``BACKUP`` targets.
         * Because they *have no* secondary ledgers.
     * Force anything with ``NUMOBS_INIT`` = 9 to ``NUMOBS_INIT`` = 3.
@@ -18,7 +18,7 @@ desitarget Change Log
     * Also flag ``BGS`` targets in bright-time with ``DELTACHI2 < 40``.
 
 .. _`PR #707`: https://github.com/desihub/desitarget/pull/707
-.. _`PR #708`: https://github.com/desihub/desitarget/pull/708
+.. _`PR #709`: https://github.com/desihub/desitarget/pull/709
 
 0.57.0 (2021-04-04)
 -------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -333,10 +333,19 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
     # ADM extract just the targets that match the input zcat.
     targets_zmatcher = targets[zmatcher]
 
-    # ADM special case. In dark time, if a QSO target is above feasible
-    # ADM galaxy redshifts, set NUMOBS_INIT to be like a QSO, not an ELG.
-    if survey == "sv3" or survey == "main":
+    # ADM special cases for SV3.
+    if survey == "sv3":
+        if zcat is not None:
+            # ADM a necessary hack as we created ledgers for SV3 with
+            # ADM NUMOBS_INIT==9 then later decided on NUMOBS_INIT==3.
+            ii = targets_zmatcher["NUMOBS_INIT"] == 9
+            targets_zmatcher["NUMOBS_INIT"][ii] = 3
+            # ADM make sure to also force a permanent change of state for
+            # ADM the actual *targets* that will be returned as the mtl.
+            targets["NUMOBS_INIT"][zmatcher[ii]] = 3
         if (obsconditions.mask(obscon) & obsconditions.mask("DARK")) != 0:
+            # ADM In dark time, if a QSO target is above feasible galaxy
+            # ADM redshifts, NUMOBS should behave like a QSO, not an ELG.
             ii = targets_zmatcher[desi_target] & desi_mask["QSO"] != 0
             # ADM the secondary bit-names that correspond to primary QSOs.
             sns = [bn for bn in scnd_mask.names() if scnd_mask[bn].flavor == 'QSO']

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -892,9 +892,9 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey):
     else:
         # ADM ...else, we want tiles that uniquely appear in the combined
         # ADM "alltiles" and "donetiles" (as they aren't in "donetiles").
-        tids = np.concatenate([alltiles["TILEID"], donetiles["TILEID"]])
-        _, cnt = np.unique(tids, return_counts=True)
-        tiles = alltiles[cnt == 1]
+        newtids = set(alltiles["TILEID"]) - set(donetiles["TILEID"])
+        ii = np.array([tid in newtids for tid in alltiles["TILEID"]])
+        tiles = alltiles[ii]
 
     # ADM restrict the tiles to be processed to the correct survey.
     ii = tiles["SURVEY"] == survey


### PR DESCRIPTION
This PR includes some updates to the MTL loop for SV3:

- Only ever run the secondary targets for `BRIGHT` and `DARK` programs (because `BACKUP` targets _have no_ secondary ledgers).
- Force anything with `NUMOBS_INIT == 9` to `NUMOBS_INIT == 3` (i.e. force an update to all galaxy/MWS target classes).
  * This was decided on _after_ we made initial ledgers and went on-sky.
  * The first ledger row will retain `NUMOBS_INIT == 9` to match the target files.
  * Subsequent rows will change to `NUMOBS_INIT = 3`
    - and `NUMOBS_MORE` will drop to `2` for targets that require additional observations.
