### PR TITLE
General improvements to MTL functionality.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ desitarget Change Log
 0.57.2 (unreleased)
 -------------------
 
-* No changes yet.
+* General improvements to MTL functionality [`PR #710`_]. Includes:
+   * Significant speed-up of :func:`mtl.inflate_ledger()`.
+   * Unit test to compare the desitarget ``ZWARN`` bit-mask to redrock.
+
+.. _`PR #710`: https://github.com/desihub/desitarget/pull/710
 
 0.57.1 (2021-04-07)
 -------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -764,7 +764,8 @@ def inflate_ledger(mtl, hpdirname, columns=None, header=False, strictcols=False,
         from the `hpdirname` directory.
     strictcols : :class:`bool`, optional, defaults to ``False``
         If ``True`` then strictly return only the columns in `columns`,
-        otherwise, inflate the ledger with the new columns.
+        otherwise, inflate the ledger with the new columns. Ignored if
+        `columns` is set to ``None``.
     quick : :class:`bool`, optional, defaults to ``False``
         If ``True``, call the "quick" version of reading targets
         which is much faster but makes fewer error checks.
@@ -778,6 +779,9 @@ def inflate_ledger(mtl, hpdirname, columns=None, header=False, strictcols=False,
     -----
     - Will run more quickly if the targets in `mtl` are clustered.
     - TARGETID is always returned, even if it isn't in `columns`.
+    - Any column in `mtl` that is also in `columns` will be OVERWRITTEN.
+      So, be careful not to pass `columns=None` if you only intend to
+      ADD columns to `mtl` rather than also SUBSTITUTING some columns.
     """
     # ADM if a table was passed convert it to a numpy array.
     if isinstance(mtl, Table):

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -2,6 +2,18 @@
 # -*- coding: utf-8 -*-
 """Test desitarget.mtl.
 """
+
+# ADM only run unit tests that require redrock if its installed.
+try:
+    # ADM import the zwarn mask from redrock.
+    from redrock.zwarning import ZWarningMask as rrMx
+    norr = False
+except ImportError:
+    from desiutil.log import get_logger
+    log = get_logger()
+    log.info('redrock not installed; skipping ZWARN consistency check')
+    norr = True
+
 import os
 import unittest
 import numpy as np
@@ -177,17 +189,18 @@ class TestMTL(unittest.TestCase):
         # ADM all BGS targets should always have NUMOBS_MORE=1.
         self.assertTrue(np.all(bgszcat["NUMOBS_MORE"] == 1))
 
+    @unittest.skipIf(norr, 'redrock not installed; skip ZWARN consistency check')
     def test_zwarn_in_sync(self):
-        """Check redrock doesn't add ZWARN flags missing from desitarget.
+        """Check redrock and desitarget ZWARN bit-masks are consistent.
         """
-        # ADM import the zwarn mask from redrock.
-        from redrock.zwarning import ZWarningMask as rrMx
         # ADM import the zwarn mask from desitarget.
         from desitarget.targetmask import zwarn_mask as dtMx
         dtbitnames = dtMx.names()
         for (bitname, bitval) in rrMx.flags():
+            # ADM check bit-names are consistent.
             self.assertTrue(bitname in dtbitnames,
                             "missing ZWARN bit {} from redrock".format(bitname))
+            # ADM check bit-values are consistent.
             self.assertTrue(dtMx[bitname] == bitval,
                             "ZWARN bit value mismatch for {}".format(bitname))
 

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -177,6 +177,19 @@ class TestMTL(unittest.TestCase):
         # ADM all BGS targets should always have NUMOBS_MORE=1.
         self.assertTrue(np.all(bgszcat["NUMOBS_MORE"] == 1))
 
+    def test_zwarn_in_sync(self):
+        """Check redrock doesn't add ZWARN flags missing from desitarget.
+        """
+        # ADM import the zwarn mask from redrock.
+        from redrock.zwarning import ZWarningMask as rrMx
+        # ADM import the zwarn mask from desitarget.
+        from desitarget.targetmask import zwarn_mask as dtMx
+        dtbitnames = dtMx.names()
+        for (bitname, bitval) in rrMx.flags():
+            self.assertTrue(bitname in dtbitnames,
+                            "missing ZWARN bit {} from redrock".format(bitname))
+            self.assertTrue(dtMx[bitname] == bitval,
+                            "ZWARN bit value mismatch for {}".format(bitname))
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -191,6 +191,7 @@ class TestMTL(unittest.TestCase):
             self.assertTrue(dtMx[bitname] == bitval,
                             "ZWARN bit value mismatch for {}".format(bitname))
 
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/py/desitarget/uratmatch.py
+++ b/py/desitarget/uratmatch.py
@@ -128,7 +128,6 @@ def scrape_urat(url="http://cdsarc.u-strasbg.fr/ftp/I/329/URAT1/v12/",
     for nfile, fileinfo in enumerate(filelist):
         # ADM make the wget command to retrieve the file and issue it.
         cmd = 'wget -q {} -P {}'.format(os.path.join(url, fileinfo), bindir)
-        print(cmd)
         os.system(cmd)
         if nfile % 25 == 0 or test:
             elapsed = time() - start


### PR DESCRIPTION
This PR incorporates a couple of useful features to help MTL functionality. It:

- Removes any checks of the data model in `mtl.inflate_ledger()`. This translates to a significant speed-up, which approaches 50x in many use cases.
- Adds a unit test to check the `desitarget` `ZWARN` bit-mask agrees with the `redrock` version. 
  * This should prevent `desitarget` from neglecting any changes made to `ZWARN` in `redrock`.