### PR TITLE
Fix new ZWARN bit-mask unit test.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,13 @@ desitarget Change Log
 0.57.2 (unreleased)
 -------------------
 
+* Fix new ``ZWARN`` unit test from `PR #710`_ [`PR #711`_].
 * General improvements to MTL functionality [`PR #710`_]. Includes:
    * Significant speed-up of :func:`mtl.inflate_ledger()`.
    * Unit test to compare the desitarget ``ZWARN`` bit-mask to redrock.
 
 .. _`PR #710`: https://github.com/desihub/desitarget/pull/710
+.. _`PR #711`: https://github.com/desihub/desitarget/pull/711
 
 0.57.1 (2021-04-07)
 -------------------

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -197,12 +197,15 @@ class TestMTL(unittest.TestCase):
         from desitarget.targetmask import zwarn_mask as dtMx
         dtbitnames = dtMx.names()
         for (bitname, bitval) in rrMx.flags():
-            # ADM check bit-names are consistent.
-            self.assertTrue(bitname in dtbitnames,
-                            "missing ZWARN bit {} from redrock".format(bitname))
-            # ADM check bit-values are consistent.
-            self.assertTrue(dtMx[bitname] == bitval,
-                            "ZWARN bit value mismatch for {}".format(bitname))
+            if "RESERVED" not in bitname:
+                # ADM check bit-names are consistent.
+                self.assertTrue(bitname in dtbitnames,
+                                "missing ZWARN bit {} from redrock".format(
+                                    bitname))
+                # ADM check bit-values are consistent.
+                self.assertTrue(dtMx[bitname] == bitval,
+                                "ZWARN bit value mismatch for {}".format(
+                                    bitname))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes the `ZWARN` unit test that was added in #710.