### PR TITLE
Update data model of MTL ledgers for the Main Survey

### DIFF
--- a/bin/make_initial_mtl_ledger
+++ b/bin/make_initial_mtl_ledger
@@ -35,7 +35,7 @@ ap.add_argument("--numproc", type=int,
 ap.add_argument('--healpixels',
                 help="HEALPixels corresponding to `nside` (e.g. '6,9,57'). Only \
                 write the ledger for targets in these pixels, at the default    \
-                nside, which is [{}].format(mtlnside)",
+                nside, which is [{}]".format(mtlnside),
                 default=None)
 
 ns = ap.parse_args()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,7 @@ desitarget Change Log
    * Ensure ``TARGET_STATE`` is a long enough string for all states.
    * Allow new columns to be easily added to the zcat/MTL ledgers.
        * In preparation for SQUEzE, QuasarNET, etc.
+   * Don't assume first 500 fibermap rows are unique targets for a petal.
    * Simplify the data model for ToO ledgers and default to .ecsv format.
        * In preparation for committing ToO ledgers to svn.
 * Fix new ``ZWARN`` unit test from `PR #710`_ [`PR #711`_].

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,13 @@ desitarget Change Log
 0.57.2 (unreleased)
 -------------------
 
+* Update data model of MTL ledgers for the Main Survey [`PR #712`_]:
+   * Express the ``TIMESTAMP`` in strict ISO format.
+   * Ensure ``TARGET_STATE`` is a long enough string for all states.
+   * Allow new columns to be easily added to the zcat/MTL ledgers.
+       * In preparation for SQUEzE, QuasarNET, etc.
+   * Simplify the data model for ToO ledgers and default to .ecsv format.
+       * In preparation for committing ToO ledgers to svn.
 * Fix new ``ZWARN`` unit test from `PR #710`_ [`PR #711`_].
 * General improvements to MTL functionality [`PR #710`_]. Includes:
    * Significant speed-up of :func:`mtl.inflate_ledger()`.
@@ -12,6 +19,7 @@ desitarget Change Log
 
 .. _`PR #710`: https://github.com/desihub/desitarget/pull/710
 .. _`PR #711`: https://github.com/desihub/desitarget/pull/711
+.. _`PR #712`: https://github.com/desihub/desitarget/pull/712
 
 0.57.1 (2021-04-07)
 -------------------

--- a/py/desitarget/ToO.py
+++ b/py/desitarget/ToO.py
@@ -71,7 +71,7 @@ def get_filename(toodir=None, ender="ecsv", outname=False):
     tdir = get_too_dir(toodir)
 
     dr = release//1000
-    fn = io.find_target_files(tdir, flavor="ToO", ender=ender, nohp=True, dr=dr)
+    fn = io.find_target_files(tdir, flavor="ToO", ender="ecsv", nohp=True)
     # ADM change the name slightly to make this the "input" ledger.
 
     if outname:
@@ -79,7 +79,7 @@ def get_filename(toodir=None, ender="ecsv", outname=False):
     return fn.replace(".{}".format(ender), "-input.{}".format(ender))
 
 
-def _write_too_files(filename, data, ecsv=False):
+def _write_too_files(filename, data, ecsv=True):
     """Write ToO ledgers and files.
 
     Parameters
@@ -88,7 +88,7 @@ def _write_too_files(filename, data, ecsv=False):
         Full path to filename to which to write Targets of Opportunity.
     data : :class:`~numpy.ndarray` or `~astropy.table.Table`
         Table or array of Targets of Opportunity to write.
-    ecsv : :class:`bool`, optional, defaults to ``False``
+    ecsv : :class:`bool`, optional, defaults to ``True``
         If ``True`` then write as a .ecsv file, if ``False`` then write
         as a .fits file.
 
@@ -451,7 +451,7 @@ def finalize_too(inledger, survey="main"):
     return outdata
 
 
-def ledger_to_targets(toodir=None, survey="main", ecsv=False, outdir=None):
+def ledger_to_targets(toodir=None, survey="main", ecsv=True, outdir=None):
     """Convert a ToO ledger to a file of ToO targets.
 
     Parameters
@@ -464,7 +464,7 @@ def ledger_to_targets(toodir=None, survey="main", ecsv=False, outdir=None):
     toodir : :class:`str`, optional, defaults to ``None``
         The directory to treat as the Targets of Opportunity I/O directory.
         If ``None`` then look up from the $TOO_DIR environment variable.
-    ecsv : :class:`bool`, optional, defaults to ``False``
+    ecsv : :class:`bool`, optional, defaults to ``True``
         If ``True`` then write as a .ecsv file, if ``False`` then write
         as a .fits file.
     outdir : :class:`str`, optional, defaults to ``None``

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -159,7 +159,7 @@ obsmask:
     - [DONE,           2, "enough observations already obtained"]
     - [MORE_ZWARN,     3, "ambiguous redshift; need more observations"]
     - [MORE_ZGOOD,     4, "redshift known; need more observations"]
-    - [MORE_MIDZQSO,   8, "z > 0.7 QSO; more observations at very low priority"]
+    - [MORE_MIDZQSO,   8, "mid-z QSO; more observations at very low priority"]
     - [DONOTOBSERVE,  16, "Do not observe this target (possibly temporarily)"]
 
 #- Bits that can be set in TARGETID. See the schema at
@@ -207,21 +207,21 @@ priorities:
 # ADM safest to set MORE_ZGOOD for ELGs/LRGs to DONE PROVIDED they have NUMOBS=1 as
 # ADM they can match QSO targets that require multiple observations and trump those
 # ADM QSOs with a higher priority. There is a unit test to check NUMOBS=1 for ELGs/LRGs.
-        ELG: {UNOBS: 3000, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        LRG: {UNOBS: 3200, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        ELG: {UNOBS: 3000, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        LRG: {UNOBS: 3200, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 # ADM The MORE_MIDZQSO priority is driven by secondary programs from Gontcho a Gontcho (1.4 < z < 2.1)
 # ADM and Weiner et al. (0.7 < z < 2.1) to reobserve confirmed quasars where possible. The priority
 # ADM of 100 should only be higher than DONE (and secondary filler) targets.
         QSO: {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, MORE_MIDZQSO: 100, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
         # ADM don't prioritize a N/S target if it doesn't have other bits set
-        LRG_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
+        LRG_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         QSO_HIZ: SAME_AS_LRG_NORTH
         ELG_NORTH: SAME_AS_LRG_NORTH
         QSO_NORTH: SAME_AS_LRG_NORTH
         LRG_SOUTH: SAME_AS_LRG_NORTH
         ELG_SOUTH: SAME_AS_LRG_NORTH
         QSO_SOUTH: SAME_AS_LRG_NORTH
-        BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0}
+        BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, MORE_MIDZQSO: 0}
         #- Standards and sky are treated specially; priorities don't apply
         STD_FAINT:  -1
         STD_WD:     -1
@@ -244,12 +244,12 @@ priorities:
     # ADM reserve 2998 for MWS_WD (ensuring a priority below Dark Survey targets, just in case)
     #- reobserving successes has lower priority than MWS
     bgs_mask:
-        BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BGS_BRIGHT: {UNOBS: 2100, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BGS_WISE: {UNOBS: 2000, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BGS_FAINT_HIP: {UNOBS: 2100, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BGS_FAINT: {UNOBS: 2000, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BGS_BRIGHT: {UNOBS: 2100, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BGS_WISE: {UNOBS: 2000, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BGS_FAINT_HIP: {UNOBS: 2100, MORE_ZWARN: 2, MORE_ZGOOD: 1000, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         # ADM don't prioritize a N/S target if it doesn't have other bits set
-        BGS_FAINT_SOUTH: {UNOBS: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
+        BGS_FAINT_SOUTH: {UNOBS: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         BGS_FAINT_NORTH: SAME_AS_BGS_FAINT_SOUTH
         BGS_BRIGHT_SOUTH: SAME_AS_BGS_FAINT_SOUTH
         BGS_BRIGHT_NORTH: SAME_AS_BGS_FAINT_SOUTH
@@ -259,23 +259,23 @@ priorities:
     #- Milky Way Survey: priorities 1000-1999
     # ADM WDs should be prioritized above BGS at 2998
     mws_mask: 
-        MWS_BROAD:                    {UNOBS: 1400, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_WD:                       {UNOBS: 2998, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_NEARBY:                   {UNOBS: 1600, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        MWS_BHB:                      {UNOBS: 1550, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        MWS_BROAD:                    {UNOBS: 1400, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_WD:                       {UNOBS: 2998, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_NEARBY:                   {UNOBS: 1600, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_BHB:                      {UNOBS: 1550, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 
         # ADM don't prioritize a N/S target if it doesn't have other bits set
-        MWS_BROAD_NORTH:              {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0}
+        MWS_BROAD_NORTH:              {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         MWS_BROAD_SOUTH:              SAME_AS_MWS_BROAD_NORTH
-        MWS_MAIN_BLUE:                {UNOBS: 1500, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        MWS_MAIN_BLUE:                {UNOBS: 1500, MORE_ZWARN: 2, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         MWS_MAIN_BLUE_NORTH:          SAME_AS_MWS_BROAD_NORTH
         MWS_MAIN_BLUE_SOUTH:          SAME_AS_MWS_BROAD_NORTH
         MWS_MAIN_RED:                 SAME_AS_MWS_MAIN_BLUE
         MWS_MAIN_RED_NORTH:           SAME_AS_MWS_BROAD_NORTH
         MWS_MAIN_RED_SOUTH:           SAME_AS_MWS_BROAD_NORTH
-        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BACKUP_FAINT:                 {UNOBS: 8, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
+        BACKUP_BRIGHT:                {UNOBS: 9, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BACKUP_FAINT:                 {UNOBS: 8, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BACKUP_VERY_FAINT:            {UNOBS: 7, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         # ADM Standards are special; priorities don't apply.
         GAIA_STD_FAINT:  -1
         GAIA_STD_WD:  -1
@@ -284,10 +284,10 @@ priorities:
     # ADM secondary target priorities. Probably all have very low UNOBS...
     scnd_mask:
     # ADM ...except VETO, which is special and always takes precedence.
-        VETO:                   {UNOBS: 10000, DONE: 10000, OBS: 0, DONOTOBSERVE: 0}
-        DR16Q:                  {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
-        BRIGHT_TOO_LOP:         {UNOBS: 1000, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
-        BRIGHT_TOO_HIP:         {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0}
+        VETO:                   {UNOBS: 10000, DONE: 10000, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        DR16Q:                  {UNOBS: 10, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BRIGHT_TOO_LOP:         {UNOBS: 1000, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        BRIGHT_TOO_HIP:         {UNOBS: 9999, DONE:    2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         DARK_TOO_LOP:           SAME_AS_BRIGHT_TOO_LOP
         DARK_TOO_HIP:           SAME_AS_BRIGHT_TOO_HIP
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2492,7 +2492,10 @@ def read_mtl_ledger(filename, unique=True, isodate=None):
     if ".ecsv" in filename:
         # ADM infer the column names and types (for the dtype).
         # ADM (this snippet is much quicker than a Table read).
-        from desitarget.mtl import mtldatamodel as mtldm
+        from desitarget.mtl import mtldatamodel, survey_data_model
+        # ADM allow for the full set of possible columns.
+        mtldm = survey_data_model(mtldatamodel, survey="main")
+        # ADM the data model can differ depending on survey type.
         names, forms = [], []
         with open(filename) as f:
             for line in f:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2354,7 +2354,7 @@ def find_target_files(targdir, dr='X', flavor="targets", survey="main",
 
     # ADM the generic directory structure beneath $TARG_DIR or $MTL_DIR.
     fn = os.path.join(targdir, drstr, version, flavor)
-    if flavor == "mtl":
+    if flavor == "mtl" or flavor == "ToO":
         fn = targdir
 
     # ADM masks are a special case beneath $MASK_DIR.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -78,8 +78,8 @@ def survey_data_model(dm, survey='main'):
         `mtldatamodel`.
     survey : :class:`str`, optional, defaults to "main"
         Used to construct the right data model for an iteration of DESI.
-        Options are ``'main'`` and ``'svX``' (where X is 1, 2, 3 etc.)
-        for the main survey and different iterations of SV, respectively.
+        Options are ``'main'`` ``'cmx'``, ``'svX``' (for X of 1, 2, etc.)
+        for the main survey, commissioning and iterations of SV.
 
     Returns
     -------
@@ -88,7 +88,7 @@ def survey_data_model(dm, survey='main'):
         the passed `dm` with any columns from `msaddcols` added. If
         `survey` is sv-like, this will just be the input `dm`.
     """
-    if survey[:2] == 'sv':
+    if survey[:2] == 'sv' or survey == 'cmx':
         return dm
     elif survey == 'main':
         return np.array([],
@@ -105,9 +105,9 @@ def get_utc_date(survey="sv3"):
     Parameters
     ----------
     survey : :class:`str`, optional, defaults to "sv3"
-        Used to look up the correct ledger, in combination with `obscon`.
-        Options are ``'main'`` and ``'svX``' (where X is 1, 2, 3 etc.)
-        for the main survey and different iterations of SV, respectively.
+        Used to construct the right ISO format for an iteration of DESI.
+        Options are ``'main'`` ``'cmx'``, ``'svX``' (for X of 1, 2, etc.)
+        for the main survey, commissioning and iterations of SV.
 
     Returns
     -------
@@ -121,7 +121,7 @@ def get_utc_date(survey="sv3"):
     - The `survey` input defaults to `"sv3"` for backwards compatibility
       (we became stricter about the format for the main survey).
     """
-    if survey[:2] == 'sv':
+    if survey[:2] == 'sv' or survey == 'cmx':
         return datetime.utcnow().isoformat(timespec='seconds')
     elif survey == 'main':
         return get_utc_iso_date()

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -73,7 +73,7 @@ def survey_data_model(dm, survey='main'):
 
     Parameters
     ----------
-    dm :class:`~numpy.array`
+    dm : :class:`~numpy.array`
         A data model related to MTL. Typically one of `zcatdatamodel` or
         `mtldatamodel`.
     survey : :class:`str`, optional, defaults to "main"

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -395,7 +395,9 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
         ztargets['Z'] = -1 * np.ones(n, dtype=np.float32)
         ztargets['ZWARN'] = -1 * np.ones(n, dtype=np.int32)
         # ADM a catch all for added zcat columns.
-        xtracols = ['ZTILEID'] + list(msaddcols.dtype.names)
+        xtracols = ['ZTILEID']
+        if survey == 'main':
+            xtracols += list(msaddcols.dtype.names)
         for xtracol in xtracols:
             ztargets[xtracol] = -1 * np.ones(n, dtype=np.int32)
         # ADM if zcat wasn't passed, there is a one-to-one correspondence
@@ -488,7 +490,9 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
         mtl[col][zmatcher] = ztargets[col]
     # ADM add ZTILEID, other columns, if passed, otherwise we're likely
     # ADM to be working with non-ledger-based mocks and can let it slide.
-    xtracols = ['ZTILEID'] + list(msaddcols.dtype.names)
+    xtracols = ['ZTILEID']
+    if survey == "main":
+        xtracols += list(msaddcols.dtype.names)
     for xtracol in xtracols:
         if xtracol in ztargets.dtype.names:
             mtl[xtracol][zmatcher] = ztargets[xtracol]

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -3,6 +3,8 @@ desitarget.mtl
 ==============
 
 Merged target lists.
+
+.. _`STRICT ISO format`: https://stackoverflow.com/a/55157458
 """
 
 import os
@@ -74,7 +76,7 @@ def get_utc_date(survey="sv3"):
     Returns
     -------
     :class:`str`
-        The UTC data, appropriate to make a TIMESTAMP.
+        The UTC date, appropriate for making a TIMESTAMP.
 
     Notes
     -----
@@ -99,7 +101,7 @@ def get_utc_iso_date():
     Returns
     -------
     :class:`str`
-        The UTC data in STRICT ISO format, appropriate for a TIMESTAMP.
+        UTC date in `STRICT ISO format`_, appropriate for a TIMESTAMP.
     """
     return datetime.now(tz=timezone.utc).isoformat(timespec='seconds')
 
@@ -427,7 +429,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
     mtl['PRIORITY'] = mtl['PRIORITY_INIT']
     mtl['TARGET_STATE'] = "UNOBS"
     # ADM add the time and version of the desitarget code that was run.
-    mtl["TIMESTAMP"] = get_utc_date()
+    mtl["TIMESTAMP"] = get_utc_date(survey=survey)
     mtl["VERSION"] = dt_version
 
     # ADM now populate the new mtl columns with the updated information.
@@ -944,7 +946,7 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey):
     newtiles = np.zeros(len(tiles), dtype=mtltilefiledm.dtype)
     newtiles["TILEID"] = tiles["TILEID"]
     # ADM look up the time.
-    newtiles["TIMESTAMP"] = get_utc_date()
+    newtiles["TIMESTAMP"] = get_utc_date(survey=survey)
     # ADM add the version of desitarget.
     newtiles["VERSION"] = dt_version
     # ADM add the program/obscon.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -14,7 +14,7 @@ from astropy.table import Table
 from astropy.io import ascii
 import fitsio
 from time import time
-from datetime import datetime
+from datetime import datetime, timezone
 from glob import glob, iglob
 
 from . import __version__ as dt_version
@@ -61,8 +61,15 @@ mtltilefiledm = np.array([], dtype=[
 mtlformatdict = {"PARALLAX": '%16.8f', 'PMRA': '%16.8f', 'PMDEC': '%16.8f'}
 
 
-def get_utc_date():
+def get_utc_date(survey="sv3"):
     """Convenience function to grab the UTC date.
+
+    Parameters
+    ----------
+    survey : :class:`str`, optional, defaults to "sv3"
+        Used to look up the correct ledger, in combination with `obscon`.
+        Options are ``'main'`` and ``'svX``' (where X is 1, 2, 3 etc.)
+        for the main survey and different iterations of SV, respectively.
 
     Returns
     -------
@@ -73,8 +80,28 @@ def get_utc_date():
     -----
     - This is spun off into its own function to have a consistent way to
       record time across the entire desitarget package.
+    - The `survey` input defaults to `"sv3"` for backwards compatibility
+      (we became stricter about the format for the main survey).
     """
-    return datetime.utcnow().isoformat(timespec='seconds')
+    if survey[:2] == 'sv':
+        return datetime.utcnow().isoformat(timespec='seconds')
+    elif survey == 'main':
+        return get_utc_iso_date()
+    else:
+        msg = "Allowed 'survey' inputs are sv(X) or main, not {}".format(survey)
+        log.critical(msg)
+        raise ValueError(msg)
+
+
+def get_utc_iso_date():
+    """Convenience function to grab the UTC date in STRICT ISO format.
+
+    Returns
+    -------
+    :class:`str`
+        The UTC data in STRICT ISO format, appropriate for a TIMESTAMP.
+    """
+    return datetime.now(tz=timezone.utc).isoformat(timespec='seconds')
 
 
 def get_mtl_dir(mtldir=None):

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1051,9 +1051,12 @@ def make_zcat_rr_backstop(zcatdir, tiles, obscon, survey):
         for zbestfn in zbestfns:
             zz = fitsio.read(zbestfn, "ZBEST")
             allzs.append(zz)
-            # ADM only read in the first set of exposures.
-            fm = fitsio.read(zbestfn, "FIBERMAP", rows=np.arange(len(zz)))
-            allfms.append(fm)
+            # ADM read in all of the exposures in the fibermap.
+            fm = fitsio.read(zbestfn, "FIBERMAP")
+            # ADM recover the information for unique targets based on the
+            # ADM first entry for each TARGETID.
+            _, ii = np.unique(fm['TARGETID'], return_index=True)
+            allfms.append(fm[ii])
             # ADM check the correct TILEID was written in the fibermap.
             if set(fm["TILEID"]) != set([tile["TILEID"]]):
                 msg = "Directory and fibermap don't match for tile".format(tile)

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -21,7 +21,7 @@ from astropy.table import Table, join
 
 from desitarget.targetmask import desi_mask as Mx
 from desitarget.targetmask import bgs_mask, obsconditions
-from desitarget.mtl import make_mtl, mtldatamodel, msaddcols, survey_data_model
+from desitarget.mtl import make_mtl, mtldatamodel, survey_data_model
 from desitarget.targets import initial_priority_numobs, main_cmx_or_sv
 from desitarget.targets import switch_main_cmx_or_sv
 

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -21,7 +21,7 @@ from astropy.table import Table, join
 
 from desitarget.targetmask import desi_mask as Mx
 from desitarget.targetmask import bgs_mask, obsconditions
-from desitarget.mtl import make_mtl, mtldatamodel
+from desitarget.mtl import make_mtl, mtldatamodel, msaddcols, survey_data_model
 from desitarget.targets import initial_priority_numobs, main_cmx_or_sv
 from desitarget.targets import switch_main_cmx_or_sv
 
@@ -62,6 +62,17 @@ class TestMTL(unittest.TestCase):
         self.zcat['SPECTYPE'] = ['QSO', 'QSO', 'QSO', 'GALAXY', 'GALAXY']
         self.zcat['ZTILEID'] = [-1, -1, -1, -1, -1]
 
+    def update_data_model(self, cat):
+        """Catalogs have a different data model for the Main Survey.
+        """
+        _, _, survey = main_cmx_or_sv(cat)
+        truedm = survey_data_model(cat, survey=survey)
+        addedcols = list(set(truedm.dtype.names) - set(cat.dtype.names))
+        for col in addedcols:
+            cat[col] = [-1] * len(cat)
+
+        return cat
+
     def reset_targets(self, prefix):
         """Add prefix to TARGET columns"""
 
@@ -85,8 +96,11 @@ class TestMTL(unittest.TestCase):
         # ADM loop through once each for the main survey, commissioning and SV.
         for prefix in ["", "CMX_", "SV1_"]:
             t = self.reset_targets(prefix)
+            t = self.update_data_model(t)
             mtl = make_mtl(t, "BRIGHT|GRAY|DARK", trimcols=True)
             mtldm = switch_main_cmx_or_sv(mtldatamodel, mtl)
+            _, _, survey = main_cmx_or_sv(mtldm)
+            mtldm = survey_data_model(mtldm, survey=survey)
             refnames = sorted(mtldm.dtype.names)
             mtlnames = sorted(mtl.dtype.names)
             self.assertEqual(refnames, mtlnames)
@@ -97,6 +111,7 @@ class TestMTL(unittest.TestCase):
         # ADM loop through once for SV and once for the main survey.
         for prefix in ["", "SV1_"]:
             t = self.reset_targets(prefix)
+            t = self.update_data_model(t)
             mtl = make_mtl(t, "GRAY|DARK")
             mtl.sort(keys='TARGETID')
             self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [1, 1, 4, 4, 4, 1]))
@@ -112,7 +127,9 @@ class TestMTL(unittest.TestCase):
         # ADM loop through once for SV and once for the main survey.
         for prefix in ["", "SV1_"]:
             t = self.reset_targets(prefix)
-            mtl = make_mtl(t, "DARK|GRAY", zcat=self.zcat, trim=False)
+            t = self.update_data_model(t)
+            zcat = self.update_data_model(self.zcat.copy())
+            mtl = make_mtl(t, "DARK|GRAY", zcat=zcat, trim=False)
             mtl.sort(keys='TARGETID')
             pp = self.post_prio.copy()
             nom = [0, 0, 0, 3, 3, 1]
@@ -123,7 +140,8 @@ class TestMTL(unittest.TestCase):
             self.assertTrue(np.all(mtl['NUMOBS_MORE'] == nom))
             # - change one target to a SAFE (BADSKY) target and confirm priority=0 not 1
             t[prefix+'DESI_TARGET'][0] = Mx.BAD_SKY
-            mtl = make_mtl(t, "DARK|GRAY", zcat=self.zcat, trim=False)
+            zcat = self.update_data_model(self.zcat.copy())
+            mtl = make_mtl(t, "DARK|GRAY", zcat=zcat, trim=False)
             mtl.sort(keys='TARGETID')
             self.assertEqual(mtl['PRIORITY'][0], 0)
 
@@ -133,7 +151,9 @@ class TestMTL(unittest.TestCase):
         # ADM loop through once for SV and once for the main survey.
         for prefix in ["", "SV1_"]:
             t = self.reset_targets(prefix)
-            mtl = make_mtl(t, "BRIGHT", zcat=self.zcat, trim=True)
+            t = self.update_data_model(t)
+            zcat = self.update_data_model(self.zcat.copy())
+            mtl = make_mtl(t, "BRIGHT", zcat=zcat, trim=True)
             testfile = 'test-aszqweladfqwezceas.fits'
             mtl.write(testfile, overwrite=True)
             x = mtl.read(testfile)
@@ -152,7 +172,7 @@ class TestMTL(unittest.TestCase):
         qtargets["DESI_TARGET"] |= Mx["QSO"]
 
         # ADM give them all a "tracer" redshift (below a mid-z QSO).
-        qzcat = self.zcat.copy()
+        qzcat = self.update_data_model(self.zcat.copy())
         qzcat["Z"] = 0.5
 
         # ADM set their initial conditions to be that of a QSO.
@@ -181,7 +201,7 @@ class TestMTL(unittest.TestCase):
         bgstargets["NUMOBS_INIT"] = ninit
 
         # ADM create a copy of the zcat.
-        bgszcat = self.zcat.copy()
+        bgszcat = self.update_data_model(self.zcat.copy())
 
         # ADM run through MTL.
         mtl = make_mtl(bgstargets, obscon="BRIGHT", zcat=bgszcat)

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -15,6 +15,7 @@ from desitarget.mtl import make_mtl, mtldatamodel, survey_data_model
 from desiutil.log import get_logger
 log = get_logger()
 
+
 class TestPriorities(unittest.TestCase):
 
     def setUp(self):

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -12,6 +12,8 @@ from desitarget.targets import calc_priority, main_cmx_or_sv
 from desitarget.targets import initial_priority_numobs
 from desitarget.mtl import make_mtl, mtldatamodel
 
+from desiutil.log import get_logger
+log = get_logger()
 
 class TestPriorities(unittest.TestCase):
 
@@ -250,6 +252,27 @@ class TestPriorities(unittest.TestCase):
                                        "ZGOOD <= ZWARN for {}".format(b))
                     self.assertGreater(zwarn, done,
                                        "ZWARN <= DONE for {}".format(b))
+
+    def test_target_state_length(self):
+        """Test TARGET_STATE string is long enough for every bit-state.
+        """
+        # ADM this just recovers the length of the TARGET_STATE string.
+        splitter = mtldatamodel["TARGET_STATE"].dtype.char
+        tslen = int(mtldatamodel["TARGET_STATE"].dtype.str.split(splitter)[-1])
+        log.info("TARGET_STATE can hold strings with lengths up to {}".format(
+            tslen))
+        msg = "Length of TARGET_STATE string insufficient to hold: {}"
+
+        # ADM loop through the bit-names.
+        for bn in desi_mask.names():
+            if "SKY" not in bn:
+                # ADM loop through defined priority states.
+                for pn in desi_mask[bn].priorities:
+                    if desi_mask[bn].priorities[pn] > 0:
+                        # ADM the length of each target state string.
+                        ts = "|".join([bn, pn])
+                        # ADM check the length is sufficient.
+                        self.assertGreaterEqual(tslen, len(ts), msg.format(ts))
 
     def test_cmx_priorities(self):
         """Test that priority calculation can handle commissioning files.

--- a/py/desitarget/test/test_qa.py
+++ b/py/desitarget/test/test_qa.py
@@ -10,9 +10,11 @@ import warnings
 import numpy as np
 import healpy as hp
 from pkg_resources import resource_filename
+from glob import glob
 from desitarget.QA import make_qa_page, _load_systematics
 from desitarget.QA import _parse_tcnames, _in_desi_footprint
-from glob import glob
+from desiutil.log import get_logger
+log = get_logger()
 
 
 class TestQA(unittest.TestCase):
@@ -26,7 +28,7 @@ class TestQA(unittest.TestCase):
         cls.pixmapfile = os.path.join(cls.datadir, 'pixweight.fits')
         cls.origdir = os.getcwd()
         cls.testdir = tempfile.mkdtemp()
-        print("working in {}...".format(cls.testdir))
+        log.info("working in {}...".format(cls.testdir))
         os.chdir(cls.testdir)
 
     @classmethod

--- a/py/desitarget/test/test_skyfibers.py
+++ b/py/desitarget/test/test_skyfibers.py
@@ -6,13 +6,16 @@ import unittest
 from pkg_resources import resource_filename
 import numpy as np
 
+from glob import glob
+from os.path import basename
+
 from desitarget import skyfibers
 from desitarget.targetmask import desi_mask
 
 from desitarget.skyutilities.legacypipe.util import LegacySurveyData
 
-from glob import glob
-from os.path import basename
+from desiutil.log import get_logger
+log = get_logger()
 
 
 class TestSKYFIBERS(unittest.TestCase):
@@ -32,10 +35,11 @@ class TestSKYFIBERS(unittest.TestCase):
         self.brickname = bricknames[0]
 
         if self.brickname != '0959p805':
-            print("brick name is {} not '0959p805'".format(brickname))
-            print("'0959p805' was chosen to as it has good g-band")
-            print("images and is relatively small")
-            raise ValueError
+            msg = "brick name is {} not '0959p805'".format(brickname)
+            msg += " '0959p805' was chosen for unit tests as it has"
+            msg += " good g-band images and is relatively small"
+            log.critical(msg)
+            raise ValueError(msg)
 
         # ADM generate a handful (~4) sky locations.
         brickarea = 0.25*0.25


### PR DESCRIPTION
This PR updates the data model for the MTL ledgers in preparation for the Main Survey:

- The `TIMESTAMP` column should now always be expressed in strict ISO format.
- The `TARGET_STATE` should now always be a sufficiently long string to encapsulate all possible states.
  * A unit test has been added to check this.
- The framework is now in place to allow new columns to be easily added to the `zcat` or the MTL ledgers.
  * This is with a view to incorporating `SQUEzE`, `QuasarNET`, etc.
- The code that matches targets to redshifts now no longer assumes that the first 500 rows in the fibermap correspond to the unique targets in one exposure.
  * The first 500 rows may eventually not correspond to a single exposure. Particularly if we move to deriving redshifts across overlapping tiles.
- The directory structure for the ToO ledgers has been simplified, and the default is now to write them in `.ecsv` format.
  * This should make it easier to commit the ToO ledgers to svn, which has become the standard Operations workflow.
