### PR TITLE
Add EDR3 options to the code that writes the Gaia-matched sweeps

### DIFF
--- a/bin/select_targets
+++ b/bin/select_targets
@@ -40,8 +40,8 @@ ap.add_argument('-m', "--mask",
                 help="If sent then mask the targets, the name of the mask file should be supplied")
 ap.add_argument('--qsoselection', choices=qso_selection_options, default='randomforest',
                 help="QSO target selection method")
-ap.add_argument("--gaiamatch", action='store_true',
-                help="DO match to Gaia DR2 chunks files in order to populate Gaia columns for MWS/STD selection")
+ap.add_argument("--gaiasub", action='store_true',
+                help="Substitute Gaia EDR3 proper motions and parallaxes in place of the sweeps (DR2) values. Only valid for DR9 sweeps files.")
 ap.add_argument("--numproc", type=int,
                 help='number of concurrent processes to use [defaults to {}]'.format(nproc),
                 default=nproc)
@@ -147,7 +147,7 @@ tcnames = _parse_tcnames(tcstring=ns.tcnames, add_all=False)
 
 targets, infn = select_targets(
     infiles, numproc=ns.numproc, qso_selection=ns.qsoselection,
-    gaiamatch=ns.gaiamatch, nside=ns.nside, pixlist=pixlist, extra=extra,
+    gaiasub=ns.gaiasub, nside=ns.nside, pixlist=pixlist, extra=extra,
     bundlefiles=ns.bundlefiles, radecbox=inlists[0], radecrad=inlists[1],
     tcnames=tcnames, survey='main', backup=not(ns.nobackup),
     resolvetargs=not(ns.noresolve), mask=not(ns.nomaskbits), return_infiles=True
@@ -195,8 +195,8 @@ if ns.bundlefiles is None:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
     # ADM extra header keywords for the output fits file.
-    extra = {k: v for k, v in zip(["tcnames"],
-                                  [ns.tcnames])}
+    extra = {k: v for k, v in zip(["tcnames", "gaiasub"],
+                                  [ns.tcnames, ns.gaiasub])}
 
     # ADM differentiate the Gaia-only and Legacy Surveys targets.
     _, _, _, _, _, gaiadr = decode_targetid(targets["TARGETID"])

--- a/bin/write_gaia_matches
+++ b/bin/write_gaia_matches
@@ -10,20 +10,40 @@ start = time()
 #warnings.simplefilter('error')
 
 import multiprocessing
-nproc = multiprocessing.cpu_count() // 2
+nproc = multiprocessing.cpu_count() // 5
 
 from desiutil.log import get_logger
 log = get_logger()
 
+# ADM the default matching radius in arcseconds.
+matchrad = 0.2
+# ADM the default Gaia data release.
+dr = "edr3"
+
 from argparse import ArgumentParser
-ap = ArgumentParser(description='Match sweeps files to Gaia and rewrite files with the Gaia columns added')
+ap = ArgumentParser(
+    description='Match sweeps files to Gaia and write matched files \
+    ($GAIA_DIR must be set and point to the Gaia DR2 files)'
+)
 ap.add_argument("src", 
                 help="Sweeps file or root directory with sweeps files")
 ap.add_argument("dest", 
                 help="Output directory")
 ap.add_argument("--numproc", type=int,
-                help='number of concurrent processes to use [{}]'.format(nproc),
+                help='number of concurrent processes [defaults to {}]'.format(
+                    nproc),
                 default=nproc)
+ap.add_argument("--matchrad", type=float,
+                help='matching radius [defaults to {}]'.format(matchrad),
+                default=matchrad)
+ap.add_argument("--dr",
+                help='Gaia data release [defaults to {}]'.format(dr),
+                default=dr)
+ap.add_argument("--include", action='store_true',
+                help='Include all the sweeps-file columns in the output files')
+ap.add_argument("--mopup", action='store_true',
+                help="Only generate files that aren't already in dest")
+
 
 ns = ap.parse_args()
 infiles = io.list_sweepfiles(ns.src)
@@ -31,9 +51,23 @@ if len(infiles) == 0:
     log.critical('no sweep files found')
     sys.exit(1)
 
+# ADM if requested, only process missing files.
+if ns.mopup:
+    # ADM the files that already appear in the dest directory.
+    donefns = io.list_sweepfiles(ns.dest)
+    log.info("{}/{} files already generated in {}".format(
+        len(donefns), len(infiles), ns.dest))
+    # ADM decode to just the edges of the already-generated files.
+    radecs = [io.decode_sweep_name(fn) for fn in donefns]
+    # ADM check if a corresponding file exists for each infile.
+    infiles = [fn for fn in infiles if io.decode_sweep_name(fn) not in radecs]
+    log.info("Generating remaining {} files".format(len(infiles)))
+
 log.info("running on {} processors".format(ns.numproc))
 
-write_gaia_matches(infiles, numproc=ns.numproc, outdir=ns.dest)
+write_gaia_matches(infiles, numproc=ns.numproc, outdir=ns.dest,
+                   matchrad=ns.matchrad, dr=ns.dr, include=ns.include)
 
-log.info('Wrote sweeps files matched to Gaia to {}...t={:.1f}s'.format(ns.dest, time()-start))
+log.info('Wrote sweeps files matched to Gaia to {}...t={:.1f}s'.format(
+    ns.dest, time()-start))
 

--- a/bin/write_gaia_matches
+++ b/bin/write_gaia_matches
@@ -39,8 +39,8 @@ ap.add_argument("--matchrad", type=float,
 ap.add_argument("--dr",
                 help='Gaia data release [defaults to {}]'.format(dr),
                 default=dr)
-ap.add_argument("--include", action='store_true',
-                help='Include all the sweeps-file columns in the output files')
+ap.add_argument("--merge", action='store_true',
+                help='merge Gaia and sweeps columns in the output files')
 ap.add_argument("--mopup", action='store_true',
                 help="Only generate files that aren't already in dest")
 
@@ -66,7 +66,7 @@ if ns.mopup:
 log.info("running on {} processors".format(ns.numproc))
 
 write_gaia_matches(infiles, numproc=ns.numproc, outdir=ns.dest,
-                   matchrad=ns.matchrad, dr=ns.dr, include=ns.include)
+                   matchrad=ns.matchrad, dr=ns.dr, merge=ns.merge)
 
 log.info('Wrote sweeps files matched to Gaia to {}...t={:.1f}s'.format(
     ns.dest, time()-start))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,8 @@ desitarget Change Log
 -------------------
 
 * Add EDR3 options to code that writes Gaia-matched sweeps [`PR #715`_].
+* New function and bin script to make a redshift catalog [`PR #714`_]
+   * Incorporates functionality from QuasarNET and SQUEzE.
 * Update data model of MTL ledgers for the Main Survey [`PR #712`_]:
    * Express the ``TIMESTAMP`` in strict ISO format.
    * Ensure ``TARGET_STATE`` is a long enough string for all states.
@@ -22,6 +24,7 @@ desitarget Change Log
 .. _`PR #710`: https://github.com/desihub/desitarget/pull/710
 .. _`PR #711`: https://github.com/desihub/desitarget/pull/711
 .. _`PR #712`: https://github.com/desihub/desitarget/pull/712
+.. _`PR #714`: https://github.com/desihub/desitarget/pull/714
 .. _`PR #715`: https://github.com/desihub/desitarget/pull/715
 
 0.57.1 (2021-04-07)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,8 @@ desitarget Change Log
 -------------------
 
 * Add EDR3 options to code that writes Gaia-matched sweeps [`PR #715`_].
+   * Also add ``gaiasub`` functionality when selecting targets.
+   * Swaps EDR3 proper motions/parallaxes for values in sweeps files.
 * New function and bin script to make a redshift catalog [`PR #714`_]
    * Incorporates functionality from QuasarNET and SQUEzE.
 * Update data model of MTL ledgers for the Main Survey [`PR #712`_]:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.57.2 (unreleased)
 -------------------
 
+* Add EDR3 options to code that writes Gaia-matched sweeps [`PR #715`_].
 * Update data model of MTL ledgers for the Main Survey [`PR #712`_]:
    * Express the ``TIMESTAMP`` in strict ISO format.
    * Ensure ``TARGET_STATE`` is a long enough string for all states.
@@ -21,6 +22,7 @@ desitarget Change Log
 .. _`PR #710`: https://github.com/desihub/desitarget/pull/710
 .. _`PR #711`: https://github.com/desihub/desitarget/pull/711
 .. _`PR #712`: https://github.com/desihub/desitarget/pull/712
+.. _`PR #715`: https://github.com/desihub/desitarget/pull/715
 
 0.57.1 (2021-04-07)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2537,7 +2537,7 @@ def apply_cuts_gaia(numproc=4, survey='main', nside=None, pixlist=None,
     return desi_target, bgs_target, mws_target, gaiaobjs
 
 
-def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
+def apply_cuts(objects, qso_selection='randomforest',
                tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD"],
                qso_optical_cuts=False, survey='main', resolvetargs=True,
                mask=True):
@@ -2551,9 +2551,6 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
     qso_selection : :class:`str`, optional, defaults to ``'randomforest'``
         The algorithm to use for QSO selection; valid options are
         ``'colorcuts'`` and ``'randomforest'``
-    gaiamatch : :class:`boolean`, optional, defaults to ``False``
-        If ``True``, match to Gaia DR2 chunks files and populate Gaia columns
-        to facilitate the MWS and STD selections.
     tcnames : :class:`list`, defaults to running all target classes
         A list of strings, e.g. ['QSO','LRG']. If passed, process targeting only
         for those specific target classes. A useful speed-up when testing.
@@ -2589,28 +2586,6 @@ def apply_cuts(objects, qso_selection='randomforest', gaiamatch=False,
     # - Check if objects is a filename instead of the actual data
     if isinstance(objects, str):
         objects = io.read_tractor(objects)
-
-    # ADM add Gaia information, if requested, and if we're going to actually
-    # ADM process the target classes that need Gaia columns
-    if gaiamatch and ("MWS" in tcnames or "STD" in tcnames):
-        log.info('Matching Gaia to {} primary objects...t = {:.1f}s'
-                 .format(len(objects), time()-start))
-        gaiainfo = match_gaia_to_primary(objects)
-        log.info('Done with Gaia match for {} primary objects...t = {:.1f}s'
-                 .format(len(objects), time()-start))
-        # ADM remove the GAIA_RA, GAIA_DEC columns as they aren't
-        # ADM in the imaging surveys data model.
-        gaiainfo = pop_gaia_coords(gaiainfo)
-        # ADM if we need to match to Gaia, stick to the first Gaia data model
-        # ADM that we adopted for DR7.
-        gaiainfo = pop_gaia_columns(
-            gaiainfo,
-            ['REF_CAT', 'GAIA_PHOT_BP_RP_EXCESS_FACTOR',
-             'GAIA_ASTROMETRIC_SIGMA5D_MAX', 'GAIA_ASTROMETRIC_PARAMS_SOLVED']
-        )
-        # ADM add the Gaia column information to the primary array.
-        for col in gaiainfo.dtype.names:
-            objects[col] = gaiainfo[col]
 
     # - ensure uppercase column names if astropy Table.
     if isinstance(objects, (Table, Row)):
@@ -2695,8 +2670,9 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         The algorithm to use for QSO selection; valid options are
         ``'colorcuts'`` and ``'randomforest'``.
     gaiamatch : :class:`boolean`, optional, defaults to ``False``
-        If ``True``, match to Gaia DR2 chunks files and populate Gaia columns
-        to facilitate the MWS and STD selections.
+        If ``True``, substitute Gaia EDR3 proper motion and parallax
+        columns over the sweeps values. If ``True``, then the GAIA_DIR
+        environment variable must be set to find the Gaia sweeps files.
     nside : :class:`int`, optional, defaults to `None`
         The (NESTED) HEALPixel nside to be used with the `pixlist` and `bundlefiles` inputs.
     pixlist : :class:`list` or `int`, optional, defaults to `None`
@@ -2858,9 +2834,8 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         '''Returns targets in filename that pass the cuts'''
         objects = io.read_tractor(filename)
         desi_target, bgs_target, mws_target = apply_cuts(
-            objects, qso_selection=qso_selection, gaiamatch=gaiamatch,
-            tcnames=tcnames, survey=survey, resolvetargs=resolvetargs,
-            mask=mask
+            objects, qso_selection=qso_selection, tcnames=tcnames,
+            survey=survey, resolvetargs=resolvetargs, mask=mask
         )
 
         return _finalize_targets(objects, desi_target, bgs_target, mws_target)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2653,7 +2653,7 @@ qso_selection_options = ['colorcuts', 'randomforest']
 
 
 def select_targets(infiles, numproc=4, qso_selection='randomforest',
-                   gaiamatch=False, nside=None, pixlist=None, bundlefiles=None,
+                   gaiasub=False, nside=None, pixlist=None, bundlefiles=None,
                    extra=None, radecbox=None, radecrad=None, mask=True,
                    tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD"],
                    survey='main', resolvetargs=True, backup=True,
@@ -2669,7 +2669,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
     qso_selection : :class:`str`, optional, defaults to ``'randomforest'``
         The algorithm to use for QSO selection; valid options are
         ``'colorcuts'`` and ``'randomforest'``.
-    gaiamatch : :class:`boolean`, optional, defaults to ``False``
+    gaiasub : :class:`boolean`, optional, defaults to ``False``
         If ``True``, substitute Gaia EDR3 proper motion and parallax
         columns over the sweeps values. If ``True``, then the GAIA_DIR
         environment variable must be set to find the Gaia sweeps files.
@@ -2832,7 +2832,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
     # - functions to run on every brick/sweep file
     def _select_targets_file(filename):
         '''Returns targets in filename that pass the cuts'''
-        objects = io.read_tractor(filename)
+        objects = io.read_tractor(filename, gaiasub=gaiasub)
         desi_target, bgs_target, mws_target = apply_cuts(
             objects, qso_selection=qso_selection, tcnames=tcnames,
             survey=survey, resolvetargs=resolvetargs, mask=mask

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -1369,9 +1369,11 @@ def write_gaia_matches(infiles, numproc=4, outdir=".", matchrad=0.2, dr="edr3",
     def _update_status(result):
         """wrapper function for the critical reduction operation,
         that occurs on the main parallel process"""
-        if nfile % 50 == 0 and nfile > 0:
-            rate = nfile / (time() - t0)
-            log.info('{}/{} files; {:.1f} files/sec'.format(nfile, nfiles, rate))
+        if nfile % 20 == 0 and nfile > 0:
+            elapsed = time() - t0
+            rate = elapsed / nfile
+            log.info('{}/{} files; {:.1f} secs/file; {:.1f} total mins elapsed'
+                     .format(nfile, nfiles, rate, elapsed/60.))
         nfile[...] += 1    # this is an in-place modification.
         return result
 

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -212,7 +212,8 @@ def sub_gaia_edr3(filename, objs=None):
 
     Notes
     -----
-        - The GAIA_DIR environment variable must be set.
+    - The GAIA_DIR environment variable must be set.
+    - The input `objs` will be altered (it it is not ``None``).
     """
     # ADM construct the GAIA sweep file location.
     ender = filename.split("dr9/")[-1].replace(".fits", '-gaiaedr3match.fits')

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -1326,7 +1326,7 @@ def write_gaia_matches(infiles, numproc=4, outdir=".", matchrad=0.2, dr="edr3",
                  .format(len(objs), time()-start))
 
         # ADM the extension name for the output file.
-        en = 'GAIA_SWEEP'
+        en = "GAIA_SWEEP"
         if include:
             # ADM if we are writing sweeps columns, remove GAIA_RA/DEC
             # ADM as they aren't in the imaging surveys data model.
@@ -1340,11 +1340,21 @@ def write_gaia_matches(infiles, numproc=4, outdir=".", matchrad=0.2, dr="edr3",
             # ADM add the Gaia column information to the sweeps array.
             for col in gaiainfo.dtype.names:
                 objs[col] = gaiainfo[col]
-            # ADM write out.
+            # ADM write out the file.
             fitsio.write(outfile, objs, extname=en, header=hdr, clobber=True)
         else:
-            # ADM otherwise we're just writing the gaiainfo.
-            fitsio.write(outfile, gaiainfo, extname=en, header=hdr, clobber=True)
+            # ADM we're just writing the gaiainfo. But, include object
+            # ADM identification information (RELEASE, BRICKID, OBJID).
+            outdm = [desc for desc in objs.dtype.descr if 'RELEASE' in desc[0]
+                     or 'BRICKID' in desc[0] or 'OBJID' in desc[0]]
+            outdm += gaiainfo.dtype.descr
+            outobjs = np.empty(len(objs), dtype=outdm)
+            for col in ['RELEASE', 'BRICKID', 'OBJID']:
+                outobjs[col] = objs[col]
+            for col in gaiainfo.dtype.names:
+                outobjs[col] = gaiainfo[col]
+            # ADM write out the file.
+            fitsio.write(outfile, outobjs, extname=en, header=hdr, clobber=True)
 
         return True
 

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -1207,7 +1207,7 @@ def match_gaia_to_primary_single(objs, matchrad=1.):
     return gaiainfo
 
 
-def write_gaia_matches(infiles, numproc=4, outdir="."):
+def write_gaia_matches(infiles, numproc=4, outdir=".", dr="edr3", include=False):
     """Match sweeps files to Gaia and rewrite with the Gaia columns added
 
     Parameters
@@ -1219,15 +1219,21 @@ def write_gaia_matches(infiles, numproc=4, outdir="."):
         The number of parallel processes to use.
     outdir : :class:`str`, optional, default to the current directory
         The directory to write the files.
+    dr : :class:`str`, optional, defaults to "edr3"
+        Name of a Gaia data release. Options are "dr2", "edr3"
+    include : :class:`bool`, optional, defaults to ``False``
+        If ``True``, include the original sweeps columns in the output
+        file. Otherwise, just include the Gaia columns.
 
     Returns
     -------
     :class:`~numpy.ndarray`
-        The original sweeps files with the columns in `gaiadatamodel`
-        added (except for the columns `GAIA_RA` and `GAIA_DEC`) are
-        written to file. The filename is the same as the input
-        filename with the ".fits" replaced by "-gaia$DRmatch.fits"
-        where $DR is extracted from the $GAIA_DIR environment variable.
+        Columns in `gaiadatamodel` or `edr3datamodel` that are matched to
+        the input sweeps files are added (if `include=True`) or returned
+        (if `include=False`) and written to file. Gaia `_RA` and `_DEC`
+        columns are not added if `include=True`. The filename is as for
+        the input filename with ".fits" replaced by "-gaia$DRmatch.fits"
+        where $DR corresponds to `dr`.
 
     Notes
     -----
@@ -1235,7 +1241,7 @@ def write_gaia_matches(infiles, numproc=4, outdir="."):
         - The environment variable $GAIA_DIR must be set.
     """
     # ADM check that the GAIA_DIR is set and retrieve it.
-    gaiadir = get_gaia_dir()
+    gaiadir = get_gaia_dir(dr)
 
     # ADM convert a single file, if passed to a list of files.
     if isinstance(infiles, str):
@@ -1248,13 +1254,7 @@ def write_gaia_matches(infiles, numproc=4, outdir="."):
 
     nfiles = len(infiles)
 
-    # ADM extract a reasonable name for output files from the Gaia directory.
-    drloc = gaiadir.find("dr")
-    # ADM if we didn't find the substring "dr" go generic.
-    if drloc == -1:
-        ender = '-gaiamatch.fits'
-    else:
-        ender = '-gaia{}match.fits'.format(gaiadir[drloc:drloc+3])
+    ender = '-gaia{}match.fits'.format(dr)
 
     # ADM the critical function to run on every file.
     def _get_gaia_matches(fnwdir):

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -1326,7 +1326,6 @@ def write_gaia_matches(infiles, numproc=4, outdir=".", matchrad=0.2, dr="edr3",
                  .format(len(objs), time()-start))
 
         # ADM the extension name for the output file.
-        en = "GAIA_SWEEP"
         if include:
             # ADM if we are writing sweeps columns, remove GAIA_RA/DEC
             # ADM as they aren't in the imaging surveys data model.
@@ -1340,8 +1339,9 @@ def write_gaia_matches(infiles, numproc=4, outdir=".", matchrad=0.2, dr="edr3",
             # ADM add the Gaia column information to the sweeps array.
             for col in gaiainfo.dtype.names:
                 objs[col] = gaiainfo[col]
-            # ADM write out the file.
-            fitsio.write(outfile, objs, extname=en, header=hdr, clobber=True)
+            # ADM write out the file, atomically.
+            fitsio.write(outfile+".tmp", objs,
+                         extname="GAIA_SWEEP", header=hdr, clobber=True)
         else:
             # ADM we're just writing the gaiainfo. But, include object
             # ADM identification information (RELEASE, BRICKID, OBJID).
@@ -1353,8 +1353,11 @@ def write_gaia_matches(infiles, numproc=4, outdir=".", matchrad=0.2, dr="edr3",
                 outobjs[col] = objs[col]
             for col in gaiainfo.dtype.names:
                 outobjs[col] = gaiainfo[col]
-            # ADM write out the file.
-            fitsio.write(outfile, outobjs, extname=en, header=hdr, clobber=True)
+            # ADM write out the file, atomically.
+            fitsio.write(outfile+".tmp", outobjs,
+                         extname="GAIA_SWEEP", header=hdr, clobber=True)
+        # ADM rename the atomically written file.
+        os.rename(outfile+'.tmp', outfile)
 
         return True
 

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -19,9 +19,10 @@ import pickle
 from glob import glob
 from time import time
 import healpy as hp
-from os.path import basename
+from . import __version__ as desitarget_version
+from desiutil import depend
 from desitarget import io
-from desitarget.io import check_fitsio_version
+from desitarget.io import check_fitsio_version, gitversion
 from desitarget.internal import sharedmem
 from desitarget.geomask import hp_in_box, add_hp_neighbors, pixarea2nside
 from desitarget.geomask import hp_beyond_gal_b, nside2nside, rewind_coords
@@ -1326,6 +1327,8 @@ def write_gaia_matches(infiles, numproc=4, outdir=".", matchrad=0.2, dr="edr3",
         hdr["GAIADR"] = dr
         # ADM match_gaia_to_primary always rewinds the epoch to 2015.5.
         hdr["REFEPOCH"] = 2015.5
+        depend.setdep(hdr, 'desitarget', desitarget_version)
+        depend.setdep(hdr, 'desitarget-git', gitversion())
 
         # ADM match to Gaia sources.
         gaiainfo = match_gaia_to_primary(objs, matchrad=matchrad, dr=dr)

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -815,7 +815,7 @@ def read_gaia_file(filename, header=False, addobjid=False):
         return outdata
 
 
-def find_gaia_files(objs, neighbors=True, radec=False):
+def find_gaia_files(objs, neighbors=True, radec=False, dr="dr2"):
     """Find full paths to Gaia healpix files for objects by RA/Dec.
 
     Parameters
@@ -829,6 +829,8 @@ def find_gaia_files(objs, neighbors=True, radec=False):
     radec : :class:`bool`, optional, defaults to ``False``
         If ``True`` then the passed `objs` is an [RA, Dec] list instead of
         a rec array.
+    dr : :class:`str`, optional, defaults to "dr2"
+        Name of a Gaia data release. Options are "dr2", "edr3"
 
     Returns
     -------
@@ -844,14 +846,14 @@ def find_gaia_files(objs, neighbors=True, radec=False):
     nside = _get_gaia_nside()
 
     # ADM check that the GAIA_DIR is set and retrieve it.
-    gaiadir = get_gaia_dir()
+    gaiadir = get_gaia_dir(dr)
     hpxdir = os.path.join(gaiadir, 'healpix')
 
     return io.find_star_files(objs, hpxdir, nside,
                               neighbors=neighbors, radec=radec)
 
 
-def find_gaia_files_hp(nside, pixlist, neighbors=True):
+def find_gaia_files_hp(nside, pixlist, neighbors=True, dr="dr2"):
     """Find full paths to Gaia healpix files in a set of HEALPixels.
 
     Parameters
@@ -864,6 +866,8 @@ def find_gaia_files_hp(nside, pixlist, neighbors=True):
         Also return files corresponding to all neighbors that touch the
         pixels in `pixlist` to prevent edge effects (e.g. a Gaia source
         is 1 arcsec outside of `pixlist` and so in an adjacent pixel).
+    dr : :class:`str`, optional, defaults to "dr2"
+        Name of a Gaia data release. Options are "dr2", "edr3"
 
     Returns
     -------
@@ -879,7 +883,7 @@ def find_gaia_files_hp(nside, pixlist, neighbors=True):
     filenside = _get_gaia_nside()
 
     # ADM check that the GAIA_DIR is set and retrieve it.
-    gaiadir = get_gaia_dir()
+    gaiadir = get_gaia_dir(dr)
     hpxdir = os.path.join(gaiadir, 'healpix')
 
     # ADM work with pixlist as an array.
@@ -899,7 +903,7 @@ def find_gaia_files_hp(nside, pixlist, neighbors=True):
     return gaiafiles
 
 
-def find_gaia_files_box(gaiabounds, neighbors=True):
+def find_gaia_files_box(gaiabounds, neighbors=True, dr="dr2"):
     """Find full paths to Gaia healpix files in an RA/Dec box.
 
     Parameters
@@ -911,6 +915,8 @@ def find_gaia_files_box(gaiabounds, neighbors=True):
         Also return files corresponding to all neighboring pixels that touch
         the files that touch the box in order to prevent edge effects (e.g. if a Gaia
         source might be 1 arcsec outside of the box and so in an adjacent pixel)
+    dr : :class:`str`, optional, defaults to "dr2"
+        Name of a Gaia data release. Options are "dr2", "edr3"
 
     Returns
     -------
@@ -930,7 +936,7 @@ def find_gaia_files_box(gaiabounds, neighbors=True):
     nside = _get_gaia_nside()
 
     # ADM check that the GAIA_DIR is set and retrieve it.
-    gaiadir = get_gaia_dir()
+    gaiadir = get_gaia_dir(dr)
     hpxdir = os.path.join(gaiadir, 'healpix')
 
     # ADM determine the pixels that touch the box.
@@ -947,7 +953,7 @@ def find_gaia_files_box(gaiabounds, neighbors=True):
     return gaiafiles
 
 
-def find_gaia_files_beyond_gal_b(mingalb, neighbors=True):
+def find_gaia_files_beyond_gal_b(mingalb, neighbors=True, dr="dr2"):
     """Find full paths to Gaia healpix files beyond a Galactic b.
 
     Parameters
@@ -959,6 +965,8 @@ def find_gaia_files_beyond_gal_b(mingalb, neighbors=True):
         Also return files corresponding to neighboring pixels that touch
         in order to prevent edge effects (e.g. if a Gaia source might be
         1 arcsec beyond mingalb and so in an adjacent pixel).
+    dr : :class:`str`, optional, defaults to "dr2"
+        Name of a Gaia data release. Options are "dr2", "edr3".
 
     Returns
     -------
@@ -977,7 +985,7 @@ def find_gaia_files_beyond_gal_b(mingalb, neighbors=True):
     nside = _get_gaia_nside()
 
     # ADM check that the GAIA_DIR is set and retrieve it.
-    gaiadir = get_gaia_dir()
+    gaiadir = get_gaia_dir(dr)
     hpxdir = os.path.join(gaiadir, 'healpix')
 
     # ADM determine the pixels beyond mingalb.
@@ -994,7 +1002,7 @@ def find_gaia_files_beyond_gal_b(mingalb, neighbors=True):
     return gaiafiles
 
 
-def find_gaia_files_tiles(tiles=None, neighbors=True):
+def find_gaia_files_tiles(tiles=None, neighbors=True, dr="dr2"):
     """
     Parameters
     ----------
@@ -1005,6 +1013,8 @@ def find_gaia_files_tiles(tiles=None, neighbors=True):
         Also return all neighboring pixels that touch the files of interest
         in order to prevent edge effects (e.g. if a Gaia source is 1 arcsec
         away from a primary source and so in an adjacent pixel).
+    dr : :class:`str`, optional, defaults to "dr2"
+        Name of a Gaia data release. Options are "dr2", "edr3".
 
     Returns
     -------
@@ -1025,7 +1035,7 @@ def find_gaia_files_tiles(tiles=None, neighbors=True):
     nside = _get_gaia_nside()
 
     # ADM check that the GAIA_DIR is set and retrieve it.
-    gaiadir = get_gaia_dir()
+    gaiadir = get_gaia_dir(dr)
     hpxdir = os.path.join(gaiadir, 'healpix')
 
     # ADM determine the pixels that touch the tiles.
@@ -1044,40 +1054,44 @@ def find_gaia_files_tiles(tiles=None, neighbors=True):
 
 
 def match_gaia_to_primary(objs, matchrad=1., retaingaia=False,
-                          gaiabounds=[0., 360., -90., 90.]):
+                          gaiabounds=[0., 360., -90., 90.], dr="edr3"):
     """Match a set of objects to Gaia healpix files and return the Gaia information.
 
     Parameters
     ----------
     objs : :class:`~numpy.ndarray`
-        Must contain at least "RA" and "DEC".
+        Must contain at least "RA", "DEC". ASSUMED TO BE AT A REFERENCE 
+        EPOCH OF 2015.5 and EQUINOX J2000.
     matchrad : :class:`float`, optional, defaults to 1 arcsec
         The matching radius in arcseconds.
     retaingaia : :class:`float`, optional, defaults to False
-        If set, return all of the Gaia information in the "area" occupied by
-        the passed objects (whether a Gaia object matches a passed RA/Dec
-        or not.) THIS ASSUMES THAT THE PASSED OBJECTS ARE FROM A SWEEPS file
-        and that the integer values nearest the maximum and minimum passed RAs
+        If set, return all of the Gaia information in the "area" occupied
+        by `objs` (whether a Gaia object matches a passed RA/Dec or not.)
+        THIS ASSUMES THAT THE PASSED OBJECTS ARE FROM A SWEEPS file and
+        that integer values nearest the maximum and minimum passed RAs
         and Decs fairly represent the areal "edges" of that file.
     gaiabounds : :class:`list`, optional, defaults to the whole sky
-        Used in conjunction with `retaingaia` to determine over what area to
-        retrieve Gaia objects that don't match a sweeps object. Pass a 4-entry
-        list to represent an area bounded by [RAmin, RAmax, DECmin, DECmax]
+        Used with `retaingaia` to determine the area over which to
+        retrieve Gaia objects that don't match a sweeps object. Pass a
+        4-entry (corresponding to [RAmin, RAmax, DECmin, DECmax]).
+    dr : :class:`str`, optional, defaults to "edr3"
+        Name of a Gaia data release. Options are "dr2", "edr3". Specifies
+        which output data model to use.
 
     Returns
     -------
     :class:`~numpy.ndarray`
-        The matching Gaia information for each object, where the returned format and
-        columns correspond to `desitarget.gaiamatch.gaiadatamodel`
+        Gaia information for each matching object, in a format like
+        `gaiadatamodel` (for `dr=dr2`) or `edr3datamodel` (`dr=edr3`).
 
     Notes
     -----
-        - The first len(objs) objects correspond row-by-row to the passed objects.
-        - For objects that do NOT have a match in the Gaia files, the "REF_ID"
+        - The first len(`objs`) objects correspond row-by-row to `objs`.
+        - For objects that do NOT have a match in Gaia, the "REF_ID"
           column is set to -1, and all other columns are zero.
-        - If `retaingaia` is True then objects after the first len(objs) objects are
-          Gaia objects that do not have a sweeps match but that are in the area
-          bounded by `gaiabounds`
+        - If `retaingaia` is ``True`` then objects after the first
+          len(`objs`) objects are Gaia objects that do not have a sweeps
+          match but are in the area bounded by `gaiabounds`.
     """
     # ADM I'm getting this old Cython RuntimeWarning on search_around_sky ****:
     # RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88
@@ -1086,23 +1100,23 @@ def match_gaia_to_primary(objs, matchrad=1., retaingaia=False,
     # ADM e.g. https://stackoverflow.com/questions/40845304/runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility
     import warnings
 
-    # ADM if retaingaia is True, retain all Gaia objects in a sweeps-like box.
+    # ADM retain all Gaia objects in a sweeps-like box.
     if retaingaia:
         ramin, ramax, decmin, decmax = gaiabounds
 
-    # ADM convert the coordinates of the input objects to a SkyCoord object.
+    # ADM convert the coordinates of the objects to a SkyCoord object.
     cobjs = SkyCoord(objs["RA"]*u.degree, objs["DEC"]*u.degree)
     nobjs = cobjs.size
 
-    # ADM deal with the special case that only a single object was passed.
+    # ADM catch the special case that only a single object was passed.
     if nobjs == 1:
         return match_gaia_to_primary_single(objs, matchrad=matchrad)
 
-    # ADM set up a zerod array of Gaia information for the passed objects.
+    # ADM make a zerod array of Gaia information for the passed objects.
     gaiainfo = np.zeros(nobjs, dtype=gaiadatamodel.dtype)
 
-    # ADM a supplemental (zero-length) array to hold Gaia objects that don't
-    # ADM match a sweeps object, in case retaingaia was set.
+    # ADM a supplemental (zero-length) array to hold Gaia objects that
+    # ADM don't match a sweeps object, in case retaingaia was set.
     suppgaiainfo = np.zeros(0, dtype=gaiadatamodel.dtype)
 
     # ADM objects without matches should have REF_ID of -1.

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -1086,7 +1086,7 @@ def match_gaia_to_primary(objs, matchrad=0.2, retaingaia=False,
     Parameters
     ----------
     objs : :class:`~numpy.ndarray`
-        Must contain at least "RA", "DEC". ASSUMED TO BE AT A REFERENCE 
+        Must contain at least "RA", "DEC". ASSUMED TO BE AT A REFERENCE
         EPOCH OF 2015.5 and EQUINOX J2000/ICRS.
     matchrad : :class:`float`, optional, defaults to 0.2 arcsec
         The matching radius in arcseconds.

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -153,7 +153,7 @@ def add_photsys(indata):
     return outdata
 
 
-def read_tractor(filename, header=False, columns=None):
+def read_tractor(filename, header=False, columns=None, gaiasub=False):
     """Read a tractor catalogue or sweeps file.
 
     Parameters
@@ -167,6 +167,11 @@ def read_tractor(filename, header=False, columns=None):
         desitarget.io.tsdatamodel.dtype.names + most of the columns in
         desitarget.gaiamatch.gaiadatamodel.dtype.names, where
         tsdatamodel is, e.g., basetsdatamodel + dr9addedcols.
+    gaiasub : :class:`boolean`, optional, defaults to ``False``
+        If ``True``, substitute Gaia EDR3 proper motion and parallax
+        columns over the sweeps values. If ``True``, then the GAIA_DIR
+        environment variable must be set to find the Gaia sweeps files,
+        and `filename` must be the full path to a DR9 sweeps file.
 
     Returns
     -------
@@ -182,6 +187,11 @@ def read_tractor(filename, header=False, columns=None):
                                   columns=columns)
     else:
         indata = fitsio.read(filename, upper=True, columns=columns)
+
+    # ADM if requested, sub-in Gaia EDR3 proper motions and parallaxes.
+    if gaiasub:
+        from desitarget.gaiamatch import sub_gaia_edr3
+        indata = sub_gaia_edr3(filename, objs=indata)
 
     # ADM form the final data model in a manner that maintains
     # ADM backwards-compatability with DR8.


### PR DESCRIPTION
This PR continues work to augment existing infrastructure in the `gaiamatch` module to work with Gaia EDR3. Existing functions are updated to have a `dr` kwarg to specify Gaia `edr3` or `dr2`. In particular, the [function](https://github.com/desihub/desitarget/blob/9362a6dfb8c5731cec902382bce02ca28dea3341/py/desitarget/gaiamatch.py#L1261) and [script](https://github.com/desihub/desitarget/blob/ADM-edr3-sweeps/bin/write_gaia_matches) that write Gaia-matched sweeps have been updated to produce EDR3 sweeps.

Example outputs of Gaia EDR3 sweeps are in:

`/global/cscratch1/sd/adamyers/gaiaedr3match/*`

which are row-by-row parallel to:

`/global/cfs/cdirs/cosmo/data/legacysurvey/dr9/*/sweep/9.0/`

I'm leaving this as a WIP until I've asked the MWS group to check the new sweeps.