### PR TITLE
Update baseline LRG selection

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -25,7 +25,7 @@ desitarget Change Log
      to swap EDR3 proper motions/parallaxes for values in sweeps files.
 * New function and bin script to make QSO redshift catalogs [`PR #714`_].
    * Incorporates functionality from QuasarNET and SQUEzE.
-* Update the baseline LRG selection [`PR #723`_]. Changes from SV3 includes:
+* Update the baseline LRG selection [`PR #723`_]. Changes from SV3 include:
     * Change the zfiber faint limit from 21.7 to 21.6
     * Change the low-z limit from z>0.3 to z>0.4
     * Change the overall density from 800/sq.deg. to 600/sq.deg.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -25,6 +25,11 @@ desitarget Change Log
      to swap EDR3 proper motions/parallaxes for values in sweeps files.
 * New function and bin script to make QSO redshift catalogs [`PR #714`_].
    * Incorporates functionality from QuasarNET and SQUEzE.
+* Update the baseline LRG selection [`PR #723`_]. Changes from SV3 includes:
+    * Change the zfiber faint limit from 21.7 to 21.6
+    * Change the low-z limit from z>0.3 to z>0.4
+    * Change the overall density from 800/sq.deg. to 600/sq.deg.
+    * Remove the LRG_LOWDENS target bit
 
 .. _`PR #714`: https://github.com/desihub/desitarget/pull/714
 .. _`PR #715`: https://github.com/desihub/desitarget/pull/715
@@ -32,6 +37,7 @@ desitarget Change Log
 .. _`PR #717`: https://github.com/desihub/desitarget/pull/717
 .. _`PR #718`: https://github.com/desihub/desitarget/pull/718
 .. _`PR #719`: https://github.com/desihub/desitarget/pull/719
+.. _`PR #723`: https://github.com/desihub/desitarget/pull/723
 
 0.57.2 (2021-04-18)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -381,7 +381,7 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
 
     Notes
     -----
-    - Current version (03/31/21) is version 15 on `the SV3 wiki`_.
+    - Current version (05/04/21) is version 254 on `the wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     # ADM LRG targets.

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -153,13 +153,13 @@ class TestCuts(unittest.TestCase):
 
         # ADM check for both defined fiberflux and fiberflux of None.
         for ff in zfiberflux, None:
-            lrg1, _ = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
+            lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
                                  zflux=zflux, w1flux=w1flux, zfiberflux=ff,
                                  gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                                  maskbits=maskbits, rfluxivar=rfluxivar,
                                  zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
                                  gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
-            lrg2, _ = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux,
+            lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux,
                                  zflux=zflux, w1flux=w1flux, zfiberflux=ff,
                                  gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                                  maskbits=maskbits, rfluxivar=rfluxivar,
@@ -170,10 +170,10 @@ class TestCuts(unittest.TestCase):
 
             # ADM check color selections alone work. Tripped us up once
             # ADM when the mocks called a missing isLRG_colors function.
-            lrg1, _ = cuts.isLRG_colors(primary=primary, gflux=gflux,
+            lrg1 = cuts.isLRG_colors(primary=primary, gflux=gflux,
                                         rflux=rflux, zflux=zflux, zfiberflux=ff,
                                         w1flux=w1flux, w2flux=w2flux)
-            lrg2, _ = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux,
+            lrg2 = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux,
                                         zflux=zflux, zfiberflux=ff,
                                         w1flux=w1flux, w2flux=w2flux)
             self.assertTrue(np.all(lrg1 == lrg2))


### PR DESCRIPTION
This PR updates the baseline LRG selection (assuming it will be the final main survey selection). Changes from SV3 include:
    * Change the zfiber faint limit from 21.7 to 21.6
    * Change the low-z limit from z>0.3 to z>0.4
    * Change the overall density from 800/sq.deg. to 600/sq.deg.
    * Remove the LRG_LOWDENS target bit