### PR TITLE
new faint limits to BGS

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 0.57.3 (unreleased)
 -------------------
 
+* BGS update. New faint limits to r< 20.175 in DECaLS and to r<20.22 for BASS/MzLS in order to get a target density of ~1400 [`PR #725`_].
 * Add utility functions ``decode/encode_negative_targetid(ra,dec,group)``
   unique to at least 2 milliarcsec [`PR #724`_].
 * Update the baseline LRG selection [`PR #723`_]. Changes from SV3 include:
@@ -43,6 +44,7 @@ desitarget Change Log
 .. _`PR #722`: https://github.com/desihub/desitarget/pull/722
 .. _`PR #723`: https://github.com/desihub/desitarget/pull/723
 .. _`PR #724`: https://github.com/desihub/desitarget/pull/724
+.. _`PR #725`: https://github.com/desihub/desitarget/pull/725
 
 0.57.2 (2021-04-18)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1479,11 +1479,11 @@ def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None,
             bgs &= rfibertotflux <= 10**((22.5-15.0)/2.5)
     elif targtype == 'faint':
         if south:
-            bgs &= rflux > 10**((22.5-20.3)/2.5)
+            bgs &= rflux > 10**((22.5-20.175)/2.5)
             bgs &= rflux <= 10**((22.5-19.5)/2.5)
             bgs &= (rfibcol)
         else:
-            bgs &= rflux > 10**((22.5-(20.3))/2.5)
+            bgs &= rflux > 10**((22.5-(20.220))/2.5)
             bgs &= rflux <= 10**((22.5-(19.5+offset))/2.5)
             bgs &= (rfibcol)
 
@@ -1615,11 +1615,11 @@ def isBGS_sga(gflux=None, rflux=None, zflux=None, w1flux=None, refcat=None,
             bgs &= rfibertotflux <= 10**((22.5-15.0)/2.5)
     elif targtype == 'faint':
         if south:
-            bgs &= rflux > 10**((22.5-20.3)/2.5)
+            bgs &= rflux > 10**((22.5-20.175)/2.5)
             bgs &= rflux <= 10**((22.5-19.5)/2.5)
             bgs &= (rfibcol)
         else:
-            bgs &= rflux > 10**((22.5-(20.3))/2.5)
+            bgs &= rflux > 10**((22.5-(20.220))/2.5)
             bgs &= rflux <= 10**((22.5-(19.5+offset))/2.5)
             bgs &= (rfibcol)
 

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1337,7 +1337,7 @@ def isBGS(rfiberflux=None, gflux=None, rflux=None, zflux=None, rfibertotflux=Non
 
     Notes
     -----
-    - Current version (03/29/21) is version 13 on `the SV3 wiki`_.
+    - Current version (05/06/21) is version 258 on `the wiki`_.
     - See :func:`~desitarget.cuts.set_target_bits` for other parameters.
     """
     _check_BGS_targtype(targtype)


### PR DESCRIPTION
Just a small change for BGS. We have updated the faint limits to r< 20.175 in DECaLS and to r<20.22 for BASS/MzLS in order to get a target density of ~1400