### PR TITLE
Update minor elements of the ELG/LRG code for the Main Survey

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,9 @@ desitarget Change Log
 0.57.3 (unreleased)
 -------------------
 
+* Update the ELG/LRG code for the Main Survey [`PR #726`_]. Includes:
+    * Deprecate the ``LRG_LOWDENS`` targeting bit. It was never used.
+    * Upweight 10% of the "filler" ELG sample to the LRG priority.
 * Update the baseline LRG selection [`PR #723`_]. Changes from SV3 include:
     * Change the zfiber faint limit from 21.7 to 21.6.
     * Change the low-z limit from z>0.3 to z>0.4.
@@ -32,7 +35,6 @@ desitarget Change Log
 * New function and bin script to make QSO redshift catalogs [`PR #714`_].
    * Incorporates functionality from QuasarNET and SQUEzE.
 
-
 .. _`PR #714`: https://github.com/desihub/desitarget/pull/714
 .. _`PR #715`: https://github.com/desihub/desitarget/pull/715
 .. _`PR #716`: https://github.com/desihub/desitarget/pull/716
@@ -41,6 +43,7 @@ desitarget Change Log
 .. _`PR #719`: https://github.com/desihub/desitarget/pull/719
 .. _`PR #722`: https://github.com/desihub/desitarget/pull/722
 .. _`PR #723`: https://github.com/desihub/desitarget/pull/723
+.. _`PR #726`: https://github.com/desihub/desitarget/pull/726
 
 0.57.2 (2021-04-18)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -513,18 +513,18 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
         lrg &= (gmag - w1mag > 2.9) | (rmag - w1mag > 1.8)  # low-z cuts
         lrg &= (
             ((rmag - w1mag > (w1mag - 17.14) * 1.8)
-            & (rmag - w1mag > (w1mag - 16.33) * 1.))
+             & (rmag - w1mag > (w1mag - 16.33) * 1.))
             | (rmag - w1mag > 3.33)
-            )  # double sliding cuts and high-z extension
+        )  # double sliding cuts and high-z extension
     else:
         lrg &= zmag - w1mag > 0.8 * (rmag - zmag) - 0.6  # non-stellar cut
         lrg &= zfibermag < 21.61                   # faint limit
         lrg &= (gmag - w1mag > 2.97) | (rmag - w1mag > 1.8)  # low-z cuts
         lrg &= (
             ((rmag - w1mag > (w1mag - 17.13) * 1.83)
-            & (rmag - w1mag > (w1mag - 16.31) * 1.))
+             & (rmag - w1mag > (w1mag - 16.31) * 1.))
             | (rmag - w1mag > 3.4)
-            )  # double sliding cuts and high-z extension
+        )  # double sliding cuts and high-z extension
 
     return lrg
 
@@ -933,11 +933,12 @@ def notinMWS_main_mask(gaia=None, gfracmasked=None, gnobs=None, gflux=None,
 
     return mws
 
+
 def isMWS_faint_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
-                      pmra=None, pmdec=None, parallax=None, parallaxerr=None,
-                      obs_rflux=None, objtype=None, paramssolved=None,
-                      gaiagmag=None, gaiabmag=None, gaiarmag=None, gaiaaen=None,
-                      primary=None, south=True):
+                       pmra=None, pmdec=None, parallax=None, parallaxerr=None,
+                       obs_rflux=None, objtype=None, paramssolved=None,
+                       gaiagmag=None, gaiabmag=None, gaiarmag=None, gaiaaen=None,
+                       primary=None, south=True):
     """Set of cuts to define a fainter extension to the MWS main sample.
     (see, e.g., :func:`~desitarget.cuts.isMWS_main` for parameters).
     """
@@ -989,6 +990,7 @@ def isMWS_faint_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=N
     # APC discarded.
 
     return faint_red, faint_blue
+
 
 def isMWS_main_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
                       pmra=None, pmdec=None, parallax=None, parallaxerr=None,

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -8,9 +8,6 @@ desi_mask:
     - [ELG,         1, "ELG", {obsconditions: DARK}]
     - [QSO,         2, "QSO", {obsconditions: DARK}]
 
-    #- ADM LRG sub-classes used in SV3 but not in the Main Survey.
-    - [LRG_LOWDENS, 3, "LRG selected using cuts that produce a lower (~600 per sq. deg.) target density", {obsconditions: DARK}]
-
     #- ADM QSO sub-classes. Used in SV1 and SV2 but ultimately deprecated for the Main Survey.
     - [QSO_HIZ,     4, "QSO selected using high-redshift Random Forest (informational bit)", {obsconditions: DARK}]
 
@@ -25,14 +22,12 @@ desi_mask:
     - [QSO_NORTH,         10, "QSO cuts tuned for Bok/Mosaic data",                                        {obsconditions: DARK}]
     - [ELG_LOP_NORTH,     11, "ELG at standard (ELG) priority tuned for Bok/Mosaic data",                  {obsconditions: DARK}]
     - [ELG_VLO_NORTH,     12, "Very-low priority ELG (filler) tuned for Bok/Mosaic data",                  {obsconditions: DARK}]
-    - [LRG_LOWDENS_NORTH, 13, "LRG cuts (lower density) tuned for Bok/Mosaic data",                        {obsconditions: DARK}]
 
     - [LRG_SOUTH,         16, "LRG cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [ELG_SOUTH,         17, "ELG cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [QSO_SOUTH,         18, "QSO cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [ELG_LOP_SOUTH,     19, "ELG at standard (ELG) priority tuned for DECam data",                       {obsconditions: DARK}]
     - [ELG_VLO_SOUTH,     20, "Very-low priority ELG (filler) tuned for DECam data",                       {obsconditions: DARK}]
-    - [LRG_LOWDENS_SOUTH, 21, "LRG cuts (lower density) tuned for DECam data",                             {obsconditions: DARK}]
 
     #- Calibration targets
     - [SKY,         32, "Blank sky locations",                                       {obsconditions: DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18}]
@@ -270,8 +265,7 @@ priorities:
         ELG_VLO: {UNOBS: 2999, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 
 # ADM Informational bits. Don't let them set priorities.
-        LRG_LOWDENS: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
-        QSO_HIZ: SAME_AS_LRG_LOWDENS
+        QSO_HIZ: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 
 # ADM don't prioritize a N/S target if it doesn't have other bits set.
         LRG_NORTH: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
@@ -279,14 +273,12 @@ priorities:
         QSO_NORTH: SAME_AS_LRG_NORTH
         ELG_LOP_NORTH: SAME_AS_LRG_NORTH
         ELG_VLO_NORTH: SAME_AS_LRG_NORTH
-        LRG_LOWDENS_NORTH: SAME_AS_LRG_NORTH
 
         LRG_SOUTH: SAME_AS_LRG_NORTH
         ELG_SOUTH: SAME_AS_LRG_NORTH
         QSO_SOUTH: SAME_AS_LRG_NORTH
         ELG_LOP_SOUTH: SAME_AS_LRG_NORTH
         ELG_VLO_SOUTH: SAME_AS_LRG_NORTH
-        LRG_LOWDENS_SOUTH: SAME_AS_LRG_NORTH
 
 # ADM calibration and other non-standard targets.
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, MORE_MIDZQSO: 0}
@@ -417,22 +409,17 @@ numobs:
         ELG_HIP: 1
         ELG_VLO: 1
 
-# ADM LRG_LOWDENS is a purely informational bit.
-        LRG_LOWDENS: 0
-
 # ADM don't observe a N/S target if it doesn't have other bits set.
         LRG_NORTH: 0
         ELG_NORTH: 0
         QSO_NORTH: 0
         ELG_LOP_NORTH: 0
         ELG_VLO_NORTH: 0
-        LRG_LOWDENS_NORTH: 0
         LRG_SOUTH: 0
         ELG_SOUTH: 0
         QSO_SOUTH: 0
         ELG_LOP_SOUTH: 0
         ELG_VLO_SOUTH: 0
-        LRG_LOWDENS_SOUTH: 0
         BAD_SKY: 0
 
 #- Standards and sky are treated specially; NUMOBS doesn't apply.

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -154,28 +154,28 @@ class TestCuts(unittest.TestCase):
         # ADM check for both defined fiberflux and fiberflux of None.
         for ff in zfiberflux, None:
             lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
-                                 zflux=zflux, w1flux=w1flux, zfiberflux=ff,
-                                 gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                                 maskbits=maskbits, rfluxivar=rfluxivar,
-                                 zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
-                                 gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
+                              zflux=zflux, w1flux=w1flux, zfiberflux=ff,
+                              gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                              maskbits=maskbits, rfluxivar=rfluxivar,
+                              zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
+                              gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
             lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux,
-                                 zflux=zflux, w1flux=w1flux, zfiberflux=ff,
-                                 gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                                 maskbits=maskbits, rfluxivar=rfluxivar,
-                                 zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
-                                 gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
+                              zflux=zflux, w1flux=w1flux, zfiberflux=ff,
+                              gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                              maskbits=maskbits, rfluxivar=rfluxivar,
+                              zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
+                              gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
 
             self.assertTrue(np.all(lrg1 == lrg2))
 
             # ADM check color selections alone work. Tripped us up once
             # ADM when the mocks called a missing isLRG_colors function.
             lrg1 = cuts.isLRG_colors(primary=primary, gflux=gflux,
-                                        rflux=rflux, zflux=zflux, zfiberflux=ff,
-                                        w1flux=w1flux, w2flux=w2flux)
+                                     rflux=rflux, zflux=zflux, zfiberflux=ff,
+                                     w1flux=w1flux, w2flux=w2flux)
             lrg2 = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux,
-                                        zflux=zflux, zfiberflux=ff,
-                                        w1flux=w1flux, w2flux=w2flux)
+                                     zflux=zflux, zfiberflux=ff,
+                                     w1flux=w1flux, w2flux=w2flux)
             self.assertTrue(np.all(lrg1 == lrg2))
 
         elg1, _ = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux, gsnr=gsnr,

--- a/py/desitarget/test/test_secondary.py
+++ b/py/desitarget/test/test_secondary.py
@@ -45,7 +45,7 @@ class TestSECONDARY(unittest.TestCase):
             # ADM ...if we've already defined the updatemws property...
             if "updatemws" in dir(Mx[Mx[0]]):
                 for bitname in Mx.names():
-                    self.assertTrue(isinstance(Mx[bitname].updatemws,bool))
+                    self.assertTrue(isinstance(Mx[bitname].updatemws, bool))
 
     def test_downsample(self):
         """Test that secondary masks all have downsample defined and <= 1.


### PR DESCRIPTION
 This PR updates some features of the ELG and LRG code for the Main Survey. It includes:

- Deprecating the `LRG_LOWDENS` targeting bit, which was never used to produce official targeting files.
- Increasing the priority of 10% of the "filler" ELG sample (`ELG_VLO`) to the LRG priority. We already added code to similarly increase the priority of the "regular" ELG sample (`ELG_LOP`) in #718.