### PR TITLE
Clean up the QSO code for the Main Survey

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,11 @@ desitarget Change Log
 0.57.3 (unreleased)
 -------------------
 
+* Clean up the QSO code for the Main Survey [`PR #727`_]. Includes:
+    * Remove QSO selection code for data releases prior to DR9.
+    * Remove code that selects high-redshift quasars (``QSO_HIZ``).
+    * Also, change the initial priorities for some of the ELG classes:
+        * ``ELG_VLO`` is now 3000, ``ELG_LOP`` is now 3100.
 * Update the ELG/LRG code for the Main Survey [`PR #726`_]. Includes:
     * Deprecate the ``LRG_LOWDENS`` targeting bit. It was never used.
     * Upweight 10% of the "filler" ELG sample to the LRG priority.
@@ -50,6 +55,7 @@ desitarget Change Log
 .. _`PR #724`: https://github.com/desihub/desitarget/pull/724
 .. _`PR #725`: https://github.com/desihub/desitarget/pull/725
 .. _`PR #726`: https://github.com/desihub/desitarget/pull/726
+.. _`PR #727`: https://github.com/desihub/desitarget/pull/727
 
 0.57.2 (2021-04-18)
 -------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2411,7 +2411,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                     qso_selection, qso_selection_options)
                 log.critical(msg)
                 raise ValueError(msg)
-    qso_north, qso_south= qso_classes
+    qso_north, qso_south = qso_classes
 
     # ADM combine QSO targeting bits for a QSO selected in any imaging.
     qso = (qso_north & photsys_north) | (qso_south & photsys_south)

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -260,9 +260,9 @@ priorities:
         QSO: {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, MORE_MIDZQSO: 100, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
 
 # ADM different priority ELGs.
-        ELG_LOP: SAME_AS_ELG
+        ELG_LOP: {UNOBS: 3100, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         ELG_HIP: SAME_AS_LRG
-        ELG_VLO: {UNOBS: 2999, MORE_ZGOOD: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        ELG_VLO: SAME_AS_ELG
 
 # ADM Informational bits. Don't let them set priorities.
         QSO_HIZ: {UNOBS: 0, DONE: 0, OBS: 0, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -190,6 +190,7 @@ def decode_targetid(targetid):
 
     return outputs
 
+
 def encode_negative_targetid(ra, dec, group=1):
     """
     Create negative 64-bit TARGETID from (ra,dec) unique to ~1.2 milliarcsec
@@ -208,12 +209,12 @@ def encode_negative_targetid(ra, dec, group=1):
     :class:`~numpy.int64` or :class:`~numpy.ndarray`
         negative TARGETID derived from (ra,dec)
     """
-    #- Hardcode number of bits
+    # Hardcode number of bits.
     nbits_ra = 30
     nbits_dec = 29
     nbits_group = 4
 
-    #- Check input dimensionality
+    # Check input dimensionality.
     scalar_input = np.isscalar(ra)
     if np.isscalar(ra) != np.isscalar(dec):
         raise TypeError('ra and dec must both be scalars or both be arrays')
@@ -223,31 +224,32 @@ def encode_negative_targetid(ra, dec, group=1):
 
     group = np.int8(group)
 
-    #- Convert to arrays to enable things like .astype(int)
+    # Convert to arrays to enable things like .astype(int).
     ra = np.atleast_1d(ra)
     dec = np.atleast_1d(dec)
 
-    assert np.all( (0.0 <= ra) & (ra <= 360.0) )
-    assert np.all( (-90.0 <= dec) & (dec <= 90.0) )
+    assert np.all((0.0 <= ra) & (ra <= 360.0))
+    assert np.all((-90.0 <= dec) & (dec <= 90.0))
 
-    #- encode ra in bits 30-59 and dec in bits 0-29
+    # encode ra in bits 30-59 and dec in bits 0-29.
     ra_bits = ((2**nbits_ra - 1) * (ra/360.0)).astype(int)
     dec_bits = ((2**nbits_dec - 1) * ((dec+90.0)/180.0)).astype(int)
     group_bitshift = nbits_dec + nbits_ra
     ra_bitshift = nbits_dec
-    targetid = -((group<<group_bitshift) + (ra_bits<<ra_bitshift) + dec_bits)
+    targetid = -((group << group_bitshift) + (ra_bits << ra_bitshift) + dec_bits)
 
-    #- return value has dimensionality of inputs
+    # return value has dimensionality of inputs.
     if scalar_input:
         return targetid[0]
     else:
         return targetid
 
+
 def decode_negative_targetid(targetid):
     """
     TODO: document
     """
-    #- Hardcode number of bits
+    # Hardcode number of bits.
     nbits_ra = 30
     nbits_dec = 29
     nbits_group = 4

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -125,7 +125,6 @@ class TestCuts(unittest.TestCase):
         w2snr = targets['FLUX_W2'] * np.sqrt(targets['FLUX_IVAR_W2'])
 
         dchisq = targets['DCHISQ']
-        deltaChi2 = dchisq[..., 0] - dchisq[..., 1]
         objtype = targets["TYPE"]
 
         gnobs, rnobs, znobs = targets['NOBS_G'], targets['NOBS_R'], targets['NOBS_Z']
@@ -219,15 +218,13 @@ class TestCuts(unittest.TestCase):
         qso1 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux,
                                w1flux=w1flux, w2flux=w2flux,
                                gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                               deltaChi2=deltaChi2, maskbits=maskbits,
-                               w1snr=w1snr, w2snr=w2snr, objtype=psftype, primary=primary,
-                               release=release)
+                               maskbits=maskbits, w1snr=w1snr, w2snr=w2snr,
+                               objtype=psftype, primary=primary)
         qso2 = cuts.isQSO_cuts(gflux=gflux, rflux=rflux, zflux=zflux,
                                w1flux=w1flux, w2flux=w2flux,
                                gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                               deltaChi2=deltaChi2, maskbits=maskbits,
-                               w1snr=w1snr, w2snr=w2snr, objtype=None, primary=None,
-                               release=release)
+                               maskbits=maskbits, w1snr=w1snr, w2snr=w2snr,
+                               objtype=None, primary=None)
         self.assertTrue(np.all(qso1 == qso2))
         # ADM also check that the color selections alone work. This tripped us up once
         # ADM with the mocks part of the code calling a non-existent LRG colors function.

--- a/py/desitarget/test/test_targetids.py
+++ b/py/desitarget/test/test_targetids.py
@@ -5,8 +5,9 @@
 import unittest
 import numpy as np
 
-from desitarget.targets import (
-        encode_negative_targetid, decode_negative_targetid )
+from desitarget.targets import (encode_negative_targetid,
+                                decode_negative_targetid)
+
 
 class TestTargetID(unittest.TestCase):
 
@@ -18,45 +19,45 @@ class TestTargetID(unittest.TestCase):
         """
         Test encoding ra,dec -> negative TARGETID
         """
-        #- Edge cases with scalars; should alsways be negative
-        for ra in (0,90,180,360):
+        # Edge cases with scalars; should alsways be negative.
+        for ra in (0, 90, 180, 360):
             for dec in (-90, 0, +90):
-                for group in (1,7,15):
-                    t = encode_negative_targetid(ra,dec,group)
+                for group in (1, 7, 15):
+                    t = encode_negative_targetid(ra, dec, group)
                     msg = f'targetid({ra},{dec},{group})'
                     self.assertLess(t, 0, msg)
                     self.assertTrue(np.isscalar(t), msg)
 
-        #- Also works with lists and arrays
+        # Also works with lists and arrays.
         ra = (0, 10, 20)
         dec = (-10, 0, 89.9)
         t = encode_negative_targetid(ra, dec)
         self.assertEqual(len(t), len(ra))
-        self.assertTrue(np.all(t<0))
+        self.assertTrue(np.all(t < 0))
 
         t = encode_negative_targetid(np.asarray(ra), np.asarray(dec))
         self.assertEqual(len(t), len(ra))
-        self.assertTrue(np.all(t<0))
+        self.assertTrue(np.all(t < 0))
 
-        #- Test invalid group numbers
+        # Test invalid group numbers.
         with self.assertRaises(ValueError):
-            encode_negative_targetid(0,0,0)
-
-        with self.assertRaises(ValueError):
-            encode_negative_targetid(0,0,16)
+            encode_negative_targetid(0, 0, 0)
 
         with self.assertRaises(ValueError):
-            encode_negative_targetid(0,0,-1)
+            encode_negative_targetid(0, 0, 16)
 
-        #- 2 milliarcsec differences -> different TARGETID
+        with self.assertRaises(ValueError):
+            encode_negative_targetid(0, 0, -1)
+
+        # 2 milliarcsec differences -> different TARGETID.
         ra, dec = 10.0, 0.0
         delta = 2.0/(3600*1000)
 
-        t1 = encode_negative_targetid(ra,dec)
-        t2 = encode_negative_targetid(ra,dec+delta)
-        t3 = encode_negative_targetid(ra,dec-delta)
-        t4 = encode_negative_targetid(ra+delta,dec)
-        t5 = encode_negative_targetid(ra-delta,dec)
+        t1 = encode_negative_targetid(ra, dec)
+        t2 = encode_negative_targetid(ra, dec+delta)
+        t3 = encode_negative_targetid(ra, dec-delta)
+        t4 = encode_negative_targetid(ra+delta, dec)
+        t5 = encode_negative_targetid(ra-delta, dec)
         self.assertNotEqual(t1, t2)
         self.assertNotEqual(t1, t3)
         self.assertNotEqual(t1, t4)
@@ -68,20 +69,19 @@ class TestTargetID(unittest.TestCase):
         self.assertNotEqual(t3, t5)
         self.assertNotEqual(t4, t5)
 
-
     def test_decode_negative_targetid(self):
         """test negative targetid encoding -> decoding round trip"""
 
-        #---- roundtrip accurate to at least 2 milliarcsec (without cos(dec))
+        # roundtrip accurate to at least 2 milliarcsec (without cos(dec)).
         n = 1000
         ra = np.random.uniform(0, 360, n)
         dec = np.random.uniform(-90, 90, n)
         group = 5
 
-        #- include corner cases
-        ra = np.concatenate( (ra, [0,0,0, 360,360,360]) )
-        dec = np.concatenate( (dec, [-90,0,90, -90,0,90]) )
-        
+        # include corner cases.
+        ra = np.concatenate((ra, [0, 0, 0, 360, 360, 360]))
+        dec = np.concatenate((dec, [-90, 0, 90, -90, 0, 90]))
+
         targetids = encode_negative_targetid(ra, dec, group)
         ra1, dec1, group1 = decode_negative_targetid(targetids)
 
@@ -90,15 +90,14 @@ class TestTargetID(unittest.TestCase):
         self.assertTrue(np.all(np.abs(dec-dec1) < delta))
         self.assertTrue(np.all(group1 == group))
 
-        #- check group roundtrip, and scalar inputs
+        # check group roundtrip, and scalar inputs.
         ra, dec = 20.1, -16.3333
-        for group in range(1,16):
+        for group in range(1, 16):
             targetid = encode_negative_targetid(ra, dec, group)
             ra1, dec1, group1 = decode_negative_targetid(targetid)
             self.assertEqual(group1, group)
             self.assertLess(np.abs(ra1-ra), delta)
             self.assertLess(np.abs(dec1-dec), delta)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR removes older cuts for selecting QSOs, to simplify the code prior to processing the on-sky Main Survey targets. It removes:

- Any Main Survey code that was used to select QSOs for data releases prior to DR9 of the Legacy Surveys.
- The Main Survey code that selects high-redshift quasars using the Random Forest (the `QSO_HIZ` quasars).
  * The `QSO_HIZ` _bit_ is retained, it's just never set.

In addition, the code fixes a bug where the `ELG_VLO` and `ELG_LOP` Main Survey target classes were being assigned the same priorities. Now, the initial priorities for these ELG classes are:
  * 3000 for `ELG_VLO`.
  * 3100 for `ELG_LOP`.