### PR TITLE
support skybricks3 fz instead of gz files

### DIFF
--- a/py/desitarget/skybricks.py
+++ b/py/desitarget/skybricks.py
@@ -90,12 +90,17 @@ class Skybricks(object):
             if len(I) == 0:
                 continue
 
-            # Read skybrick file
-            fn = os.path.join(self.skybricks_dir,
-                              'sky-%s.fits.gz' % self.skybricks['BRICKNAME'][i])
-            if not os.path.exists(fn):
-                log.warning('Missing "skybrick" file: %s' % fn)
+            # Read skybrick file, looking for fits.fz then fits.gz
+            for ext in ['fz', 'gz']:
+                fn = os.path.join(self.skybricks_dir,
+                        'sky-{}.fits.{}'.format(
+                            self.skybricks['BRICKNAME'][i], ext))
+                if os.path.exists(fn):
+                    break
+            else:
+                log.warning('Missing "skybrick" file: %s/.fz' % fn)
                 continue
+
             skymap, hdr = fitsio.read(fn, header=True)
             H, W = skymap.shape
             # create WCS object


### PR DESCRIPTION
This PR updates desitarget.skybricks to support the skybricks/v3 format which now uses fits.fz files instead of .fits.gz, while still being backwards compatible with the v2 fits.gz files.  See $DESI_ROOT/target/skybricks/v3 .

~1/1500 current sky catalog locations are rejected by skybricks/v3 (down from ~1/300 in v2), with the locations that they disagree upon having a small positive flux bias.  That's curious but hardly our biggest problem right now.  v3 is distinctly better than v2 but needs this code update to use them.