### PR TITLE
add SKYBRICKS_DIR and make module file more portable using DESI_ROOT

### DIFF
--- a/etc/desitarget.module
+++ b/etc/desitarget.module
@@ -76,16 +76,17 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
-setenv TARG_DIR /global/cfs/cdirs/desi/target/catalogs
-setenv MTL_DIR /global/cfs/cdirs/desi/target/mtl
-setenv DUST_DIR /global/cfs/cdirs/cosmo/data/dust/v0_1
-setenv CMX_DIR /global/cfs/cdirs/desi/target/cmx_files
-setenv SCND_DIR /global/cfs/cdirs/desi/target/secondary
-setenv MASK_DIR /global/cfs/cdirs/desi/target/masks
-setenv GAIA_DIR /global/cfs/cdirs/desi/target/gaia_dr2
-setenv URAT_DIR /global/cfs/cdirs/desi/target/urat_dr1
-setenv TYCHO_DIR /global/cfs/cdirs/desi/target/tycho_dr2
-setenv TOO_DIR /global/cfs/cdirs/desi/target/ToO
-setenv ZCAT_DIR /global/cfs/cdirs/desi/spectro/redux/daily
-setenv QN_MODEL_FILE /global/cfs/cdirs/desi/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
-setenv SQ_MODEL_FILE /global/cfs/cdirs/desi/target/catalogs/lya/sq_models/BOSS_train_64plates_model.json
+setenv TARG_DIR $env(DESI_ROOT)/target/catalogs
+setenv MTL_DIR  $env(DESI_ROOT)/target/mtl
+setenv DUST_DIR $env(DESI_ROOT)/external/dust/v0_1
+setenv CMX_DIR  $env(DESI_ROOT)/target/cmx_files
+setenv SCND_DIR $env(DESI_ROOT)/target/secondary
+setenv MASK_DIR $env(DESI_ROOT)/target/masks
+setenv GAIA_DIR $env(DESI_ROOT)/target/gaia_dr2
+setenv URAT_DIR $env(DESI_ROOT)/target/urat_dr1
+setenv TYCHO_DIR $env(DESI_ROOT)/target/tycho_dr2
+setenv TOO_DIR  $env(DESI_ROOT)/target/ToO
+setenv ZCAT_DIR $env(DESI_ROOT)/spectro/redux/daily
+setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
+setenv SQ_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/sq_models/BOSS_train_64plates_model.json
+setenv SKYBRICKS_DIR $env(DESI_ROOT)/target/skybricks/v3


### PR DESCRIPTION
@geordie666 this PR updates the etc/desitarget.module file to
  * be more portable by using `$DESI_ROOT` instead of `/global/cfs/cdirs/desi`
  * set `SKYBRICKS_DIR=$DESI_ROOT/target/skybricks/v3`
  * switch `$DUST_DIR` from `...cosmo/data/dust/v0_1` to `...desi/external/dust/v0_1`, which at NERSC is the same thing via links, but allows everything to be under `$DESI_ROOT` for environment portability

You can inspect the environment that would be installed with this at NERSC via:
```
source /global/cfs/cdirs/desi/software/desi_environment.sh 21.3
module unload desitarget
module load desitarget/modulefile
```
(the last two lines are the same as a `module swap desitarget/modulefile`, but allows you to inspect the environment in between to ensure that it really is unsetting `CMX_DIR` etc. before resetting correctly with the new environment file.

I'd like to tag this as 1.0.1 to get the `$SKYBRICKS_DIR` update.