### PR TITLE
Add option to use Gaia EDR3 when selecting GFAs

### DIFF
--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -23,6 +23,9 @@ ap.add_argument("surveydir",
                 help="Base directory for a Legacy Surveys Data Release (e.g. '/global/project/projectdirs/cosmo/data/legacysurvey/dr6/' at NERSC)")
 ap.add_argument("dest",
                 help="Output GFA targets directory (the file name is built on-the-fly from other inputs)")
+ap.add_argument("--gaiadr",
+                help="Gaia Data Release on which to base GFAs. Options are dr2 or edr3. Defaults to dr2.",
+                default="dr2")
 ap.add_argument('-m', '--maglim', type=float,
                 help="Magnitude limit on GFA targets in Gaia G-band (defaults to [21])",
                 default=21)
@@ -56,7 +59,7 @@ ns = ap.parse_args()
 # ADM bundlefiles potentially needs to know about them.
 extra = " --numproc {}".format(ns.numproc)
 nsdict = vars(ns)
-for nskey in "maglim", "mindec", "mingalb", "nourat":
+for nskey in "maglim", "mindec", "mingalb", "nourat", "gaiadr":
     if isinstance(nsdict[nskey], bool):
         if nsdict[nskey]:
             extra += " --{}".format(nskey)
@@ -89,13 +92,15 @@ if pixlist is not None:
 
 gfas = select_gfas(infiles, maglim=ns.maglim, numproc=ns.numproc, nside=ns.nside,
                    pixlist=pixlist, bundlefiles=ns.bundlefiles, extra=extra,
-                   mindec=ns.mindec, mingalb=ns.mingalb, addurat=not(ns.nourat))
+                   mindec=ns.mindec, mingalb=ns.mingalb, addurat=not(ns.nourat),
+                   dr=ns.gaiadr)
 
 # ADM only proceed if we're not writing a slurm script.
 if ns.bundlefiles is None:
     # ADM extra header keywords for the output fits file.
-    extra = {k: v for k, v in zip(["maglim", "mindec", "mingalb"],
-                                  [ns.maglim, ns.mindec, ns.mingalb])}
+    extra = {k: v for k, v in zip(
+        ["maglim", "mindec", "mingalb", "nourat", "gaiadr"],
+        [ns.maglim, ns.mindec, ns.mingalb, ns.nourat, ns.gaiadr])}
 
     log.info('Writing GFAs to file...t = {:.1f} mins'.format((time()-t0)/60.))
     ngfas, outfile = io.write_gfas(ns.dest, gfas, indir=ns.surveydir,

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,17 +5,26 @@ desitarget Change Log
 1.0.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Add option to use Gaia EDR3 when selecting GFAs [`PR #734`_]. Also:
+    * Initialize ``SUBPRIORITY`` with better random seeds.
+         * This is crucial when parallelizing across HEALPixels.
+    * Document that the ``io.write_`` routines alter ``SUBPRIORITY``.
+         * Plus, add a keyword to turn that overwriting behavior off.
+    * Add ``leq`` kwarg when reading ledgers with a specific `isodate`.
+         * Allows ledger entries to be read BEFORE or ON that date.
+         * Supplements the default of reading STRICTLY BEFORE that date.
+* Fix bug leading to zero MWS_FAINT targets [`PR #733`_].
+
+.. _`PR #733`: https://github.com/desihub/desitarget/pull/733
+.. _`PR #734`: https://github.com/desihub/desitarget/pull/734
 
 1.0.1 (2021-05-14)
 ------------------
 
-* Add $SKYBRICKS_DIR to module config; make more portable by using $DESI_ROOT
-  [`PR #732`_].
-* Fix bug leading to zero MWS_FAINT targets [`PR #733`_].
+* Add $SKYBRICKS_DIR to module config [`PR #732`_].
+    * Also, make more portable by using $DESI_ROOT.
 
 .. _`PR #732`: https://github.com/desihub/desitarget/pull/732
-.. _`PR #733`: https://github.com/desihub/desitarget/pull/733
 
 1.0.0 (2021-05-12)
 ------------------

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -258,10 +258,11 @@ def sub_gaia_edr3(filename, objs=None, suball=False):
     gswobjs, gswhdr = fitsio.read(gsweepfn, "GAIA_SWEEP", header=True)
 
     # ADM substitute the appropriate columns.
+    g3 = gswobjs["REF_CAT"] == 'G3'
     for col, gaiacol in zip(cols, gaiacols):
-        objs[col] = gswobjs[gaiacol]
+        objs[col][g3] = gswobjs[gaiacol][g3]
     # ADM may also need to update the REF_EPOCH.
-    objs["REF_EPOCH"] = gswhdr["REFEPOCH"]
+    objs["REF_EPOCH"][g3] = gswhdr["REFEPOCH"]
 
     # ADM if substituting everything, add vital 'PHOT_G_N_OBS' column.
     if suball:
@@ -269,7 +270,7 @@ def sub_gaia_edr3(filename, objs=None, suball=False):
         objsout = np.empty(len(objs), dtype=dt)
         for col in objs.dtype.names:
             objsout[col] = objs[col]
-        objsout['PHOT_G_N_OBS'] = gswobjs['EDR3_PHOT_G_N_OBS']
+        objsout['PHOT_G_N_OBS'][g3] = gswobjs['EDR3_PHOT_G_N_OBS'][g3]
         return objsout
 
     return objs

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -99,6 +99,23 @@ edr3datamodel = np.array([], dtype=[
 ])
 
 
+def check_gaia_survey(dr):
+    """Convenience function to check allowed Gaia Data Releases
+
+    Parameters
+    ----------
+    dr : :class:`str`
+        Name of a Gaia data release. Options are "dr2", "edr3". If one of
+        those options isn't passed, a ValueError is raised.
+    """
+    # ADM allowed Data Releases for input.
+    droptions = ["dr2", "edr3"]
+    if dr not in droptions:
+        msg = "input dr must be one of {}".format(droptions)
+        log.critical(msg)
+        raise ValueError(msg)
+
+
 def get_gaia_dir(dr="dr2"):
     """Convenience function to grab the Gaia environment variable.
 
@@ -112,12 +129,8 @@ def get_gaia_dir(dr="dr2"):
     :class:`str`
         The directory stored in the $GAIA_DIR environment variable.
     """
-    # ADM allowed Data Releases for input.
-    droptions = ["dr2", "edr3"]
-    if dr not in droptions:
-        msg = "input dr must be one of {}".format(droptions)
-        log.critical(msg)
-        raise IOError(msg)
+    # ADM check for valid Gaia DR.
+    check_gaia_survey(dr)
 
     # ADM check that the $GAIA_DIR environment variable is set.
     gaiadir = os.environ.get('GAIA_DIR')
@@ -186,12 +199,8 @@ def gaia_psflike(aen, g, dr="dr2"):
     -----
         - Input quantities are the same as in `the Gaia data model`_.
     """
-    # ADM allowed Data Releases for input.
-    droptions = ["dr2", "edr3"]
-    if dr not in droptions:
-        msg = "input dr must be one of {}".format(droptions)
-        log.critical(msg)
-        raise IOError(msg)
+    # ADM check for valid Gaia DR.
+    check_gaia_survey(dr)
 
     if dr == "dr2":
         psflike = np.logical_or(
@@ -266,11 +275,11 @@ def sub_gaia_edr3(filename, objs=None, suball=False):
 
     # ADM if substituting everything, add vital 'PHOT_G_N_OBS' column.
     if suball:
-        dt = objs.dtype.descr + [('PHOT_G_N_OBS', '>i4')]
+        dt = objs.dtype.descr + [('GAIA_PHOT_G_N_OBS', '>i4')]
         objsout = np.empty(len(objs), dtype=dt)
         for col in objs.dtype.names:
             objsout[col] = objs[col]
-        objsout['PHOT_G_N_OBS'][g3] = gswobjs['EDR3_PHOT_G_N_OBS'][g3]
+        objsout['GAIA_PHOT_G_N_OBS'][g3] = gswobjs['EDR3_PHOT_G_N_OBS'][g3]
         return objsout
 
     return objs

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -638,6 +638,11 @@ def select_gfas(infiles, maglim=18, numproc=4, nside=None,
                  .format(np.sum(urat["URAT_ID"] != -1), (time()-t0)/60))
         for col in "PMRA", "PMDEC", "URAT_ID", "URAT_SEP":
             gfas[col][ii] = urat[col]
+        # ADM there are a couple of cases where Tycho has zero REF_EPOCH.
+        # When these match to URAT, it's likely a mismatch.
+        nore = gfas["REF_EPOCH"] == 0
+        gfas["PMRA"][ii & nore] = 0.
+        gfas["PMDEC"][ii & nore] = 0.
 
     # ADM restrict to only GFAs in a set of HEALPixels, if requested.
     if pixlist is not None:

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -642,6 +642,10 @@ def select_gfas(infiles, maglim=18, numproc=4, nside=None,
         gfas = np.concatenate(gfas)
         # ADM resolve any duplicates between imaging data releases.
         gfas = resolve(gfas)
+        # ADM there may be a few objects removed from Gaia DR2 in EDR3.
+        if dr != "dr2":
+            ii = (gfas["REF_CAT"] != b"G2") & (gfas["REF_CAT"] != "G2")
+            gfas = gfas[ii]
 
     # ADM retrieve Gaia objects in the DESI footprint or passed tiles.
     log.info('Retrieving additional Gaia objects...t = {:.1f} mins'

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -75,6 +75,9 @@ def gaia_morph(gaia, dr="dr2"):
         and is set to either "GPSF" or "GGAL" based on a
         morphological cut with Gaia.
     """
+    # ADM check for valid Gaia DR.
+    check_gaia_survey(dr)
+
     # ADM determine which objects are Gaia point sources.
     g = gaia['GAIA_PHOT_G_MEAN_MAG']
     aen = gaia['GAIA_ASTROMETRIC_EXCESS_NOISE']
@@ -105,6 +108,9 @@ def gaia_gfas_from_sweep(filename, maglim=18., dr="dr2"):
     :class:`~numpy.ndarray`
         GFA objects from Gaia, formatted according to `desitarget.gfa.gfadatamodel`.
     """
+    # ADM check for valid Gaia DR.
+    check_gaia_survey(dr)
+
     # ADM read in the objects.
     objects = fitsio.read(filename)
     # ADM if Gaia EDR3 was requested, update the Gaia columns.
@@ -217,6 +223,9 @@ def gaia_in_file(infile, maglim=18, mindec=-30., mingalb=10., nside=None,
        - A "Gaia healpix file" here is as made by, e.g.
          :func:`~desitarget.gaiamatch.gaia_fits_to_healpix()`
     """
+    # ADM check for valid Gaia DR.
+    check_gaia_survey(dr)
+
     # ADM read in the Gaia file.
     objs = read_gaia_file(infile, addobjid=addobjid, dr=dr)
 
@@ -347,6 +356,9 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
     -----
        - The environment variables $GAIA_DIR and $DESIMODEL must be set.
     """
+    # ADM check for valid Gaia DR.
+    check_gaia_survey(dr)
+
     # ADM to guard against no files being found.
     if pixlist is None:
         dummyfile = find_gaia_files_hp(_get_gaia_nside(), [0],
@@ -560,6 +572,9 @@ def select_gfas(infiles, maglim=18, numproc=4, nside=None,
         - If numproc > 4, then numproc=4 is enforced for (just those)
           parts of the code that are I/O limited.
     """
+    # ADM check for valid Gaia DR.
+    check_gaia_survey(dr)
+
     # ADM the code can have memory issues for nside=2 with large numproc.
     if nside is not None and nside < 4 and numproc > 8:
         msg = 'Memory may be an issue near Plane for nside < 4 and numproc > 8'

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -25,7 +25,7 @@ from desitarget.gaiamatch import _get_gaia_nside, gaia_psflike, sub_gaia_edr3
 from desitarget.uratmatch import match_to_urat
 from desitarget.targets import encode_targetid, resolve
 from desitarget.geomask import is_in_gal_box, is_in_box, is_in_hp
-from desitarget.geomask import bundle_bricks, sweep_files_touch_hp
+from desitarget.geomask import bundle_bricks, sweep_files_touch_hp, rewind_coords
 from desitarget.randoms import get_dust
 
 from desiutil import brick
@@ -231,10 +231,17 @@ def gaia_in_file(infile, maglim=18, mindec=-30., mingalb=10., nside=None,
 
     # ADM need to change the data model to Gaia DR2 for Gaia EDR3.
     if dr == "edr3":
+        # ADM first, rewind the coordinates from 2016.0 to 2015.5.
+        rarew, decrew = rewind_coords(objs["EDR3_RA"], objs["EDR3_DEC"],
+                                      objs["EDR3_PMRA"], objs["EDR3_PMDEC"],
+                                      epochnow=2016.0, epochpast=2015.5)
+        objs["EDR3_RA"] = rarew
+        objs["EDR3_DEC"] = decrew
         gaiacols = [col.replace("EDR3", "GAIA") for col in objs.dtype.names]
         objs.dtype.names = [col.replace("GAIA_", "") if
                             "PARALLAX" in col or "PMRA" in col or "PMDEC" in col
                             else col for col in gaiacols]
+
     # ADM rename GAIA_RA/DEC to RA/DEC, as that's what's used for GFAs.
     for radec in ["RA", "DEC"]:
         objs.dtype.names = [radec if col == "GAIA_"+radec else col

--- a/py/desitarget/gfa.py
+++ b/py/desitarget/gfa.py
@@ -357,18 +357,19 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
         dummyfile = find_gaia_files_hp(nside, pixlist[0],
                                        neighbors=False, dr=dr)[0]
     dummygfas = np.array([], gaia_in_file(
-        dummyfile, addparams=addparams, test=test).dtype, dr=dr)
+        dummyfile, addparams=addparams, test=test, dr=dr).dtype)
 
     # ADM grab paths to Gaia files in the sky or the DESI footprint.
     if allsky:
-        infilesbox = find_gaia_files_box([0, 360, mindec, 90])
-        infilesgalb = find_gaia_files_beyond_gal_b(mingalb)
+        infilesbox = find_gaia_files_box([0, 360, mindec, 90], dr=dr)
+        infilesgalb = find_gaia_files_beyond_gal_b(mingalb, dr=dr)
         infiles = list(set(infilesbox).intersection(set(infilesgalb)))
         if pixlist is not None:
-            infileshp = find_gaia_files_hp(nside, pixlist, neighbors=False)
+            infileshp = find_gaia_files_hp(nside, pixlist,
+                                           neighbors=False, dr=dr)
             infiles = list(set(infiles).intersection(set(infileshp)))
     else:
-        infiles = find_gaia_files_tiles(tiles=tiles, neighbors=False)
+        infiles = find_gaia_files_tiles(tiles=tiles, neighbors=False, dr=dr)
     nfiles = len(infiles)
 
     # ADM the critical function to run on every file.
@@ -376,7 +377,7 @@ def all_gaia_in_tiles(maglim=18, numproc=4, allsky=False,
         '''wrapper on gaia_in_file() given a file name'''
         return gaia_in_file(fn, maglim=maglim, mindec=mindec, mingalb=mingalb,
                             nside=nside, pixlist=pixlist, test=test,
-                            addobjid=addobjid, addparams=addparams)
+                            addobjid=addobjid, addparams=addparams, dr=dr)
 
     # ADM this is just to count sweeps files in _update_status.
     nfile = np.zeros((), dtype='i8')

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1137,7 +1137,8 @@ def write_skies(targdir, data, indir=None, indir2=None, supp=False,
     - Various columns and header keywords are updated when writing, so
       take care. For instance, pass `subpriority=False` unless you really
       want to update the `SUBPRIORITY` column.
-    - Because of the way random seeds are constructed for SUBPRIORITY, we require nsidefile to be less than 1024
+    - Because of the way random seeds are constructed for SUBPRIORITY, we
+      require `nsidefile` to be less than 1024.
     """
     nskies = len(data)
 

--- a/py/desitarget/skybricks.py
+++ b/py/desitarget/skybricks.py
@@ -93,8 +93,8 @@ class Skybricks(object):
             # Read skybrick file, looking for fits.fz then fits.gz
             for ext in ['fz', 'gz']:
                 fn = os.path.join(self.skybricks_dir,
-                        'sky-{}.fits.{}'.format(
-                            self.skybricks['BRICKNAME'][i], ext))
+                                  'sky-{}.fits.{}'.format(
+                                      self.skybricks['BRICKNAME'][i], ext))
                 if os.path.exists(fn):
                     break
             else:

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -577,9 +577,11 @@ def calc_numobs_more(targets, zcat, obscon):
             # ADM z < midzcut it will need to drop by 2 total observations
             # ADM (midzcut is defined at the top of this module).
             ii = targets[desi_target] & desi_mask.QSO != 0
-            for scxname in scnd_mask.names():
-                if scnd_mask[scxname].flavor == "QSO":
-                    ii |= targets[scnd_target] & scnd_mask[scxname] != 0
+            # ADM the mocks may not include the secondary targets.
+            if scnd_target in targets.dtype.names:
+                for scxname in scnd_mask.names():
+                    if scnd_mask[scxname].flavor == "QSO":
+                        ii |= targets[scnd_target] & scnd_mask[scxname] != 0
             ii &= (zcat['ZWARN'] == 0)
             ii &= (zcat['Z'] < midzcut)
             numobs_more[ii] = np.maximum(0, numobs_more[ii] - 2)


### PR DESCRIPTION
This PR is focused on updating the GFA targets to use Gaia EDR3. 

It also adds a handful of requested features and bug fixes, which include:

- Initializing the `SUBPRIORITY` value in target files with better-constructed random seeds.
  * These seeds are now based on the HEALPixel number when parallelizing across pixels.
- Documenting that the `desitarget.io.write_*` routines alter the value of `SUBPRIORITY`, and including a keyword option to turn that overwriting behavior off.
- Adding a `leq` kwarg when reading ledgers with a specific `isodate`.
  * This keyword allows ledgers to be queried _before-and-on_ that date, which supplements the default option of querying the ledgers _strictly before_ the passed `isodate`.