### PR TITLE
WIP toward subpriority overrides

### DIFF
--- a/bin/select_secondary
+++ b/bin/select_secondary
@@ -33,6 +33,10 @@ ap.add_argument("--nomasking", action='store_true',
 ap.add_argument("--maskdir",
                 help="Name of the specific directory (or file) containing the bright star mask (defaults to the most recent directory in $MASK_DIR)",
                 default=None)
+ap.add_argument("--dark-subpriorities", type=str,
+                help='Optional file with dark TARGETID:SUBPRIORITY overrides')
+ap.add_argument("--bright-subpriorities", type=str,
+                help='Optional file with bright TARGETID:SUBPRIORITY overrides')
 
 ns = ap.parse_args()
 do_mask = not(ns.nomasking)
@@ -88,6 +92,13 @@ if do_mask:
 hdr["masked"] = do_mask
 hdr["maskdir"] = mdcomp
 
+# SB subpriority override logic assumes that io.write_targets will set
+# subpriorities; if they have already been set, crash early so that we
+# can fix the logic
+if np.any(scx['SUBPRIORITY'] > 0.0):
+    log.critical('SUBPRIORITY already set; fix override logic below')
+    sys.exit(1)
+
 # ADM write out the secondary targets, with bright-time
 # ADM and dark-time targets written separately.
 obscons = ["BRIGHT", "DARK"]
@@ -95,6 +106,18 @@ obscons = ["BRIGHT", "DARK"]
 if ns.writeall:
     obscons.append(None)
 for obscon in obscons:
+
+    # SB apply optional subpriority override; modifies targets in-place
+    scx['SUBPRIORITY'] = 0.0  # SB reset any previous overrides
+    if obscon == 'BRIGHT' and ns.bright_subpriorities:
+        subpriorities = fitsio.read(ns.bright_subpriorities, 'SUBPRIORITY')
+        overrideidx = override_subpriority(scx, subpriorities)
+        log.info(f'Overriding {len(overrideidx)} {obscon} subpriorities')
+    elif obscon == 'DARK' and ns.dark_subpriorities:
+        subpriorities = fitsio.read(ns.dark_subpriorities, 'SUBPRIORITY')
+        overrideidx = override_subpriority(scx, subpriorities)
+        log.info(f'Overriding {len(overrideidx)} {obscon} subpriorities')
+
     # ADM the dict() here is to make hdr immutable.
     if obscon is None:
         ntargs, outfile = io.write_secondary(ns.dest, scx, primhdr=dict(hdr),

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -13,6 +13,7 @@ from desitarget.subpriority import override_subpriority
 
 import numpy as np
 import healpy as hp
+import fitsio
 from glob import glob
 
 #import warnings
@@ -68,8 +69,8 @@ ap.add_argument("--nomasking", action='store_true',
 ap.add_argument("--maskdir",
                 help="Name of the specific directory (or file) containing the bright star mask (defaults to the most recent directory in $MASK_DIR)",
                 default=None)
-ap.add_argument("--override-subpriority", type=str,
-                help='Optional file with TARGETID:SUBPRIORITY override')
+ap.add_argument("--sky-subpriorities", type=str,
+                help='Optional file with sky TARGETID:SUBPRIORITY override')
 
 ns = ap.parse_args()
 do_mask = not(ns.nomasking)
@@ -175,13 +176,13 @@ else:
                                   [do_mask, mdcomp])}
 
     # SB apply optional subpriority override; modifies skies in-place
-    if ns.override_subpriority:
-        subpriorities = fitsio.read(ns.override_subpriority, 'SUBPRIORITY')
+    if ns.sky_subpriorities:
+        subpriorities = fitsio.read(ns.sky_subpriorities, 'SUBPRIORITY')
         ii = override_subpriority(skies, subpriorities)
         if len(ii) > 0:
-            log.info(f"Overriding {len(ii)} SUBPRIORITY from {ns.override_subpriority}")
+            log.info(f"Overriding {len(ii)} SUBPRIORITY from {ns.sky_subpriorities}")
         else:
-            log.warning(f"No matching targets to override SUBPRIORITY from {ns.override_subpriority}")
+            log.warning(f"No matching targets to override SUBPRIORITY from {ns.sky_subpriorities}")
 
 
     # ADM this correctly records the apertures in the output file header

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -9,6 +9,7 @@ from desitarget.io import check_both_set
 from desitarget.geomask import bundle_bricks
 from desitarget.targets import resolve
 from desitarget.brightmask import mask_targets, get_recent_mask_dir
+from desitarget.subpriority import override_subpriority
 
 import numpy as np
 import healpy as hp
@@ -67,6 +68,8 @@ ap.add_argument("--nomasking", action='store_true',
 ap.add_argument("--maskdir",
                 help="Name of the specific directory (or file) containing the bright star mask (defaults to the most recent directory in $MASK_DIR)",
                 default=None)
+ap.add_argument("--override-subpriority", type=str,
+                help='Optional file with TARGETID:SUBPRIORITY override')
 
 ns = ap.parse_args()
 do_mask = not(ns.nomasking)
@@ -170,6 +173,16 @@ else:
     # ADM extra header keywords for the output fits file.
     extra = {k: v for k, v in zip(["masked", "maskdir"],
                                   [do_mask, mdcomp])}
+
+    # SB apply optional subpriority override; modifies skies in-place
+    if ns.override_subpriority:
+        subpriorities = fitsio.read(ns.override_subpriority, 'SUBPRIORITY')
+        ii = override_subpriority(skies, subpriorities)
+        if len(ii) > 0:
+            log.info(f"Overriding {len(ii)} SUBPRIORITY from {ns.override_subpriority}")
+        else:
+            log.warning(f"No matching targets to override SUBPRIORITY from {ns.override_subpriority}")
+
 
     # ADM this correctly records the apertures in the output file header
     # ADM as well as adding HEALPixel information.

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -12,6 +12,7 @@ from desitarget.cuts import select_targets, qso_selection_options
 from desitarget.brightmask import mask_targets
 from desitarget.QA import _parse_tcnames
 from desitarget.targets import decode_targetid
+from desitarget.subpriority import override_subpriority
 
 from time import time
 start = time()
@@ -79,6 +80,8 @@ ap.add_argument("-noc", "--nochecksum", action='store_true',
                 help='Do NOT add the list of input files and their checksums to the output target file as the second ("INFILES") extension')
 ap.add_argument("-check", "--checkbright", action='store_true',
                 help='If passed, then log a warning about targets that could be too bright when writing output files')
+ap.add_argument("--override-subpriority", type=str,
+                help='Optional file with TARGETID:SUBPRIORITY override')
 
 ns = ap.parse_args()
 # ADM build the list of command line arguments as
@@ -160,6 +163,15 @@ if ns.bundlefiles is None:
         shatab = None
     else:
         shatab = get_checksums(infn, verbose=True)
+
+    # SB apply optional subpriority override; modifies targets in-place
+    if ns.override_subpriority:
+        subpriorities = fitsio.read(ns.override_subpriority, 'SUBPRIORITY')
+        ii = override_subpriority(targets, subpriorities)
+        if len(ii) > 0:
+            log.info(f"Overriding {len(ii)} SUBPRIORITY from {ns.override_subpriority}")
+        else:
+            log.warning(f"No matching targets to override SUBPRIORITY from {ns.override_subpriority}")
 
     # ADM only run secondary functions if --nosecondary was not passed.
     scndout = None

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -80,8 +80,10 @@ ap.add_argument("-noc", "--nochecksum", action='store_true',
                 help='Do NOT add the list of input files and their checksums to the output target file as the second ("INFILES") extension')
 ap.add_argument("-check", "--checkbright", action='store_true',
                 help='If passed, then log a warning about targets that could be too bright when writing output files')
-ap.add_argument("--override-subpriority", type=str,
-                help='Optional file with TARGETID:SUBPRIORITY override')
+ap.add_argument("--dark-subpriorities", type=str,
+                help='Optional file with dark TARGETID:SUBPRIORITY overrides')
+ap.add_argument("--bright-subpriorities", type=str,
+                help='Optional file with bright TARGETID:SUBPRIORITY overrides')
 
 ns = ap.parse_args()
 # ADM build the list of command line arguments as
@@ -164,15 +166,6 @@ if ns.bundlefiles is None:
     else:
         shatab = get_checksums(infn, verbose=True)
 
-    # SB apply optional subpriority override; modifies targets in-place
-    if ns.override_subpriority:
-        subpriorities = fitsio.read(ns.override_subpriority, 'SUBPRIORITY')
-        ii = override_subpriority(targets, subpriorities)
-        if len(ii) > 0:
-            log.info(f"Overriding {len(ii)} SUBPRIORITY from {ns.override_subpriority}")
-        else:
-            log.warning(f"No matching targets to override SUBPRIORITY from {ns.override_subpriority}")
-
     # ADM only run secondary functions if --nosecondary was not passed.
     scndout = None
     if not ns.nosecondary and len(targets) > 0:
@@ -224,7 +217,27 @@ if ns.bundlefiles is None:
         obscons.append(None)
         iis.append(~isgaia)
         supps.append(False)
+
+    # SB subpriority override logic assumes that io.write_targets will set
+    # subpriorities; if they have already been set, crash early so that we
+    # can fix the logic
+    if np.any(targets['SUBPRIORITY'] > 0.0):
+        log.critical('SUBPRIORITY already set; fix override logic below')
+        sys.exit(1)
+
     for obscon, ii, supp in zip(obscons, iis, supps):
+
+        # SB apply optional subpriority override; modifies targets in-place
+        targets['SUBPRIORITY'] = 0.0  # SB reset any previous overrides
+        if obscon == 'BRIGHT' and ns.bright_subpriorities:
+            subpriorities = fitsio.read(ns.bright_subpriorities, 'SUBPRIORITY')
+            overrideidx = override_subpriority(targets, subpriorities)
+            log.info(f'Overriding {len(overrideidx)} {obscon} subpriorities')
+        elif obscon == 'DARK' and ns.dark_subpriorities:
+            subpriorities = fitsio.read(ns.dark_subpriorities, 'SUBPRIORITY')
+            overrideidx = override_subpriority(targets, subpriorities)
+            log.info(f'Overriding {len(overrideidx)} {obscon} subpriorities')
+
         ntargs, outfile = io.write_targets(
             ns.dest, targets[ii], resolve=not(ns.noresolve), nside=nside,
             maskbits=not(ns.nomaskbits), indir=ns.sweepdir, indir2=ns.sweepdir2,

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -613,7 +613,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
         np.random.seed(616)
         # SB only set subpriorities that aren't already set, but keep original
         # full random sequence order
-        ii = data["SUBPRIORITY"] > 0.0
+        ii = data["SUBPRIORITY"] == 0.0
         data["SUBPRIORITY"][ii] = np.random.random(ntargs)[ii]
 
     # ADM add the type of survey (main, commissioning; or "cmx", sv) to the header.
@@ -970,7 +970,7 @@ def write_secondary(targdir, data, primhdr=None, scxdir=None, obscon=None,
         np.random.seed(616)
         # SB only set subpriorities that aren't already set, but keep original
         # full random sequence order
-        ii = data["SUBPRIORITY"] > 0.0
+        ii = data["SUBPRIORITY"] == 0.0
         data["SUBPRIORITY"][ii] = np.random.random(ntargs)[ii]
 
     # ADM remove the supplemental columns.
@@ -1164,7 +1164,7 @@ def write_skies(targdir, data, indir=None, indir2=None, supp=False,
 
         # SB only set subpriorities that aren't already set, but keep original
         # full random sequence order
-        ii = data["SUBPRIORITY"] > 0.0
+        ii = data["SUBPRIORITY"] == 0.0
         data["SUBPRIORITY"][ii] = np.random.random(nskies)[ii]
 
     # ADM add the extra dictionary to the header.

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -611,7 +611,10 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
     # ADM populate SUBPRIORITY with a reproducible random float.
     if "SUBPRIORITY" in data.dtype.names and mockdata is None:
         np.random.seed(616)
-        data["SUBPRIORITY"] = np.random.random(ntargs)
+        # SB only set subpriorities that aren't already set, but keep original
+        # full random sequence order
+        ii = data["SUBPRIORITY"] > 0.0
+        data["SUBPRIORITY"][ii] = np.random.random(ntargs)[ii]
 
     # ADM add the type of survey (main, commissioning; or "cmx", sv) to the header.
     hdr["SURVEY"] = survey
@@ -965,7 +968,10 @@ def write_secondary(targdir, data, primhdr=None, scxdir=None, obscon=None,
     if "SUBPRIORITY" in data.dtype.names:
         ntargs = len(data)
         np.random.seed(616)
-        data["SUBPRIORITY"] = np.random.random(ntargs)
+        # SB only set subpriorities that aren't already set, but keep original
+        # full random sequence order
+        ii = data["SUBPRIORITY"] > 0.0
+        data["SUBPRIORITY"][ii] = np.random.random(ntargs)[ii]
 
     # ADM remove the supplemental columns.
     from desitarget.secondary import suppdatamodel
@@ -1155,7 +1161,11 @@ def write_skies(targdir, data, indir=None, indir2=None, supp=False,
             np.random.seed(626)
         else:
             np.random.seed(616)
-        data["SUBPRIORITY"] = np.random.random(nskies)
+
+        # SB only set subpriorities that aren't already set, but keep original
+        # full random sequence order
+        ii = data["SUBPRIORITY"] > 0.0
+        data["SUBPRIORITY"][ii] = np.random.random(nskies)[ii]
 
     # ADM add the extra dictionary to the header.
     if extra is not None:

--- a/py/desitarget/subpriority.py
+++ b/py/desitarget/subpriority.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+
+"""
+Get what subpriority was used by fiberassign
+"""
+
+import os.path
+import numpy as np
+import fitsio
+from desiutil.log import get_logger
+
+def override_subpriority(targets, override):
+    """
+    Override SUBPRIORITY column in targets for those in override table
+
+    Args:
+        targets: table with columns TARGETID and SUBPRIORITY
+        override: table with columns TARGETID and SUBPRIORITY
+
+    Returns:
+        indices of targets table rows that were changed
+
+    Modifies ``targets`` table in-place without copying memory.
+    Rows in ``targets`` that aren't in ``override`` are unchanged.
+    Rows in ``override`` that aren't in ``targets`` are ignored.
+    """
+    log = get_logger()
+    ii = np.where(np.isin(targets['TARGETID'], override['TARGETID']))[0]
+    n = len(ii)
+    if n > 0:
+        subprio_dict = dict()
+        for tid, subprio in zip(override['TARGETID'], override['SUBPRIORITY']):
+            subprio_dict[tid] = subprio
+
+        for i in ii:
+            tid = targets['TARGETID'][i]
+            targets['SUBPRIORITY'][i] = subprio_dict[tid]
+
+    return ii
+
+
+def get_fiberassign_subpriorities(fiberassignfiles,
+        survey, program=None, expect_unique=False):
+    """
+    TODO: document
+    """
+    log = get_logger()
+
+    #- allow duplicate inputs, but don't process multiple tiles
+    processed = set()
+
+    subpriorities = list()
+    for filename in fiberassignfiles:
+        #- Have we already processed this file (e.g. from an earlier expid)?
+        basename = os.path.basename(filename)
+        if basename in processed:
+            continue
+        else:
+            processed.add(basename)
+
+        with fitsio.FITS(filename) as fx:
+            hdr = fx[0].read_header()
+
+            if 'SURVEY' not in hdr:
+                log.warning(f"Skipping {filename} missing SURVEY keyword")
+                continue
+
+            if 'FAPRGRM' not in hdr:
+                log.warning(f"Skipping {filename} missing FAPRGRM keyword")
+                continue
+
+            if survey and (hdr['SURVEY'].lower() != survey.lower()):
+                log.info(f"Skipping {filename} with SURVEY {hdr['SURVEY']} != {survey}")
+                continue
+
+            if program and (hdr['FAPRGRM'].lower() != program.lower()):
+                log.info(f"Skipping {filename} with FAPRGRM {hdr['FAPRGRM']} != {program}")
+                continue
+
+            log.info(f'Reading {filename}')
+            sp = fx['TARGETS'].read(columns=['TARGETID', 'SUBPRIORITY'])
+
+        subpriorities.append(sp)
+
+    log.info('Stacking individual fiberassign inputs')
+    subpriorities = np.hstack(subpriorities)
+
+    #- QA checks on basic assumptions
+    log.info('Checking assumptions about TARGETID:SUBPRIORITY uniqueness')
+    tid, sortedidx = np.unique(subpriorities['TARGETID'], return_index=True)
+    if len(tid) != len(subpriorities):
+        if expect_unique:
+            log.warning('Some TARGETIDs appear multiple times')
+
+        subpriodict = dict()
+        for targetid, subprio in zip(
+                subpriorities['TARGETID'], subpriorities['SUBPRIORITY']):
+            if targetid in subpriodict:
+                if subprio != subpriodict[targetid]:
+                    log.error(f'TARGETID {targetid} has multiple subpriorities')
+            else:
+                subpriodict[targetid] = subprio
+
+    log.info('Sorting by TARGETID')
+    subpriorities = subpriorities[sortedidx]
+
+    return subpriorities
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument('-i', '--infiles', nargs='+', required=True,
+            help='Input fiberassign files with TARGETS HDU')
+    p.add_argument('-o', '--outfile', required=True,
+            help='Output FITS file to keep TARGETID SUBPRIORITY')
+    p.add_argument('--survey', default='main',
+            help='SURVEY survey filter')
+    p.add_argument('--faprgrm', required=True,
+            help='FAPRGRM program filter')
+    
+    args = p.parse_args()
+    log = get_logger()
+
+    nfiles = len(args.infiles)
+    log.info(f'Getting target subpriorities from {nfiles} fiberassign files')
+    subpriorities = get_fiberassign_subpriorities(
+            args.infiles, args.survey, args.faprgrm, expect_unique=True)
+    log.info(f'{len(subpriorities)} targets')
+
+    if 'DESI_ROOT' in os.environ:
+        desiroot = os.path.normpath(os.getenv('DESI_ROOT'))
+    else:
+        desiroot = None
+
+    hdr = fitsio.FITSHDR()
+    for i, filename in enumerate(args.infiles):
+        if desiroot and filename.startswith(desiroot):
+            filename = filename.replace(desiroot, '$DESI_ROOT')
+
+        hdr[f'INFIL{i:03d}'] = filename
+
+    fitsio.write(args.outfile, subpriorities, extname='SUBPRIORITY', header=hdr, clobber=True)
+    log.info(f'Wrote {args.outfile}')
+
+
+

--- a/py/desitarget/subpriority.py
+++ b/py/desitarget/subpriority.py
@@ -11,6 +11,7 @@ import fitsio
 from desiutil.log import get_logger
 
 from desitarget.targetmask import desi_mask
+from desitarget.geomask import match
 
 def override_subpriority(targets, override):
     """
@@ -27,19 +28,11 @@ def override_subpriority(targets, override):
     Rows in ``targets`` that aren't in ``override`` are unchanged.
     Rows in ``override`` that aren't in ``targets`` are ignored.
     """
-    log = get_logger()
-    ii = np.where(np.isin(targets['TARGETID'], override['TARGETID']))[0]
-    n = len(ii)
-    if n > 0:
-        subprio_dict = dict()
-        for tid, subprio in zip(override['TARGETID'], override['SUBPRIORITY']):
-            subprio_dict[tid] = subprio
+    ii_targ, ii_over = match(targets['TARGETID'], override['TARGETID'])
+    if len(ii_targ) > 0:
+        targets['SUBPRIORITY'][ii_targ] = override['SUBPRIORITY'][ii_over]
 
-        for i in ii:
-            tid = targets['TARGETID'][i]
-            targets['SUBPRIORITY'][i] = subprio_dict[tid]
-
-    return ii
+    return np.sort(ii_targ)
 
 
 def get_fiberassign_subpriorities(fiberassignfiles):

--- a/py/desitarget/test/test_geomask.py
+++ b/py/desitarget/test/test_geomask.py
@@ -14,7 +14,7 @@ class TestGEOMASK(unittest.TestCase):
 
     @classmethod
     def setUp(self):
-        drdir = '/global/project/projectdirs/cosmo/work/legacysurvey/dr8b/'
+        drdir = '/blat/foo'  # doesn't have to exist, just for paths
         self.surveydir = os.path.join(drdir, 'decam')
         self.surveydir2 = os.path.join(drdir, '90prime-mosaic')
 
@@ -29,6 +29,33 @@ class TestGEOMASK(unittest.TestCase):
         foo = geomask.bundle_bricks(1, 1, 1,
                                     surveydirs=[self.surveydir, self.surveydir2])
         self.assertTrue(foo is None)
+
+    def test_match(self):
+        a = np.array([1,2,3,4])
+        b = np.array([4,3])
+        iia, iib = geomask.match(a, b)
+
+        #- returned indices match
+        self.assertTrue(np.all(a[iia] == b[iib]))
+
+        #- ... and are complete
+        ainb = np.isin(a, b)
+        bina = np.isin(b, a)
+        self.assertTrue(np.all( np.isin(a[ainb], a[iia]) ) )
+        self.assertTrue(np.all( np.isin(b[bina], b[iib]) ) )
+
+        #- Check corner cases
+        a = np.array([1,2,3,4])
+        b = np.array([5,6])
+        iia, iib = geomask.match(a, b)
+        self.assertEqual(len(iia), 0)
+        self.assertEqual(len(iib), 0)
+
+        a = np.array([1,2,3,4])
+        b = np.array([4,3,2,1])
+        iia, iib = geomask.match(a, b)
+        self.assertTrue(np.all(a[iia] == b[iib]))
+        self.assertTrue(len(iia), len(a))
 
 
 if __name__ == '__main__':

--- a/py/desitarget/test/test_subpriority.py
+++ b/py/desitarget/test/test_subpriority.py
@@ -1,0 +1,54 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desitarget.subpriority
+"""
+import unittest
+from pkg_resources import resource_filename
+import numpy as np
+import os
+from astropy.table import Table
+
+import desitarget.subpriority
+
+class TestSubpriority(unittest.TestCase):
+
+    @classmethod
+    def setUp(self):
+        pass
+
+    def test_override(self):
+        n = 10
+        targets = Table()
+        ids = np.arange(n)
+        np.random.shuffle(ids)
+        targets['TARGETID'] = ids
+        orig_subpriority = np.random.random(n)
+        targets['SUBPRIORITY'] = orig_subpriority.copy()
+
+        override = Table()
+        override['TARGETID'] = np.array([3,2,20])
+        override['SUBPRIORITY'] = np.array([10.0, 20.0, 30.0])
+
+        desitarget.subpriority.override_subpriority(targets, override)
+
+        #- Check that we overrode correctly; don't juse geomask.match
+        #- to avoid circularity of code and test
+        for i, tid in enumerate(targets['TARGETID']):
+            in_override = np.where(override['TARGETID'] == tid)[0]
+            if len(in_override) > 0:
+                j = in_override[0]
+                self.assertEqual(targets['SUBPRIORITY'][i], override['SUBPRIORITY'][j])
+            else:
+                self.assertEqual(targets['SUBPRIORITY'][i], orig_subpriority[i])
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+def test_suite():
+    """Allows testing of only this module with the command:
+
+        python setup.py test -m desitarget.test.test_geomask
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
This PR is work in progress towards providing optional SUBPRIORITY overrides to account for fiberassign accidentally resetting SUBPRIORITY for the first lunation of the main survey.  This doesn't yet do everything we need, but it provides something tangible to discuss to get there.

### What works ###

`desitarget.subpriority.get_fiberassign_subpriority()` takes an input list of fiberassign files and writes an output FITS table with TARGETID, SUBPRIORITY columns for all targets covered by those tiles (not just those assigned), while filtering on SURVEY (main) and FAPRGRM (dark, bright).  The output files would be used for overriding subpriority when rerunning select_targets.

Additionally, `py/desitarget/subpriority.py` has a `if __name__ == "__main__"` that can be used to call `get_fiberassign_subpriority` from the command line.  I didn't put this into bin/ because I didn't want to pollute desitarget/bin with a one-off script, but it is handy to call it from the command line with a glob and I wanted to record the code for making those override lists.

`desitarget.subpriority.override_subpriority(targets, override)` updates the `SUBPRIORITY` column of `TARGETS` in-place by matching on `TARGETID` in the `override` table.  Both `targets` and `override` can have entries that aren't in the other table.  This is put into a separate function so that `bin/select_targets` and `bin/select_skies` can use the same code.

`desitarget.io.write_*` functions updated to only set SUBPRIORITY for entries that aren't already set (i.e. >0).  This is implemented such that SUBPRIORITY row `i` would get the same value regardless of whether the other rows are pre-set or not.  To be tested.

**TODO**: when I ran on /global/cfs/cdirs/desi/spectro/data/202105*/*/fiberassign*.fits.gz I found more main+dark targets than when running on /global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/00[12] .  Figure out why.

### What doesn't work (yet) ###

I implemented a single `select_targets --override-subpriority FILENAME` option, but then post-facto realized that `select_targets` does both bright and dark in a single run and thus needs two separate override lists.  I think this would move the call to `override_subpriority` to immediately before `io.write_targets`, using `obscon` to select which override list to use, since unfortunately the same TARGETID appears in already observed dark and bright tiles with different SUBPRIORITY (though I haven't checked if those are science targets or just skies).

`select_skies --override-subpriority FILENAME` is implemented, but I probably need to update `get_fiberassign_subpriority()` to split out science targets from skies to get the union of dark+bright skies covered by already observed tiles.

Question: were any secondary targets included in the initial target/mtl files?  I wasn't sure what the SUBPRIORITY situation was for secondaries, so I didn't update `bin/select_secondary` (yet?).  I did put a hook in `io.write_secondary` for not-resetting already set SUBPRIORITY; it's just not used yet.

Also: for the SUBPRIORITY that *are* set by `io.write_*`, I didn't change the random seed generation to be per-healpix, which I think we want to do but I wanted to keep that concept separate from the concept of providing external SUBPRIORITY override lists.

@geordie666 please take a look and let's chat.
