### PR TITLE
reproducible order of input files

### DIFF
--- a/bin/average_files
+++ b/bin/average_files
@@ -20,7 +20,7 @@ ap.add_argument("outfile",
 
 ns = ap.parse_args()
 
-fns = glob(ns.infilestring)
+fns = sorted(glob(ns.infilestring))
 
 nfns = len(fns)
 objs, hdr = fitsio.read(fns[0], header=True)

--- a/bin/make_new_sv
+++ b/bin/make_new_sv
@@ -22,7 +22,7 @@ _ = ap.parse_args()
 svroot = resource_filename('desitarget', 'sv')
 
 # ADM retrieve the highest current sv directory.
-fns = glob(svroot+'*')
+fns = sorted(glob(svroot+'*'))
 svlist = [int(fn[-1]) for fn in fns if os.path.isdir(fn)]
 maxsv = np.max(svlist)
 

--- a/bin/select_secondary
+++ b/bin/select_secondary
@@ -44,7 +44,7 @@ if not os.path.exists(ns.priminfodir):
     raise ValueError(msg)
 
 # ADM read survey type from the header of the first file in priminfodir.
-fns = glob(os.path.join(ns.priminfodir, "*fits"))
+fns = sorted(glob(os.path.join(ns.priminfodir, "*fits")))
 hdr = fitsio.read_header(fns[0], 'SCND_TARG')
 surv = hdr["SURVEY"].rstrip()
 

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -153,7 +153,6 @@ targets, infn = select_targets(
     resolvetargs=not(ns.noresolve), mask=not(ns.nomaskbits), return_infiles=True
 )
 
-
 if ns.bundlefiles is None:
     # ADM Set the list of infiles actually processed by select_targets() to
     # ADM None if we DON'T want to write their checksums to the output file.

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -153,6 +153,7 @@ targets, infn = select_targets(
     resolvetargs=not(ns.noresolve), mask=not(ns.nomaskbits), return_infiles=True
 )
 
+
 if ns.bundlefiles is None:
     # ADM Set the list of infiles actually processed by select_targets() to
     # ADM None if we DON'T want to write their checksums to the output file.

--- a/py/desitarget/brightmask.py
+++ b/py/desitarget/brightmask.py
@@ -98,9 +98,9 @@ def get_recent_mask_dir(input_dir=None):
             log.error(msg)
             raise IOError(msg)
         # ADM a fairly exhaustive list of possible mask directories.
-        mds = glob(os.path.join(md, "*maglim*")) + \
-            glob(os.path.join(md, "*/*maglim*")) + \
-            glob(os.path.join(md, "*/*/*maglim*"))
+        mds = sorted(glob(os.path.join(md, "*maglim*"))) + \
+            sorted(glob(os.path.join(md, "*/*maglim*"))) + \
+            sorted(glob(os.path.join(md, "*/*/*maglim*")))
         if len(mds) == 0:
             msg = "no mask sub-directories found in {}".format(md)
             log.error(msg)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2997,7 +2997,8 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
         # ADM a hack to ensure we have the correct targeting data model
         # ADM outside of the Legacy Surveys footprint.
         dummy = infiles[0]
-        infiles = list(set(np.hstack([filesperpixel[pix] for pix in pixlist])))
+        infiles = list(np.unique(np.hstack([filesperpixel[pix] for pix in pixlist])))
+
         if len(infiles) == 0:
             log.info('ZERO sweep files in passed pixel list!!!')
             log.info('Run with dummy sweep file to write Gaia-only objects...')

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -536,7 +536,7 @@ def gaia_csv_to_fits(dr="dr2", numproc=32):
         os.makedirs(fitsdir)
 
     # ADM construct the list of input files.
-    infiles = glob("{}/GaiaSource*csv*".format(csvdir))
+    infiles = sorted(glob("{}/GaiaSource*csv*".format(csvdir)))
     nfiles = len(infiles)
 
     # ADM the critical function to run on every file.

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1678,7 +1678,7 @@ def list_targetfiles(root):
     # ADM catch case where a file was sent instead of a directory.
     if os.path.isfile(root):
         return [root]
-    allfns = glob(os.path.join(root, '*target*fits'))
+    allfns = sorted(glob(os.path.join(root, '*target*fits')))
     fns, nfns = np.unique(allfns, return_counts=True)
     if np.any(nfns > 1):
         badfns = fns[nfns > 1]
@@ -2024,7 +2024,7 @@ def get_checksums(infiles, verbose=False, check_existing=True):
     checkdict = {}
     for ld in ldir:
         # ADM look for a shasum file.
-        shalist = glob(os.path.join(ld, "*.sha256sum"))
+        shalist = sorted(glob(os.path.join(ld, "*.sha256sum")))
         if len(shalist) > 0 and check_existing:
             shafn = shalist[0]
             if verbose:
@@ -2203,7 +2203,7 @@ def check_hp_target_dir(hpdirname):
     # ADM numbers and NSIDEs.
     nside = []
     pixlist = []
-    fns = glob(os.path.join(hpdirname, "*fits"))
+    fns = sorted(glob(os.path.join(hpdirname, "*fits")))
     pixdict = {}
     for fn in fns:
         hdr = read_targets_header(fn)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1061,7 +1061,7 @@ def make_zcat_rr_backstop(zcatdir, tiles, obscon, survey):
         tiledir = os.path.join(rootdir, str(tile["TILEID"]))
         ymdir = os.path.join(tiledir, tile["ZDATE"])
         # ADM and retrieve the redshifts.
-        zbestfns = glob(os.path.join(ymdir, "zbest*"))
+        zbestfns = sorted(glob(os.path.join(ymdir, "zbest*")))
         for zbestfn in zbestfns:
             zz = fitsio.read(zbestfn, "ZBEST")
             allzs.append(zz)

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -395,7 +395,7 @@ def add_primary_info(scxtargs, priminfodir):
     log.info("Begin matching primaries in {} to secondaries...t={:.1f}s"
              .format(priminfodir, time()-start))
     # ADM read all of the files from the priminfodir.
-    primfns = glob(os.path.join(priminfodir, "*fits"))
+    primfns = sorted(glob(os.path.join(priminfodir, "*fits")))
     # ADM if there are no files, there were no primary matches
     # ADM and we can just return.
     if len(primfns) == 0:
@@ -978,7 +978,7 @@ def select_secondary(priminfodir, sep=1., scxdir=None, darkbright=False):
         raise ValueError(msg)
 
     # ADM read in the SURVEY from the first file in priminfodir.
-    fns = glob(os.path.join(priminfodir, "*fits"))
+    fns = sorted(glob(os.path.join(priminfodir, "*fits")))
     hdr = fitsio.read_header(fns[0], 'SCND_TARG')
     survey = hdr["SURVEY"].rstrip()
 

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -105,14 +105,14 @@ def get_brick_info(drdirs, counts=False, allbricks=False):
     for dd in drdirs:
         # ADM in the simplest case, read in the survey bricks file, which lists
         # ADM the bricks of interest for this DR.
-        sbfile = glob(dd+'/*bricks-dr*')
+        sbfile = sorted(glob(dd+'/*bricks-dr*'))
         if len(sbfile) > 0:
             brickinfo = fitsio.read(sbfile[0], upper=True)
             # ADM fitsio reads things in as bytes, so convert to unicode.
             bricknames.append(brickinfo['BRICKNAME'].astype('U'))
         else:
             # ADM hack for test bricks where we don't generate the bricks file.
-            fns = glob(os.path.join(dd, 'tractor', '*', '*fits'))
+            fns = sorted(glob(os.path.join(dd, 'tractor', '*', '*fits')))
             bricknames.append([io.brickname_from_filename(fn)
                                for fn in fns])
 
@@ -797,7 +797,7 @@ def repartition_skies(skydirname, numproc=1):
     # ADM make the "unpartioned" directory if it doesn't exist.
     os.makedirs(os.path.join(skydirname, "unpartitioned"), exist_ok=True)
     # ADM loop over the files in the sky directory and build the info.
-    skyfiles = glob(os.path.join(skydirname, '*fits'))
+    skyfiles = sorted(glob(os.path.join(skydirname, '*fits')))
     for skyfile in skyfiles:
         # ADM rename the sky file so as not to overwrite.
         sfnewname = os.path.join(os.path.dirname(skyfile), "unpartitioned",

--- a/py/desitarget/skyutilities/legacypipe/util.py
+++ b/py/desitarget/skyutilities/legacypipe/util.py
@@ -241,22 +241,22 @@ class LegacySurveyData(object):
             if self.version in ['dr1','dr2']:
                 return swaplist([os.path.join(basedir, 'decals-ccds.fits.gz')])
             else:
-                return swaplist(
-                    glob(os.path.join(truebasedir, 'survey-ccds-*.fits.gz')))
+                return swaplist(sorted(
+                    glob(os.path.join(truebasedir, 'survey-ccds-*.fits.gz'))))
 
         elif filetype == 'ccd-kds':
-            return swaplist(
-                glob(os.path.join(truebasedir, 'survey-ccds-*.kd.fits')))
+            return swaplist(sorted(
+                glob(os.path.join(truebasedir, 'survey-ccds-*.kd.fits'))))
 
         elif filetype == 'tycho2':
             return swap(os.path.join(basedir, 'tycho2.fits.gz'))
 
         elif filetype == 'annotated-ccds':
             if self.version == 'dr2':
-                return swaplist(
-                    glob(os.path.join(basedir, 'decals-ccds-annotated.fits')))
-            return swaplist(
-                glob(os.path.join(truebasedir, 'ccds-annotated-*.fits.gz')))
+                return swaplist(sorted(
+                    glob(os.path.join(basedir, 'decals-ccds-annotated.fits'))))
+            return swaplist(sorted(
+                glob(os.path.join(truebasedir, 'ccds-annotated-*.fits.gz'))))
 
         elif filetype == 'tractor':
             return swap(os.path.join(basedir, 'tractor', brickpre,

--- a/py/desitarget/test/make_testcmx.py
+++ b/py/desitarget/test/make_testcmx.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     start = time()
 
     cmxdir = os.getenv("CMX_DIR")
-    fns = glob(os.path.join(cmxdir, "*fits"))
+    fns = sorted(glob(os.path.join(cmxdir, "*fits")))
     for fn in fns:
         print("reading {}".format(fn))
         objs = fitsio.read(fn)

--- a/py/desitarget/test/test_brightmask.py
+++ b/py/desitarget/test/test_brightmask.py
@@ -37,7 +37,7 @@ class TestBRIGHTMASK(unittest.TestCase):
 
         # ADM allowed HEALPixels in the Tycho directory.
         pixnum = []
-        fns = glob(os.path.join(os.environ["TYCHO_DIR"], 'healpix', '*fits'))
+        fns = sorted(glob(os.path.join(os.environ["TYCHO_DIR"], 'healpix', '*fits')))
         for fn in fns:
             data, hdr = fitsio.read(fn, "TYCHOHPX", header=True)
             nside = hdr["HPXNSIDE"]
@@ -146,7 +146,7 @@ class TestBRIGHTMASK(unittest.TestCase):
         self.assertEqual(mxdir, mxd)
 
         # ADM check all of the files were made in the correct place.
-        fns = glob(os.path.join(mxdir, "masks-hp*fits"))
+        fns = sorted(glob(os.path.join(mxdir, "masks-hp*fits")))
         self.assertEqual(len(fns), len(self.pixnum)+1)
 
         # ADM check the extra kwargs were written to the header.

--- a/py/desitarget/test/test_qa.py
+++ b/py/desitarget/test/test_qa.py
@@ -51,7 +51,7 @@ class TestQA(unittest.TestCase):
         # ADM Remove the output files.
         # SJB only in testdir, just in case something else did a chdir
         os.chdir(self.testdir)
-        for filelist in [glob("*png"), glob("*html"), glob("*dat")]:
+        for filelist in [sorted(glob("*png")), sorted(glob("*html")), sorted(glob("*dat"))]:
             for filename in filelist:
                 if os.path.exists(filename):
                     os.remove(filename)

--- a/py/desitarget/test/test_secondary.py
+++ b/py/desitarget/test/test_secondary.py
@@ -16,7 +16,7 @@ class TestSECONDARY(unittest.TestCase):
         # ADM these are the allowed types of observations of secondaries.
         self.flavors = {"SPARE", "DEDICATED", "SSV", "QSO", "TOO"}
         # ADM this is the list of defined directories for SV.
-        fns = glob(resource_filename('desitarget', 'sv*'))
+        fns = sorted(glob(resource_filename('desitarget', 'sv*')))
         svlist = [os.path.basename(fn) for fn in fns if os.path.isdir(fn)]
         # ADM loop over all SV flavors and main survey to get all masks.
         from desitarget.targetmask import scnd_mask as Mx

--- a/py/desitarget/test/test_skyfibers.py
+++ b/py/desitarget/test/test_skyfibers.py
@@ -29,7 +29,7 @@ class TestSKYFIBERS(unittest.TestCase):
         self.survey = LegacySurveyData(self.sd)
 
         # ADM determine which bricks we can access in the test directory.
-        brickdirs = glob("{}/coadd/*/*".format(self.survey.survey_dir))
+        brickdirs = sorted(glob("{}/coadd/*/*".format(self.survey.survey_dir)))
         bricknames = [basename(brickdir) for brickdir in brickdirs]
         # ADM just test with one brick.
         self.brickname = bricknames[0]

--- a/py/desitarget/test/test_sv.py
+++ b/py/desitarget/test/test_sv.py
@@ -46,7 +46,7 @@ class TestSV(unittest.TestCase):
         """Test SV cuts work.
         """
         # ADM find all svX sub-directories in the desitarget directory.
-        fns = glob(resource_filename('desitarget', 'sv*'))
+        fns = sorted(glob(resource_filename('desitarget', 'sv*')))
         svlist = [os.path.basename(fn) for fn in fns if os.path.isdir(fn)]
 
         for survey in svlist:

--- a/py/desitarget/uratmatch.py
+++ b/py/desitarget/uratmatch.py
@@ -238,7 +238,7 @@ def urat_csv_to_fits(numproc=5):
         os.makedirs(fitsdir)
 
     # ADM construct the list of input files.
-    infiles = glob("{}/*csv*".format(csvdir))
+    infiles = sorted(glob("{}/*csv*".format(csvdir)))
     nfiles = len(infiles)
 
     # ADM the critical function to run on every file.


### PR DESCRIPTION
@geordie666 this fixes a bug originally found by @araichoor : `select_targets` was getting its input files in a random order, which resulted in the output targets having a random order.  This was problematic because the SUBPRIORITY assigned to the targets was based upon their order in the file, thus breaking the TARGETID:SUBPRIORITY mapping from one run to the next.

The update that actually fixed the problem was changing
```
infiles = list(set(np.hstack([filesperpixel[pix] for pix in pixlist])))
```
to
```
infiles = list(np.unique(np.hstack([filesperpixel[pix] for pix in pixlist])))
```
i.e. `set` returns a random order of unique items, while `np.unique` returns sorted unique items.  I'm not sure if leaving the `list(...)` cast was necessary, but I was trying to keep the update as minimal as possible.

Along the way, I also wrapped `sorted(glob(...))` everywhere `glob` appeared, but that wasn't the core issue here and I didn't undo those.

Reproducer:
```
select_targets /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/north/sweep/9.0 \
    $CSCRATCH/desi/targets/reproducibility/test-9142-1 \
    -s2 /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/south/sweep/9.0 \
    --nside 64 --healpixels 9142 --numproc 16 --nosecondary \
    --gaiasub &> test-9142-1.log

select_targets /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/north/sweep/9.0 \
    $CSCRATCH/desi/targets/reproducibility/test-9142-2 \
    -s2 /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/south/sweep/9.0 \
    --nside 64 --healpixels 9142 --numproc 16 --nosecondary \
    --gaiasub &> test-9142-2.log

import fitsio                                                                               
a = fitsio.read('test-9142-1/dr9/1.0.1.dev5024/targets/main/resolve/bright/targets-bright-hp-9142.fits')                                                                                
b = fitsio.read('test-9142-2/dr9/1.0.1.dev5024/targets/main/resolve/bright/targets-bright-hp-9142.fits')                                                                                

np.all(a['TARGETID'] == b['TARGETID'])  #- Previously False, now True
np.all(np.sort(a['TARGETID']) == np.sort(b['TARGETID'])) #- True

```