### PR TITLE
Allow initial ledgers to use a preordained timestamp

### DIFF
--- a/bin/make_initial_mtl_ledger
+++ b/bin/make_initial_mtl_ledger
@@ -37,6 +37,13 @@ ap.add_argument('--healpixels',
                 write the ledger for targets in these pixels, at the default    \
                 nside, which is [{}]".format(mtlnside),
                 default=None)
+ap.add_argument('--timestamp',
+                help="Override the TIMESTAMP created by make_mtl, and use
+                this time instead",
+                default=None)
+ap.add_argument('--exemptmf',
+                help="Exempt pure-MWS_FAINT targets from the TIMESTAMP override",
+                action='store_true')
 
 ns = ap.parse_args()
 
@@ -45,4 +52,5 @@ pixlist = ns.healpixels
 if pixlist is not None:
     pixlist = [int(pix) for pix in pixlist.split(',')]
 
-make_ledger(ns.targdir, ns.dest, pixlist=pixlist, obscon=ns.obscon, numproc=ns.numproc)
+make_ledger(ns.targdir, ns.dest, pixlist=pixlist, obscon=ns.obscon,
+            numproc=ns.numproc, timestamp=ns.timestamp, exemptmf=ns.exemptmf)

--- a/bin/make_initial_mtl_ledger
+++ b/bin/make_initial_mtl_ledger
@@ -38,11 +38,12 @@ ap.add_argument('--healpixels',
                 nside, which is [{}]".format(mtlnside),
                 default=None)
 ap.add_argument('--timestamp',
-                help="Override the TIMESTAMP created by make_mtl, and use
-                this time instead",
+                help="Override the TIMESTAMP created by make_mtl, and use this  \
+                time instead",
                 default=None)
 ap.add_argument('--exemptmf',
-                help="Exempt pure-MWS_FAINT targets from the TIMESTAMP override",
+                help="Exempt targets that are purely MWS_FAINT targets from the \
+                TIMESTAMP override",
                 action='store_true')
 
 ns = ap.parse_args()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,7 +4,12 @@ desitarget Change Log
 
 1.0.2 (unreleased)
 ------------------
-
+* Allow initial ledgers to use a preordained timestamp [`PR #739`_].
+    * ``MWS_FAINT`` targets can be exempted from this timestamp.
+    * Also change data model for initial ledgers:
+        * ``ZS`` and ``ZINFO`` are replaced by ``Z_QN``
+	* This is not backwards-compatible to version `1.0.0`
+    * Fix `PR #734`_ bug where ``hpxlist`` was used in `write_secondary`.
 * Ensure fixed order of input files for reproducible outputs [`PR #738`_].
 * Refactor data model and I/O for the QSO zcats [`PR #737`_]. Includes:
     * New directory structures.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -31,6 +31,7 @@ desitarget Change Log
 .. _`PR #734`: https://github.com/desihub/desitarget/pull/734
 .. _`PR #737`: https://github.com/desihub/desitarget/pull/737
 .. _`PR #738`: https://github.com/desihub/desitarget/pull/738
+.. _`PR #739`: https://github.com/desihub/desitarget/pull/739
 
 1.0.1 (2021-05-14)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -934,8 +934,7 @@ def write_secondary(targdir, data, primhdr=None, scxdir=None, obscon=None,
     subpriority : :class:`bool`, optional, defaults to ``True``
         If ``True`` and a `SUBPRIORITY` column is in the input `data`,
         then `SUBPRIORITY` is overwritten by a random float in the range
-        0 to 1, using either seed 717, or seed 717 + the first value in
-        `hpxlist`, if `hpxlist` is passed and not ``None``.
+        0 to 1, using seed 717.
 
     Returns
     -------
@@ -991,8 +990,6 @@ def write_secondary(targdir, data, primhdr=None, scxdir=None, obscon=None,
     if "SUBPRIORITY" in data.dtype.names and subpriority:
         ntargs = len(data)
         subpseed = 717
-        if hpxlist is not None:
-            subpseed += int(hpxlist[0])
         np.random.seed(subpseed)
         data["SUBPRIORITY"] = np.random.random(ntargs)
         hdr["SUBPSEED"] = subpseed

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -625,8 +625,13 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
         _ = check_timestamp(timestamp)
         origts = mtl["TIMESTAMP"].copy()
         mtl["TIMESTAMP"] = timestamp
-        # ADM don't use the bespoke timestamp for MWS_FAINT targets.
+        # ADM don't use the bespoke timestamp for MWS_FAINT_* targets.
         if exemptmf:
+            # ADM do not update the timestamp for targets for which
+            # ADM MWS_FAINT_* is controlling the priority. As MWS_FAINT_*
+            # ADM targets are the lowest-priority UNOBSERVED targets,
+            # ADM this is equivalent to not updating the timestamp for
+            # ADM targets that are purely MWS_FAINT.
             ii = np.array(["MWS_FAINT" in ts for ts in mtl["TARGET_STATE"]])
             mtl["TIMESTAMP"][ii] = origts[ii]
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -594,7 +594,10 @@ def is_pure_mws_faint(targets):
     # ADM to look up all combination of just MWS_FAINT_ bits.
     pure_mf_bits = []
     for bitvals in set(targets[mws_target_col]):
-        mf = np.all(["MWS_FAINT" in names for names in mws_mask.names(bitvals)])
+        # ADM at a minimum, the bit combination must have MWS_FAINT_ set...
+        mf = np.any(["MWS_FAINT" in names for names in mws_mask.names(bitvals)])
+        # ADM ...but it must ONLY have combinations of MWS_FAINT_ set.
+        mf &= np.all(["MWS_FAINT" in names for names in mws_mask.names(bitvals)])
         if mf:
             pure_mf_bits.append(bitvals)
 
@@ -606,8 +609,8 @@ def is_pure_mws_faint(targets):
     for bitvals in pure_mf_bits:
         is_pure_mws_faint |= targets[mws_target_col] == bitvals
 
-    # ADM to be pure-MWS, the DESI_TARGET column needs to be MWS_ANY.
-    is_pure_mws_faint &= targets[desi_target_col] == desi_mask["MWS_ANY"]
+    # ADM to be pure-MWS in bright-time, BGS_ANY can't be set.
+    is_pure_mws_faint &= (targets[desi_target_col] & desi_mask["BGS_ANY"] == 0)
 
     return is_pure_mws_faint
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -49,7 +49,7 @@ mtldatamodel = np.array([], dtype=[
 
 # ADM columns to add to the mtl/zcat data models for the Main Survey.
 msaddcols = np.array([], dtype=[
-    ('ZS', 'U2'), ('ZINFO', 'U8'), ('DELTACHI2', '>f8'),
+    ('Z_QN', '>f8'), ('DELTACHI2', '>f8'),
     ])
 
 zcatdatamodel = np.array([], dtype=[

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -596,14 +596,11 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
     timestamp : :class:`str`, optional
         A timestamp to use in place of that assigned by `make_mtl`.
     exemptmf : :class:`bool`, optional, defaults to ``False``
-        If ``True`` then exempt any target that is:
-            - only `MWS_ANY` in the desi_target bitmask and
-            - only includes target classes that contain the string
-              "MWS_FAINT" in the mws_target bitmask
-        from accepting `timestamp`. These targets will instead revert to
-        a TIMESTAMP corresponding to when the code was run. This is to
-        fix a bug where "MWS_FAINT_*" targets were not initially included
-        in the (1.0.0) target files for the Main Survey.
+        If ``True`` then exempt any target that has a `TARGET_STATE`
+        driven by `MWS_FAINT_*` classes from accepting `timestamp`. These
+        targets will instead revert to a TIMESTAMP corresponding to when
+        the code was run. This is to fix a bug where "MWS_FAINT" targets
+        were not included in the (1.0.0) Main Survey target files.
 
     Returns
     -------
@@ -683,14 +680,11 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
     timestamp : :class:`str`, optional
         A timestamp to use in place of that assigned by `make_mtl`.
     exemptmf : :class:`bool`, optional, defaults to ``False``
-        If ``True`` then exempt any target that is:
-            - only `MWS_ANY` in the desi_target bitmask and
-            - only includes target classes that contain the string
-              "MWS_FAINT" in the mws_target bitmask
-        from accepting `timestamp`. These targets will instead revert to
-        a TIMESTAMP corresponding to when the code was run. This is to
-        fix a bug where "MWS_FAINT_*" targets were not initially included
-        in the (1.0.0) target files for the Main Survey.
+        If ``True`` then exempt any target that has a `TARGET_STATE`
+        driven by `MWS_FAINT_*` classes from accepting `timestamp`. These
+        targets will instead revert to a TIMESTAMP corresponding to when
+        the code was run. This is to fix a bug where "MWS_FAINT" targets
+        were not included in the (1.0.0) Main Survey target files.
 
     Returns
     -------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -619,7 +619,7 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
 
     # ADM if requested, substitute a bespoke timestamp.
     if timestamp is not None:
-        hdr["TIMESTAMP"] = timestamp
+        hdr["TSFORCED"] = timestamp
         hdr["EXEMPTMF"] = exemptmf
         # ADM check the timestamp is valid.
         _ = check_timestamp(timestamp)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -659,6 +659,8 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
     each HEALPixel in `pixlist`.
     """
     t0 = time()
+    # ADM a dictionary to hold header keywords for the ouput file.
+    hdr = {}
 
     # ADM in case an integer was passed.
     pixlist = np.atleast_1d(pixlist)
@@ -668,14 +670,16 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
 
     # ADM if requested, substitute a bespoke timestamp.
     if timestamp is not None:
+        hdr["TIMESTAMP"] = timestamp
+        hdr["EXEMPTMF"] = exemptmf
         # ADM check the timestamp is valid.
-        check_timestamp(timestamp)
-        origts = mtl["TIMESTAMP"]
+        _ = check_timestamp(timestamp)
+        origts = mtl["TIMESTAMP"].copy()
         mtl["TIMESTAMP"] = timestamp
         # ADM don't use the bespoke timestamp for MWS_FAINT targets.
         if exemptmf:
             ii = is_pure_mws_faint(mtl)
-            mtl[ii]["TIMESTAMP"] = origts[ii]
+            mtl["TIMESTAMP"][ii] = origts[ii]
 
     # ADM the HEALPixel within which each target in the MTL lies.
     theta, phi = np.radians(90-mtl["DEC"]), np.radians(mtl["RA"])
@@ -690,7 +694,7 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
             nt, fn = io.write_mtl(
                 outdirname, mtl[inpix].as_array(), indir=indirname, ecsv=ecsv,
                 survey=survey, obscon=obscon, nsidefile=nside, hpxlist=pix,
-                scnd=scnd)
+                scnd=scnd, extra=hdr)
             if verbose:
                 log.info('{} targets written to {}...t={:.1f}s'.format(
                     nt, fn, time()-t0))


### PR DESCRIPTION
This PR adds an option to pass a timestamp when making initial ledgers. The passed timestamp will then be used in place of the `TIMESTAMP` column generated by `make_mtl()`. `MWS_FAINT` targets can be exempted from this forced timestamp, and will instead adopt the usual "recent" timestamp generated by `make_mtl()`.

The purpose of these changes is to address the issue where `1.0.0` ledgers (and target files) were generated without `MWS_FAINT` targets, as fixed in #733. This PR should allow `1.1.0` ledgers to be generated with `TIMESTAMP`s that correspond to `1.0.0` ledgers for all targets except `MWS_FAINT`, as suggested by @sbailey.

Some other minor updates are included in this PR:

- The data model has been altered for the ledgers:
  * ``ZS`` and ``ZINFO`` are replaced by ``Z_QN``, as QuasarNP redshifts are the only non-redrock information that we'll be using to make LyA decisions.
  * This data-model-update is _not_ backwards compatible. So, if you're using `desitarget` functionality to read the never-to-be-spoken-of-again `1.0.0` ledgers, then you'll have to use version `1.0.0` of `desitarget`.
- A bug where an extraneous `hpxlist` was passed to `write_secondary()`, that was introduced in #734, and was [noticed by Anand ](https://github.com/desihub/desitarget/pull/738#issuecomment-849159262) has been fixed.