### PR TITLE
record subpriority overrides in header keywords

### DIFF
--- a/bin/select_skies
+++ b/bin/select_skies
@@ -69,7 +69,7 @@ ap.add_argument("--nomasking", action='store_true',
 ap.add_argument("--maskdir",
                 help="Name of the specific directory (or file) containing the bright star mask (defaults to the most recent directory in $MASK_DIR)",
                 default=None)
-ap.add_argument("--sky-subpriorities", type=str,
+ap.add_argument("--sky-subpriorities", "--sky_subpriorities", type=str,
                 help='Optional file with sky TARGETID:SUBPRIORITY override')
 
 ns = ap.parse_args()
@@ -78,7 +78,8 @@ do_mask = not(ns.nomasking)
 # ADM bundlefiles potentially needs to know about them.
 extra = " --numproc {}".format(ns.numproc)
 nsdict = vars(ns)
-for nskey in "nskiespersqdeg", "bands", "apertures", "nomasking", "maskdir":
+for nskey in ["nskiespersqdeg", "bands", "apertures", "nomasking", "maskdir",
+              "sky_subpriorities"]:
     if isinstance(nsdict[nskey], bool):
         if nsdict[nskey]:
             extra += " --{}".format(nskey)
@@ -172,8 +173,14 @@ else:
         mdcomp = "/".join(md[md.index("masks"):])
 
     # ADM extra header keywords for the output fits file.
-    extra = {k: v for k, v in zip(["masked", "maskdir"],
-                                  [do_mask, mdcomp])}
+    extra = {
+        "masked": do_mask,
+        "maskdir": mdcomp,
+        "cmdline": ' '.join(sys.argv),
+        }
+    extradeps = {
+        "sky-subpriorities-override": str(ns.sky_subpriorities),
+        }
 
     # SB apply optional subpriority override; modifies skies in-place
     if ns.sky_subpriorities:
@@ -189,6 +196,7 @@ else:
     nskies, outfile = io.write_skies(ns.dest, skies, indir=ns.surveydir,
                                      indir2=ns.surveydir2, nside=nside,
                                      apertures_arcsec=apertures, extra=extra,
+                                     extradeps=extradeps,
                                      nskiespersqdeg=nskiespersqdeg,
                                      nsidefile=ns.nside, hpxlist=pixlist)
 

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -80,9 +80,9 @@ ap.add_argument("-noc", "--nochecksum", action='store_true',
                 help='Do NOT add the list of input files and their checksums to the output target file as the second ("INFILES") extension')
 ap.add_argument("-check", "--checkbright", action='store_true',
                 help='If passed, then log a warning about targets that could be too bright when writing output files')
-ap.add_argument("--dark-subpriorities", type=str,
+ap.add_argument("--dark-subpriorities", "--dark_subpriorities", type=str,
                 help='Optional file with dark TARGETID:SUBPRIORITY overrides')
-ap.add_argument("--bright-subpriorities", type=str,
+ap.add_argument("--bright-subpriorities", "--bright_subpriorities", type=str,
                 help='Optional file with bright TARGETID:SUBPRIORITY overrides')
 
 ns = ap.parse_args()
@@ -91,7 +91,8 @@ ns = ap.parse_args()
 extra = " --numproc {}".format(ns.numproc)
 nsdict = vars(ns)
 for nskey in ["tcnames", "noresolve", "nomaskbits", "writeall",
-              "nosecondary", "nobackup", "nochecksum", "gaiasub", "scnddir"]:
+              "nosecondary", "nobackup", "nochecksum", "gaiasub", "scnddir",
+              "dark_subpriorities", "bright_subpriorities"]:
     if isinstance(nsdict[nskey], bool):
         if nsdict[nskey]:
             extra += " --{}".format(nskey)
@@ -200,8 +201,15 @@ if ns.bundlefiles is None:
         targets = mask_targets(targets, inmaskfile=ns.mask, nside=nside)
 
     # ADM extra header keywords for the output fits file.
-    extra = {k: v for k, v in zip(["tcnames", "gaiasub"],
-                                  [ns.tcnames, ns.gaiasub])}
+    extra = {
+        "tcnames": ns.tcnames,
+        "gaiasub": ns.gaiasub,
+        "cmdline": ' '.join(sys.argv),  #- just in case...
+        }
+    extradeps = {
+        "bright-subpriorities-override": str(ns.bright_subpriorities),
+        "dark-subpriorities-override": str(ns.dark_subpriorities),
+        }
 
     # ADM differentiate the Gaia-only and Legacy Surveys targets.
     _, _, _, _, _, gaiadr = decode_targetid(targets["TARGETID"])
@@ -243,6 +251,7 @@ if ns.bundlefiles is None:
             maskbits=not(ns.nomaskbits), indir=ns.sweepdir, indir2=ns.sweepdir2,
             obscon=obscon, scndout=scndout, survey="main", nsidefile=ns.nside,
             hpxlist=pixlist, supp=supp, qso_selection=ns.qsoselection,
-            extra=extra, infiles=shatab, checkbright=ns.checkbright
+            extra=extra, extradeps=extradeps,
+            infiles=shatab, checkbright=ns.checkbright
         )
         log.info('{} targets written to {}...t={:.1f}s'.format(ntargs, outfile, time()-start))

--- a/bin/supplement_skies
+++ b/bin/supplement_skies
@@ -63,7 +63,7 @@ ap.add_argument("--nomasking", action='store_true',
 ap.add_argument("--maskdir",
                 help="Name of the specific directory (or file) containing the bright star mask (defaults to the most recent directory in $MASK_DIR)",
                 default=None)
-ap.add_argument("--sky-subpriorities", type=str,
+ap.add_argument("--sky-subpriorities", "--sky_subpriorities", type=str,
                 help='Optional file with sky TARGETID:SUBPRIORITY override')
 
 ns = ap.parse_args()
@@ -97,7 +97,8 @@ extra = " --numproc {}".format(ns.numproc)
 extra += " --nskiespersqdeg {}".format(nskiespersqdeg)
 extra += " --gaiadir {}".format(gaiadir)
 nsdict = vars(ns)
-for nskey in "mindec", "mingalb", "radius", "nomasking", "maskdir":
+for nskey in ["mindec", "mingalb", "radius", "nomasking", "maskdir",
+              "sky_subpriorities"]:
     if isinstance(nsdict[nskey], bool):
         if nsdict[nskey]:
             extra += " --{}".format(nskey)
@@ -154,6 +155,18 @@ if ns.bundlefiles is None:
         ["radius", "mindec", "mingalb", "masked", "maskdir"],
         [ns.radius, ns.mindec, ns.mingalb, do_mask, mdcomp])}
 
+    extra = {
+        "radius": ns.radius,
+        "mindec": ns.mindec,
+        "mingalb": ns.mingalb,
+        "masked": do_mask,
+        "maskdir": mdcomp,
+        "cmdline": ' '.join(sys.argv),
+        }
+    extradeps = {
+        "sky-subpriorities-override": str(ns.sky_subpriorities),
+        }
+
         # SB apply optional subpriority override; modifies skies in-place
     if ns.sky_subpriorities:
         subpriorities = fitsio.read(ns.sky_subpriorities, 'SUBPRIORITY')
@@ -165,8 +178,8 @@ if ns.bundlefiles is None:
 
     nskies, outfile = io.write_skies(ns.dest, supp_skies, supp=True, indir=gaiadir,
                                      nside=nside, nskiespersqdeg=nskiespersqdeg,
-                                     extra=extra, nsidefile=ns.nside,
-                                     hpxlist=pixlist)
+                                     extra=extra, extradeps=extradeps,
+                                     nsidefile=ns.nside, hpxlist=pixlist)
 
     log.info('{} supplemental skies written to {}'.format(nskies, outfile))
 else:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -98,6 +98,9 @@ desitarget API
 .. automodule:: desitarget.skyutilities.legacypipe.util
     :members:
 
+.. automodule:: desitarget.subpriority
+    :members:
+
 .. automodule:: desitarget.sv1
     :members:
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 1.1.0 (unreleased)
 ------------------
 
-* Enable optional subpriority overrides [`PR #740`_].
+* Enable optional subpriority overrides [`PR #740`_, `PR #741`_].
 * Allow initial ledgers to use a preordained timestamp [`PR #739`_].
     * ``MWS_FAINT`` targets can be exempted from this timestamp.
     * Also change data model for initial ledgers:
@@ -35,6 +35,7 @@ desitarget Change Log
 .. _`PR #738`: https://github.com/desihub/desitarget/pull/738
 .. _`PR #739`: https://github.com/desihub/desitarget/pull/739
 .. _`PR #740`: https://github.com/desihub/desitarget/pull/740
+.. _`PR #741`: https://github.com/desihub/desitarget/pull/741
 
 1.0.1 (2021-05-14)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -458,6 +458,7 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
                   qso_selection=None, nside=None, survey="main", nsidefile=None,
                   hpxlist=None, scndout=None, resolve=True, maskbits=True,
                   obscon=None, mockdata=None, supp=False, extra=None,
+                  extradeps=None,
                   infiles=None, checkbright=False, subpriority=True):
     """Write target catalogues.
 
@@ -508,6 +509,8 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
     extra : :class:`dict`, optional
         If passed (and not None), write these extra dictionary keys and
         values to the output header.
+    extradeps : :class:`dict`, optional
+        If not None, add extra DEPNAMnn/DEPVERnn keywords to output header
     infiles : :class:`list` or `~numpy.ndarray`, optional
         If passed (and not None), write a second extension "INFILES" that
         contains the files in `infiles` and their SHA-256 checksums. If
@@ -609,6 +612,11 @@ def write_targets(targdir, data, indir=None, indir2=None, nchunks=None,
         depend.setdep(hdr, 'qso-selection', 'unknown')
     else:
         depend.setdep(hdr, 'qso-selection', qso_selection)
+
+    # SB add extra dependencies if requested
+    if extradeps is not None:
+        for key, value in extradeps.items():
+            depend.setdep(hdr, key, value)
 
     # ADM add HEALPix column, if requested by input.
     if nside is not None:
@@ -1081,8 +1089,8 @@ def write_secondary(targdir, data, primhdr=None, scxdir=None, obscon=None,
 
 def write_skies(targdir, data, indir=None, indir2=None, supp=False,
                 apertures_arcsec=None, nskiespersqdeg=None, nside=None,
-                nsidefile=None, hpxlist=None, extra=None, mock=False,
-                subpriority=True):
+                nsidefile=None, hpxlist=None, extra=None, extradeps=None,
+                mock=False, subpriority=True):
     """Write a target catalogue of sky locations.
 
     Parameters
@@ -1119,6 +1127,8 @@ def write_skies(targdir, data, indir=None, indir2=None, supp=False,
     extra : :class:`dict`, optional
         If passed (and not None), write these extra dictionary keys and
         values to the output header.
+    extradeps : :class:`dict`, optional
+        If not None, add extra DEPNAMnn/DEPVERnn keywords to output header
     mock : :class:`bool`, optional, defaults to ``False``.
         If ``True`` then construct the file path for mock sky
         target catalogs.
@@ -1178,6 +1188,11 @@ def write_skies(targdir, data, indir=None, indir2=None, supp=False,
         depend.setdep(hdr, 'input-data-release', indir)
     if indir2 is not None:
         depend.setdep(hdr, 'input-data-release-2', indir2)
+
+    # SB add extra dependencies if requested
+    if extradeps is not None:
+        for key, value in extradeps.items():
+            depend.setdep(hdr, key, value)
 
     if apertures_arcsec is not None:
         for i, ap in enumerate(apertures_arcsec):


### PR DESCRIPTION
This PR adds header keyword provenance for what subpriority overrides were used, if any.  Example outputs are in /global/cscratch1/sd/sjbailey/desi/targets/provenance, with headers e.g.
```
DEPNAM17= 'bright-subpriorities-override'                                       
DEPVER17= '../subpriorities-bright.fits'                                        
DEPNAM18= 'dark-subpriorities-override'                                         
DEPVER18= '../subpriorities-dark.fits'                                          
```
I went with the DEPNAMnn/DEPVERnn to avoid cryptic 8-char limited keywords like SUBPBROV.

Belt and suspenders, I also added and "CMDLINE" keyword that records the full command line call directly from sys.argv, e.g.
```
CMDLINE = '/global/common/software/desi/users/sjbailey/desitarget/bin/select_t&
'CONTINUE  'argets /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/north/sweep/9.&
'CONTINUE  '0 . -s2 /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/south/sweep/9&
'CONTINUE  '.0 --nside 64 --healpixels 9142 --numproc 16 --nosecondary --gaiasu&
'CONTINUE  'b --dark-subpriorities ../subpriorities-dark.fits --bright-subprior&
'CONTINUE  'ities ../subpriorities-bright.fits'                                  
```

this applies to select_targets, select_skies, and supplement_skies, which are the 3 scripts that accept subpriority overrides.

@geordie666 please double check my implementation of passing the options into the `for nskey in ...` blocks.  I think I followed your instructions correctly, but that's also the piece I didn't know how to test / verify.