### PR TITLE
support mtl 1.0.0 format

### DIFF
--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2613,6 +2613,12 @@ def read_mtl_ledger(filename, unique=True, isodate=None,
                     iname, iform = [i+1 for i, stringy in enumerate(l) if
                                     "name" in stringy or "datatype" in stringy]
                     name, form = l[iname][:-1], l[iform][:-1]
+
+                    # SB for backwards compatibility with mtl 1.0.0 format,
+                    # SB which doesn't have Z_QN and has placeholder ZS,ZINFO
+                    if name not in mtldm.dtype.names:
+                        continue
+
                     names.append(name)
                     if 'string' in form:
                         forms.append(mtldm[name].dtype.str)
@@ -2630,7 +2636,7 @@ def read_mtl_ledger(filename, unique=True, isodate=None,
         prelim = Table.read(filename, comment='#', format='ascii.basic',
                             guess=False)
         mtl = np.zeros(len(prelim), dtype=dt)
-        for col in prelim.columns:
+        for col in mtl.dtype.names:
             mtl[col] = prelim[col]
     elif ".fits" in filename:
         mtl = fitsio.read(filename, extension="MTL")


### PR DESCRIPTION
This PR adds `read_mtl_ledger` support for the mtl/1.0.0 format, which doesn't have Z_QN but does columns ZS and ZINFO that are now gone.

Motivation: fiberassign needs latest desitarget to get the `write_targets(..., subpriority=False)` functionality.  But, current desitarget doesn't support reading the mtl/1.0.0 format, which breaks the ability to test current fiberassign on mtl/1.0.0 files for comparison with fiberassign/4.0.0 on previously designed tiles.  Thus this PR.

The solution here is admittedly fragile if the mtl format continues to evolve.  I certainly hope it doesn't, but if it does change again and this becomes problematic, I suggest tackling a deeper refactor about the optimizations for speed-reading the ecsv file without requiring a specific single set of expected columns (via mtldatamodel).