### PR TITLE
override_subpriority support duplicate TARGETID inputs

### DIFF
--- a/bin/select_secondary
+++ b/bin/select_secondary
@@ -5,6 +5,7 @@ import numpy as np
 from desitarget.secondary import select_secondary, _get_scxdir
 from desitarget.brightmask import is_in_bright_mask, get_recent_mask_dir
 from desitarget import io
+from desitarget.subpriority import override_subpriority
 import os
 from glob import glob
 from time import time

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 1.1.0 (unreleased)
 ------------------
 
+* override_subpriority support duplicate input TARGETID from secondaries
+  [`PR #743`_].
 * Support reading mtl 1.0.0 format with different columns [`PR #742`_].
 * Enable optional subpriority overrides [`PR #740`_, `PR #741`_].
 * Allow initial ledgers to use a preordained timestamp [`PR #739`_].
@@ -38,6 +40,7 @@ desitarget Change Log
 .. _`PR #740`: https://github.com/desihub/desitarget/pull/740
 .. _`PR #741`: https://github.com/desihub/desitarget/pull/741
 .. _`PR #742`: https://github.com/desihub/desitarget/pull/742
+.. _`PR #743`: https://github.com/desihub/desitarget/pull/743
 
 1.0.1 (2021-05-14)
 ------------------

--- a/py/desitarget/test/test_subpriority.py
+++ b/py/desitarget/test/test_subpriority.py
@@ -41,6 +41,30 @@ class TestSubpriority(unittest.TestCase):
             else:
                 self.assertEqual(targets['SUBPRIORITY'][i], orig_subpriority[i])
 
+    def test_override_duplicates(self):
+        """Test subpriority override with duplicate input TARGETIDs"""
+        targets = Table()
+        targets['TARGETID'] = [1,2,3,2,1,5]
+        n = len(targets['TARGETID'])
+        orig_subpriority = np.random.random(n)
+        targets['SUBPRIORITY'] = orig_subpriority.copy()
+
+        override = Table()
+        override['TARGETID'] = np.array([3,2,20])
+        override['SUBPRIORITY'] = np.array([10.0, 20.0, 30.0])
+
+        desitarget.subpriority.override_subpriority(targets, override)
+
+        #- Check that we overrode correctly; don't juse geomask.match
+        #- to avoid circularity of code and test
+        for i, tid in enumerate(targets['TARGETID']):
+            in_override = np.where(override['TARGETID'] == tid)[0]
+            if len(in_override) > 0:
+                j = in_override[0]
+                self.assertEqual(targets['SUBPRIORITY'][i], override['SUBPRIORITY'][j])
+            else:
+                self.assertEqual(targets['SUBPRIORITY'][i], orig_subpriority[i])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds support for duplicate TARGETID inputs in override_subpriority, while still using the faster `geomask.match` function when the inputs are unique.  Duplicates can occur in secondary programs when more than one secondary matches a primary.  Includes unit tests.