### PR TITLE
Set up the end-to-end MTL Main Survey loop

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,11 @@ desitarget Change Log
 1.1.0 (unreleased)
 ------------------
 
+* Set up the end-to-end MTL Main Survey loop [`PR #744`_]. Includes:
+    * mtl-done-tiles file ``TIMESTAMP`` is later than any ledger entry.
+    * Read the zcats from the zqso files instead of making a "backstop".
+    * Add ``IS_QSO_QN`` column to the initial ledgers.
+        Again, this is not backwards-compatible to version `1.0.0`.
 * Enable optional subpriority overrides [`PR #740`_].
 * Allow initial ledgers to use a preordained timestamp [`PR #739`_].
     * ``MWS_FAINT`` targets can be exempted from this timestamp.
@@ -35,6 +40,7 @@ desitarget Change Log
 .. _`PR #738`: https://github.com/desihub/desitarget/pull/738
 .. _`PR #739`: https://github.com/desihub/desitarget/pull/739
 .. _`PR #740`: https://github.com/desihub/desitarget/pull/740
+.. _`PR #744`: https://github.com/desihub/desitarget/pull/744
 
 1.0.1 (2021-05-14)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2786,7 +2786,7 @@ def read_ecsv_header(filename):
         # ADM retrieve just the key, val pairs. Also remove white space.
         keyvals = d.split("{")[-1].strip("}").replace(" ", "").split(",")
         for keyval in keyvals:
-            key, val = keyval.split(":")
+            key, val = keyval.split(":", maxsplit=1)
             hdr[key] = val
 
     return hdr

--- a/py/desitarget/lyazcat.py
+++ b/py/desitarget/lyazcat.py
@@ -41,7 +41,7 @@ zcatdatamodel = np.array([], [('RA', '>f8'), ('DEC', '>f8'), ('TARGETID', '>i8')
                               ('MWS_TARGET', '>i8'), ('SCND_TARGET', '>i8'),
                               ('Z', '>f8'), ('ZWARN', '>i8'),
                               ('SPECTYPE', '<U6'), ('DELTACHI2', '>f8'),
-                              ('NUMOBS', '>i8'), ('ZTILEID', '>i4')])
+                              ('NUMOBS', '>i4'), ('ZTILEID', '>i4')])
 qndm = [('Z_QN', '>f8'), ('Z_QN_CONF', '>f8'), ('IS_QSO_QN', '>i2')]
 sqdm = [('Z_SQ', '>f8'), ('Z_SQ_CONF', '>f8')]
 absdm = [('Z_ABS', '>f8'), ('Z_ABS_CONF', '>f8')]

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1371,8 +1371,9 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     # ADM useful to know how many targets were updated.
     _, _, _, _, sky, _ = decode_targetid(zcat["TARGETID"])
     ntargs, nsky = np.sum(sky == 0), np.sum(sky)
-    log.info("Update state for {} targets (zcat also contains {} skies)".format(
-        ntargs, nsky))
+    msg = "Update state for {} targets".format(ntargs)
+    msg += " (the zcats also contain {} skies with +ve TARGETIDs)".format(nsky)
+    log.info(msg)
 
     # ADM update the appropriate ledger.
     update_ledger(hpdirname, zcat, obscon=obscon,

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1108,7 +1108,7 @@ def make_zcat(zcatdir, tiles, obscon, survey):
         A string matching ONE obscondition in the desitarget bitmask yaml
         file (i.e. `desitarget.targetmask.obsconditions`), e.g. "DARK".
         Governs how ZWARN is updated using `DELTACHI2` when `survey` is
-        "sv3" (in :func:`~desitarget.mtl.make_zcat_rr_backstop()).
+        "sv3" (in :func:`~desitarget.mtl.make_zcat_rr_backstop()`).
     survey : :class:`str`, optional, defaults to "main"
         Used to update `ZWARN` using `DELTACHI2` for a given survey type.
         Options are ``'main'`` and ``'svX``' (where X is 1, 2, 3 etc.)
@@ -1123,7 +1123,7 @@ def make_zcat(zcatdir, tiles, obscon, survey):
     Notes
     -----
     - For surveys prior to "main" this is just a wrapper on
-      make_zcat_rr_backstop().
+      :func:`~desitarget.mtl.make_zcat_rr_backstop()`.
     """
     if survey != "main":
         return make_zcat_rr_backstop(zcatdir, tiles, obscon, survey)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -15,7 +15,7 @@ import sys
 from astropy.table import Table
 from astropy.io import ascii
 import fitsio
-from time import time
+from time import time, sleep
 from datetime import datetime, timezone
 from glob import glob, iglob
 
@@ -1354,8 +1354,7 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     if len(tiles) == 0:
         return hpdirname, mtltilefn, ztilefn, tiles
 
-    # ADM create the zcat: This will likely change, but for now let's
-    # ADM just use redrock.
+    # ADM create the catalog of updated redshifts.
     zcat = make_zcat(zcatdir, tiles, obscon, survey)
 
     # ADM insist that for an MTL loop with real observations, the zcat
@@ -1379,6 +1378,12 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     # ADM update the appropriate ledger.
     update_ledger(hpdirname, zcat, obscon=obscon,
                   numobs_from_ledger=numobs_from_ledger)
+
+    # ADM for the main survey "holding pen" method, ensure the TIMESTAMP
+    # ADM in the mtl-done-tiles file is always later than in the ledgers.
+    if survey == "main":
+        sleep(1)
+        tiles["TIMESTAMP"] = get_utc_date(survey=survey)
 
     # ADM write the processed tiles to the MTL tile file.
     io.write_mtl_tile_file(mtltilefn, tiles)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -49,7 +49,7 @@ mtldatamodel = np.array([], dtype=[
 
 # ADM columns to add to the mtl/zcat data models for the Main Survey.
 msaddcols = np.array([], dtype=[
-    ('Z_QN', '>f8'), ('DELTACHI2', '>f8'),
+    ('Z_QN', '>f8'), ('IS_QSO_QN', '>i2'), ('DELTACHI2', '>f8'),
     ])
 
 zcatdatamodel = np.array([], dtype=[
@@ -482,7 +482,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
     # NUMOBS_MORE should also be 0.
     # ## mtl['NUMOBS_MORE'] = ztargets['NUMOBS_MORE']
     ii = (priority <= 2)
-    log.info('{:d} of {:d} targets have priority zero, setting N_obs=0.'.format(
+    log.info('{:d} of {:d} targets have priority <=2, setting N_obs=0.'.format(
         np.sum(ii), n))
     ztargets['NUMOBS_MORE'][ii] = 0
 
@@ -1107,7 +1107,8 @@ def make_zcat(zcatdir, tiles, obscon, survey):
     obscon : :class:`str`
         A string matching ONE obscondition in the desitarget bitmask yaml
         file (i.e. `desitarget.targetmask.obsconditions`), e.g. "DARK".
-        Governs how ZWARN is updated using `DELTACHI2`.
+        Governs how ZWARN is updated using `DELTACHI2` when `survey` is
+        "sv3" (in :func:`~desitarget.mtl.make_zcat_rr_backstop()).
     survey : :class:`str`, optional, defaults to "main"
         Used to update `ZWARN` using `DELTACHI2` for a given survey type.
         Options are ``'main'`` and ``'svX``' (where X is 1, 2, 3 etc.)


### PR DESCRIPTION
This PR sets up the full MTL loop for the Main Survey. It:

- Ensures that the `TIMESTAMP` in the mtl-done-tiles file is always later than any ledger entry.
- Integrates the zcats from the zqso files (made by `lyazcat.py`) instead of using a "backstop" function.
- Adds an `IS_QSO_QN` column to the initial ledgers. Again, this change to the data model is not backwards compatible with ledgers used by version `1.0.0` of `desitarget`, but we already broke that for the `1.1` tag.

The final missing piece is to get the logic for LyA QSO repeats exactly correct and test that new element.
