### PR TITLE
Don't allow the MWS_FAINT targets to affect the state of any secondaries.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -48,6 +48,7 @@ desitarget Change Log
 .. _`PR #742`: https://github.com/desihub/desitarget/pull/742
 .. _`PR #743`: https://github.com/desihub/desitarget/pull/743
 .. _`PR #744`: https://github.com/desihub/desitarget/pull/744
+.. _`PR #746`: https://github.com/desihub/desitarget/pull/746
 
 1.0.1 (2021-05-14)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 1.1.0 (unreleased)
 ------------------
 
+* Don't allow ``MWS_FAINT`` classes to affect secondaries [`PR #746`_].
 * Set up the end-to-end MTL Main Survey loop [`PR #744`_]. Includes:
     * mtl-done-tiles file ``TIMESTAMP`` is later than any ledger entry.
     * Read the zcats from the zqso files instead of making a "backstop".


### PR DESCRIPTION
This PR prevents the `MWS_FAINT` targets from merging with and updating the state of secondary targets for the Main Survey. This proved necessary to preserve the original state of secondary targets, as we didn't start the survey with the `MWS_FAINT` target class.

This is a short PR with a specific focus, so I'll merge it once tests pass.