### PR TITLE
Turn off the MWS_FAINT target classes.

### DIFF
--- a/bin/make_initial_mtl_ledger
+++ b/bin/make_initial_mtl_ledger
@@ -41,10 +41,6 @@ ap.add_argument('--timestamp',
                 help="Override the TIMESTAMP created by make_mtl, and use this  \
                 time instead",
                 default=None)
-ap.add_argument('--exemptmf',
-                help="Exempt targets that are purely MWS_FAINT targets from the \
-                TIMESTAMP override",
-                action='store_true')
 
 ns = ap.parse_args()
 
@@ -54,4 +50,4 @@ if pixlist is not None:
     pixlist = [int(pix) for pix in pixlist.split(',')]
 
 make_ledger(ns.targdir, ns.dest, pixlist=pixlist, obscon=ns.obscon,
-            numproc=ns.numproc, timestamp=ns.timestamp, exemptmf=ns.exemptmf)
+            numproc=ns.numproc, timestamp=ns.timestamp)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,12 @@ desitarget Change Log
 1.1.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Turn off the ``MWS_FAINT`` target classes [`PR #748`_]. Includes:
+    * Don't set any of the ``MWS_FAINT`` target bits.
+    * No need to exempt ``MWS_FAINT`` from forced ledger TIMESTAMPs.
+    * Remove special logic for merging ``MWS_FAINT`` with secondaries.
+
+.. _`PR #748`: https://github.com/desihub/desitarget/pull/748
 
 1.1.0 (2021-05-29)
 ------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2606,13 +2606,13 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     mws_target |= mws_red_n * mws_mask.MWS_MAIN_RED_NORTH
     mws_target |= mws_red_s * mws_mask.MWS_MAIN_RED_SOUTH
 
-    # Add MWS FAINT blue/red split
-    mws_target |= mws_faint_blue * mws_mask.MWS_FAINT_BLUE
-    mws_target |= mws_faint_blue_n * mws_mask.MWS_FAINT_BLUE_NORTH
-    mws_target |= mws_faint_blue_s * mws_mask.MWS_FAINT_BLUE_SOUTH
-    mws_target |= mws_faint_red * mws_mask.MWS_FAINT_RED
-    mws_target |= mws_faint_red_n * mws_mask.MWS_FAINT_RED_NORTH
-    mws_target |= mws_faint_red_s * mws_mask.MWS_FAINT_RED_SOUTH
+    # Add MWS FAINT blue/red split. Only ever set in v1.1 of desitarget.
+#    mws_target |= mws_faint_blue * mws_mask.MWS_FAINT_BLUE
+#    mws_target |= mws_faint_blue_n * mws_mask.MWS_FAINT_BLUE_NORTH
+#    mws_target |= mws_faint_blue_s * mws_mask.MWS_FAINT_BLUE_SOUTH
+#    mws_target |= mws_faint_red * mws_mask.MWS_FAINT_RED
+#    mws_target |= mws_faint_red_n * mws_mask.MWS_FAINT_RED_NORTH
+#    mws_target |= mws_faint_red_s * mws_mask.MWS_FAINT_RED_SOUTH
 
     # Are any BGS or MWS bit set?  Tell desi_target too.
     desi_target |= (bgs_target != 0) * desi_mask.BGS_ANY

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -566,7 +566,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
 
 def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
                       indirname=None, verbose=True, scnd=False,
-                      timestamp=None, exemptmf=False):
+                      timestamp=None):
     """
     Make an initial MTL ledger file for targets in a set of HEALPixels.
 
@@ -595,12 +595,6 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
         If ``True`` then this is a ledger of secondary targets.
     timestamp : :class:`str`, optional
         A timestamp to use in place of that assigned by `make_mtl`.
-    exemptmf : :class:`bool`, optional, defaults to ``False``
-        If ``True`` then exempt any target that has a `TARGET_STATE`
-        driven by `MWS_FAINT_*` classes from accepting `timestamp`. These
-        targets will instead revert to a TIMESTAMP corresponding to when
-        the code was run. This is to fix a bug where "MWS_FAINT" targets
-        were not included in the (1.0.0) Main Survey target files.
 
     Returns
     -------
@@ -619,21 +613,10 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
 
     # ADM if requested, substitute a bespoke timestamp.
     if timestamp is not None:
-        hdr["TSFORCED"] = timestamp
-        hdr["EXEMPTMF"] = exemptmf
         # ADM check the timestamp is valid.
         _ = check_timestamp(timestamp)
-        origts = mtl["TIMESTAMP"].copy()
+        hdr["TSFORCED"] = timestamp
         mtl["TIMESTAMP"] = timestamp
-        # ADM don't use the bespoke timestamp for MWS_FAINT_* targets.
-        if exemptmf:
-            # ADM do not update the timestamp for targets for which
-            # ADM MWS_FAINT_* is controlling the priority. As MWS_FAINT_*
-            # ADM targets are the lowest-priority UNOBSERVED targets,
-            # ADM this is equivalent to not updating the timestamp for
-            # ADM targets that are purely MWS_FAINT.
-            ii = np.array(["MWS_FAINT" in ts for ts in mtl["TARGET_STATE"]])
-            mtl["TIMESTAMP"][ii] = origts[ii]
 
     # ADM the HEALPixel within which each target in the MTL lies.
     theta, phi = np.radians(90-mtl["DEC"]), np.radians(mtl["RA"])
@@ -657,7 +640,7 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
 
 
 def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
-                numproc=1, timestamp=None, exemptmf=False):
+                numproc=1, timestamp=None):
     """
     Make initial MTL ledger files for HEALPixels, in parallel.
 
@@ -684,12 +667,6 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
         Number of processes to parallelize across.
     timestamp : :class:`str`, optional
         A timestamp to use in place of that assigned by `make_mtl`.
-    exemptmf : :class:`bool`, optional, defaults to ``False``
-        If ``True`` then exempt any target that has a `TARGET_STATE`
-        driven by `MWS_FAINT_*` classes from accepting `timestamp`. These
-        targets will instead revert to a TIMESTAMP corresponding to when
-        the code was run. This is to fix a bug where "MWS_FAINT" targets
-        were not included in the (1.0.0) Main Survey target files.
 
     Returns
     -------
@@ -777,7 +754,7 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
         return make_ledger_in_hp(
             targs, outdirname, mtlnside, pix, obscon=obscon,
             indirname=hpdirname, verbose=False, scnd=scnd,
-            timestamp=timestamp, exemptmf=exemptmf)
+            timestamp=timestamp)
 
     # ADM this is just to count pixels in _update_status.
     npix = np.ones((), dtype='i8')

--- a/py/desitarget/secondary.py
+++ b/py/desitarget/secondary.py
@@ -546,31 +546,6 @@ def match_secondary(primtargs, scxdir, scndout, sep=1.,
              .format(scndout, sep, time()-start))
     mtargs, mscx = radec_match_to(targs, scxtargs[inhp], sep=sep)
 
-    # ADM we need special handling of MWS_FAINT sources. These were
-    # ADM introduced after the start of the Main Survey so should never
-    # ADM be allowed to merge with secondaries.
-    if surv == 'main':
-        desi_mask, _, mws_mask = mx[:3]
-        # ADM find the indexes of pure MWS_FAINT targets, which are
-        # ADM combinations like [MWS_FAINT_BLUE, MWS_FAINT_BLUE_NORTH],
-        # ADM [MWS_FAINT_RED, MWS_FAINT_RED_NORTH], etc.
-        is_mws_faint = np.zeros(len(targs), dtype="?")
-        for color in "BLUE", "RED":
-            for hemi in "NORTH", "SOUTH":
-                mwf_bits = (mws_mask["MWS_FAINT_{}".format(color)] |
-                            mws_mask["MWS_FAINT_{}_{}".format(color, hemi)])
-                is_mws_faint |= targs["MWS_TARGET"] == mwf_bits
-        # ADM pure mws_faint have no other bits set in DESI_TARGET.
-        is_mws_faint &= targs["DESI_TARGET"] == desi_mask["MWS_ANY"]
-        # ADM recast the boolean as indices.
-        mws_faint = np.where(is_mws_faint)[0]
-        # ADM find indices of matches (mtargs) that are also MWS_FAINT.
-        # ADM "invert" as we want True where mtargs is NOT MWS_FAINT.
-        ii = np.isin(mtargs, mws_faint, invert=True)
-        # ADM update the matchs to ignore MWS_FAINT.
-        mtargs = mtargs[ii]
-        mscx = mscx[ii]
-
     # ADM recast the indices to the full set of secondary targets,
     # ADM instead of just those that were in the relevant HEALPixels.
     mscx = np.where(inhp)[0][mscx]


### PR DESCRIPTION
This PR turns off all aspects of the `MWS_FAINT_*` target classes, including:

- No longer setting any of the `MWS_FAINT` target bits.
- No longer exempting `MWS_FAINT` from forced ledger TIMESTAMPs. There's no need to anymore.
- Removing special logic that had been added to merge `MWS_FAINT` with secondary targets.

In the end, we decided that this was the simplest way to make progress because we were in a bind after not starting the Main Survey with the `MWS_FAINT` target classes. The problem was that if we included `MWS_FAINT` targets they would occasionally be merged with secondary targets that had previously matched a different target, which would update the behavior of fiberassign. If we attempted to prevent the `MWS_FAINT` targets from merging with secondary targets, we would produce duplicate targets with the same `TARGETID`, and `TARGETID` needs to be unique to track targets downstream of `desitarget`.

We will revisit the `MWS_FAINT` target classes as a pure secondary class during the summer shutdown.

I'll merge this as soon as tests pass as I'll need to tag new versions of the Main Survey targets.