### PR TITLE
Add the final QSO decision logic to the full Main Survey MTL loop.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 1.1.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Add final QSO decision logic to full Main Survey MTL loop [`PR #750`_].
+
+.. _`PR #750`: https://github.com/desihub/desitarget/pull/750
 
 1.1.1 (2021-05-29)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,9 @@ desitarget Change Log
 1.1.2 (unreleased)
 ------------------
 
-* Add final QSO decision logic to full Main Survey MTL loop [`PR #750`_].
+* Add final QSO decision logic to full Main Survey MTL loop [`PR #751`_].
 
-.. _`PR #750`: https://github.com/desihub/desitarget/pull/750
+.. _`PR #751`: https://github.com/desihub/desitarget/pull/751
 
 1.1.1 (2021-05-29)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,9 @@ desitarget Change Log
 ------------------
 
 * Add final QSO decision logic to full Main Survey MTL loop [`PR #751`_].
+* Make creation of zqso catalogs robust to missing columns [`PR #750`_].
 
+.. _`PR #750`: https://github.com/desihub/desitarget/pull/750
 .. _`PR #751`: https://github.com/desihub/desitarget/pull/751
 
 1.1.1 (2021-05-29)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1116,7 +1116,7 @@ def make_zcat(zcatdir, tiles, obscon, survey):
         tiledir = os.path.join(rootdir, str(tile["TILEID"]))
         ymdir = os.path.join(tiledir, tile["ZDATE"])
         # ADM and retrieve the zqso/lyazcat catalog.
-        qsozcatfns = sorted(glob(os.path.join(ymdir, "zqso*")))
+        qsozcatfns = sorted(glob(os.path.join(ymdir, "zqso*fits")))
         for qsozcatfn in qsozcatfns:
             zz = fitsio.read(qsozcatfn, "QSOZCAT")
             allzs.append(zz)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -303,8 +303,14 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
     ----------
     targets : :class:`~numpy.array` or `~astropy.table.Table`
         A numpy rec array or astropy Table with at least the columns
-        ``TARGETID``, ``DESI_TARGET``, ``NUMOBS_INIT``, ``PRIORITY_INIT``.
-        or the corresponding columns for SV or commissioning.
+        `TARGETID`, `DESI_TARGET`, `BGS_TARGET`, `MWS_TARGET` (or the
+        corresponding columns for SV or commissioning) `NUMOBS_INIT` and
+        `PRIORITY_INIT`. `targets` must also contain `PRIORITY` if `zcat`
+        is not ``None`` (i.e. if this isn't the first time through MTL
+        and/or if `targets` is itself an mtl array). `PRIORITY` is needed
+        to "lock in" the state of Ly-Alpha QSOs. `targets` may also
+        contain `SCND_TARGET` (or the corresponding columns for SV) if
+        secondary targets are under consideration.
     obscon : :class:`str`
         A combination of strings that are in the desitarget bitmask yaml
         file (specifically in `desitarget.targetmask.obsconditions`), e.g.
@@ -348,6 +354,8 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
     Notes
     -----
     - Sources in the zcat with `ZWARN` of `NODATA` are always ignored.
+    - The input `zcat` WILL BE MODIFIED. So, if a desire is that `zcat`
+      remains unaltered, make sure to copy `zcat` before passing it.
     """
     start = time()
     # ADM set up the default logger.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -393,8 +393,9 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
         ok = np.in1d(zcat['TARGETID'], targets['TARGETID'])
         num_extra = np.count_nonzero(~ok)
         if num_extra > 0:
-            log.info("Ignoring {} zcat entries that aren't in the input "
-                     "target list (i.e. likely skies)".format(num_extra))
+            log.info("Ignoring {} z entries that aren't in the input target list"
+                     " (e.g. likely skies, secondaries-when-running-primary, "
+                     "primaries-when-running-secondary, etc.)".format(num_extra))
             zcat = zcat[ok]
         # ADM also ignore anything with NODATA set in ZWARN.
         nodata = zcat["ZWARN"] & zwarn_mask["NODATA"] != 0
@@ -798,7 +799,7 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
         Redshift catalog table with columns ``TARGETID``, ``NUMOBS``,
         ``Z``, ``ZWARN``, ``ZTILEID``, and ``msaddcols`` at the top of
         the code for the Main Survey.
-    targets : :class:`~numpy.array` or `~astropy.table.Table`, optional, defaults to ``None``
+    targets : :class:`~numpy.array` or `~astropy.table.Table`, optional
         A numpy rec array or astropy Table with at least the columns
         ``RA``, ``DEC``, ``TARGETID``, ``DESI_TARGET``, ``NUMOBS_INIT``,
         and ``PRIORITY_INIT``. If ``None``, then assume the `zcat`

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -576,14 +576,19 @@ def calc_numobs_more(targets, zcat, obscon):
             # ADM If a QSO target is confirmed to have a redshift at
             # ADM z < midzcut it will need to drop by 2 total observations
             # ADM (midzcut is defined at the top of this module).
-            ii = targets[desi_target] & desi_mask.QSO != 0
+            isqso = targets[desi_target] & desi_mask.QSO != 0
             # ADM the mocks may not include the secondary targets.
             if scnd_target in targets.dtype.names:
                 for scxname in scnd_mask.names():
                     if scnd_mask[scxname].flavor == "QSO":
-                        ii |= targets[scnd_target] & scnd_mask[scxname] != 0
-            ii &= (zcat['ZWARN'] == 0)
-            ii &= (zcat['Z'] < midzcut)
+                        isqso |= targets[scnd_target] & scnd_mask[scxname] != 0
+            # ADM the definition used for "not-LyA" in calc_priority.
+            midz = (zcat['Z'] < zcut) & ((zcat['Z_QN'] < zcut)
+                                         | (zcat["IS_QSO_QN"] != 1))
+            # ADM the likely low-z sources get fewer (2) observations.
+            loz = ((zcat['Z'] < midzcut) | (zcat['Z_QN'] < midzcut) |
+                   (zcat["IS_QSO_QN"] != 1))
+            ii = isqso & midz & loz
             numobs_more[ii] = np.maximum(0, numobs_more[ii] - 2)
 
     return numobs_more
@@ -717,24 +722,52 @@ def calc_priority(targets, zcat, obscon, state=False):
             pricon = obsconditions.mask(desi_mask[name].obsconditions)
             if (obsconditions.mask(obscon) & pricon) != 0:
                 ii = (targets[desi_target] & desi_mask[name]) != 0
+
                 # ADM LyA QSOs require more observations.
                 # ADM (zcut is defined at the top of this module).
-                good_hiz = zgood & (zcat['Z'] >= zcut)
-                # ADM Mid-z QSOs require more observations at low
-                # ADM priority as requested by some secondary programs.
-                if survey == "sv3":
-                    good_midz = zgood & (zcat['Z'] >= midzcut) & (zcat['Z'] < zcut)
-                # ADM for the Main Survey EVERY QSO that isn't a LyA QSO
-                # drops to the MIDZ priority until it's done.
-                else:
-                    good_midz = zgood & (zcat['Z'] < zcut)
+                # ADM Main Survey decisions are made using QN/Redrock.
+                if survey == "main":
+                    good_hiz = (zcat['Z'] >= zcut) | ((zcat['Z_QN'] >= zcut) &
+                                                      (zcat["IS_QSO_QN"] == 1))
+                    # ADM all non-LyA-QSOs need more low-priority passes
+                    # ADM in the Main Survey. The mid-z QSOs get 4 passes
+                    # ADM at this lower priority, as requested by some
+                    # ADM secondaries, which is set in calc_numobs_more.
+                    good_midz = (zcat['Z'] < zcut) & ((zcat['Z_QN'] < zcut) |
+                                                      (zcat["IS_QSO_QN"] != 1))
+                    # ADM good_hiz & good_midz should never occur in
+                    # ADM the Main Survey as they're complements.
+                    assert not np.any(good_hiz & good_midz)
+                    # ADM flip to the done state if we've reached it.
+                    good_hiz &= ~done
+                    good_midz &= ~done
 
-                for sbool, sname in zip(
-                        [unobs, done, good_hiz, good_midz,
-                         ~good_hiz & ~good_midz, zwarn],
-                        ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_MIDZQSO",
-                         "DONE", "MORE_ZWARN"]
-                ):
+                    # ADM Main Survey QSOs have no zwarn priority state.
+                    sbools = [unobs, done, good_hiz, good_midz,
+                              ~good_hiz & ~good_midz]
+                    snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_MIDZQSO",
+                              "DONE"]
+
+                # In SV decisions were made without QN.
+                elif survey == "sv3":
+                    good_hiz = zgood & (zcat['Z'] >= zcut)
+                    # ADM SV3 specified mid-z QSOs required more passes.
+                    good_midz = zgood & (zcat['Z'] >= midzcut) & (zcat['Z'] < zcut)
+                    # ADM in SV3 we had a zwarn priority state for QSOs.
+                    sbools = [unobs, done, good_hiz, good_midz,
+                              ~good_hiz & ~good_midz, zwarn]
+                    snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_MIDZQSO",
+                              "DONE", "MORE_ZWARN"]
+
+                else:
+                    good_hiz = zgood & (zcat['Z'] >= zcut)
+                    good_midz = zgood & (zcat['Z'] < zcut)
+                    sbools = [unobs, done, good_hiz, good_midz,
+                              ~good_hiz & ~good_midz, zwarn]
+                    snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_MIDZQSO",
+                              "DONE", "MORE_ZWARN"]
+
+                for sbool, sname in zip(sbools, snames):
                     # ADM update priorities and target states.
                     Mxp = desi_mask[name].priorities[sname]
                     # ADM tiered system in SV3. Decrement MORE_ZWARN

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -665,6 +665,7 @@ def calc_priority(targets, zcat, obscon, state=False):
         done = np.zeros(len(targets), dtype=bool)
         zgood = np.zeros(len(targets), dtype=bool)
         zwarn = np.zeros(len(targets), dtype=bool)
+        lya = np.zeros(len(targets), dtype=bool)
     else:
         nmore = zcat["NUMOBS_MORE"]
         assert np.all(nmore >= 0)

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -671,12 +671,13 @@ def calc_priority(targets, zcat, obscon, state=False):
         done = ~unobs & (nmore == 0)
         zgood = ~unobs & (nmore > 0) & (zcat['ZWARN'] == 0)
         zwarn = ~unobs & (nmore > 0) & (zcat['ZWARN'] != 0)
-        # ADM used to "lock in" the state of LyA QSOs...
-        lya = targets["PRIORITY"] == desi_mask["QSO"].priorities["MORE_ZGOOD"]
-        # ADM ...once they're observed...
-        lya &= ~unobs
-        # ADM ... and until they're done.
-        lya &= ~done
+        if survey == 'main':
+            # ADM used to "lock in" the state of LyA QSOs...
+            lya = targets["PRIORITY"] == desi_mask["QSO"].priorities["MORE_ZGOOD"]
+            # ADM ...once they're observed...
+            lya &= ~unobs
+            # ADM ... and until they're done.
+            lya &= ~done
 
     # zgood, zwarn, done, and unobs should be mutually exclusive and cover all
     # targets.

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -572,8 +572,9 @@ def calc_numobs_more(targets, zcat, obscon):
     # ADM main case, just decrement by NUMOBS.
     numobs_more = np.maximum(0, targets['NUMOBS_INIT'] - zcat['NUMOBS'])
 
-    if survey == 'main':
-        # ADM apply special QSO behavior, but only in dark time.
+    # ADM apply special QSO behavior, but only in dark time and after
+    # ADM some observations have occurred.
+    if survey == 'main' and np.any(zcat["NUMOBS"] > 0):
         if (obsconditions.mask(obscon) & obsconditions.mask("DARK")) != 0:
             # ADM A QSO target that is confirmed to have a redshift at
             # ADM z < midzcut will need to drop by 2 total observations

--- a/py/desitarget/test/test_geomask.py
+++ b/py/desitarget/test/test_geomask.py
@@ -31,28 +31,28 @@ class TestGEOMASK(unittest.TestCase):
         self.assertTrue(foo is None)
 
     def test_match(self):
-        a = np.array([1,2,3,4])
-        b = np.array([4,3])
+        a = np.array([1, 2, 3, 4])
+        b = np.array([4, 3])
         iia, iib = geomask.match(a, b)
 
-        #- returned indices match
+        # - returned indices match
         self.assertTrue(np.all(a[iia] == b[iib]))
 
-        #- ... and are complete
+        # - ... and are complete
         ainb = np.isin(a, b)
         bina = np.isin(b, a)
-        self.assertTrue(np.all( np.isin(a[ainb], a[iia]) ) )
-        self.assertTrue(np.all( np.isin(b[bina], b[iib]) ) )
+        self.assertTrue(np.all(np.isin(a[ainb], a[iia])))
+        self.assertTrue(np.all(np.isin(b[bina], b[iib])))
 
-        #- Check corner cases
-        a = np.array([1,2,3,4])
-        b = np.array([5,6])
+        # - Check corner cases
+        a = np.array([1, 2, 3, 4])
+        b = np.array([5, 6])
         iia, iib = geomask.match(a, b)
         self.assertEqual(len(iia), 0)
         self.assertEqual(len(iib), 0)
 
-        a = np.array([1,2,3,4])
-        b = np.array([4,3,2,1])
+        a = np.array([1, 2, 3, 4])
+        b = np.array([4, 3, 2, 1])
         iia, iib = geomask.match(a, b)
         self.assertTrue(np.all(a[iia] == b[iib]))
         self.assertTrue(len(iia), len(a))

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -15,6 +15,7 @@ from desitarget import io
 from desitarget.targetmask import obsconditions
 from desitarget import __version__
 
+
 class TestIO(unittest.TestCase):
 
     @classmethod
@@ -137,7 +138,7 @@ class TestIO(unittest.TestCase):
         from astropy.table import Table
 
         targets = Table()
-        targets['TARGETID'] = [1,2,3,4,5,6]
+        targets['TARGETID'] = [1, 2, 3, 4, 5, 6]
         D = obsconditions.DARK
         G = obsconditions.GRAY
         B = obsconditions.BRIGHT
@@ -145,22 +146,22 @@ class TestIO(unittest.TestCase):
         iidark = targets['OBSCONDITIONS'] == obsconditions.DARK
         iibright = targets['OBSCONDITIONS'] == obsconditions.BRIGHT
 
-        #- some RA,DEC within nested nside=8 healpix 123
-        targets['RA'] = np.random.uniform(105,106,len(targets))
-        targets['DEC'] = np.random.uniform(72,73,len(targets))
+        # - some RA,DEC within nested nside=8 healpix 123
+        targets['RA'] = np.random.uniform(105, 106, len(targets))
+        targets['DEC'] = np.random.uniform(72, 73, len(targets))
         nside = 8
         hpix = 123
 
-        #- Set some but not all SUBPRIORITY
+        # - Set some but not all SUBPRIORITY
         targets['SUBPRIORITY'] = np.zeros(len(targets))
         targets['SUBPRIORITY'][0::2] = 2.0
 
         targets = np.asarray(targets)
 
         io.write_targets(self.testdir, targets, obscon='DARK',
-                nsidefile=nside, hpxlist=[hpix,])
+                         nsidefile=nside, hpxlist=[hpix, ])
         io.write_targets(self.testdir, targets, obscon='BRIGHT',
-                nsidefile=nside, hpxlist=[hpix,])
+                         nsidefile=nside, hpxlist=[hpix, ])
 
         darkfile = f'{self.testdir}/drX/{__version__}/targets/main/resolve/dark/targets-dark-hp-{hpix}.fits'
         brightfile = f'{self.testdir}/drX/{__version__}/targets/main/resolve/bright/targets-bright-hp-{hpix}.fits'
@@ -168,22 +169,21 @@ class TestIO(unittest.TestCase):
         self.assertTrue(os.path.exists(darkfile))
         self.assertTrue(os.path.exists(brightfile))
 
-        #- Each dark,bright file should only have the targets for that obscon
-        #- and should only override the zero SUBPRIORITY
+        # - Each dark,bright file should only have the targets for that obscon
+        # - and should only override the zero SUBPRIORITY
         dt = Table.read(darkfile)
         self.assertEqual(len(dt), 2)
         self.assertTrue(np.all(dt['TARGETID'] == targets['TARGETID'][iidark]))
-        self.assertTrue(np.all(dt['SUBPRIORITY']>0.0))
+        self.assertTrue(np.all(dt['SUBPRIORITY'] > 0.0))
         self.assertEqual(dt['SUBPRIORITY'][0], 2.0)
         self.assertNotEqual(dt['SUBPRIORITY'][1], 0.0)
 
         bt = Table.read(brightfile)
         self.assertEqual(len(bt), 2)
         self.assertTrue(np.all(bt['TARGETID'] == targets['TARGETID'][iibright]))
-        self.assertTrue(np.all(bt['SUBPRIORITY']>0.0))
+        self.assertTrue(np.all(bt['SUBPRIORITY'] > 0.0))
         self.assertEqual(bt['SUBPRIORITY'][0], 2.0)
         self.assertNotEqual(bt['SUBPRIORITY'][1], 0.0)
-
 
 
 if __name__ == '__main__':

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -235,7 +235,7 @@ class TestMTL(unittest.TestCase):
             modzcat[zcol][iilyaz] = self.midz
             modzcat[zcol][iimidz] = self.lyaz
 
-        # ADM run the MTL.
+        # ADM run MTL.
         mtl = make_mtl(mtl, "DARK", zcat=modzcat, trim=False)
 
         # ADM the result should leave the LyA QSO unchanged (it's "locked
@@ -248,6 +248,22 @@ class TestMTL(unittest.TestCase):
 
         self.assertTrue(np.all(mtl['PRIORITY'] == pp))
         self.assertTrue(np.all(mtl['NUMOBS_MORE'] == nom))
+
+        # ADM add an observation.
+        zcat["NUMOBS"] += 1
+
+        # ADM now reverse the process, returning the mid-z QSO to the
+        # ADM mid-z redshift and the LyA QSO to the Ly-A redshift.
+        for zcol in "Z", "Z_QN":
+            modzcat[zcol][iilyaz] = self.lyaz
+            modzcat[zcol][iimidz] = self.midz
+
+        # ADM run MTL.
+        mtl = make_mtl(mtl, "DARK", zcat=modzcat, trim=False)
+
+        # ADM the once-and-future mid-z QSO should remain "locked in" as
+        # ADM a LyA quasar. So, the priorities should be unchanged.
+        self.assertTrue(np.all(mtl['PRIORITY'] == pp))
 
     def test_mtl_io(self):
         """Test MTL correctly handles masked NUMOBS quantities.

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -210,7 +210,7 @@ class TestMTL(unittest.TestCase):
     def test_lya_lock_in(self):
         """Test LyA QSOs remain LyA QSOs, even when the zcat changes.
         """
-	# ADM set up the MTL as for test_zcat.
+        # ADM set up the MTL as for test_zcat.
         t = self.reset_targets("")
         t = self.update_data_model(t)
         zcat = self.update_data_model(self.zcat.copy())

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -32,12 +32,51 @@ class TestMTL(unittest.TestCase):
         self.targets = Table()
         self.types = np.array(['ELG_LOP', 'LRG', 'QSO', 'QSO', 'QSO', 'ELG_LOP'])
         self.priorities = [Mx[t].priorities['UNOBS'] for t in self.types]
+
+        # ADM checked-by-hand priorities and numbers of observations.
+        # ADM priorities after one pass through MTL.
         self.post_prio = [Mx[t].priorities['UNOBS'] for t in self.types]
-        self.post_prio[0] = Mx['ELG_LOP'].priorities['DONE']  # ELG
-        self.post_prio[1] = Mx['LRG'].priorities['DONE']  # LRG...all one-pass
-        self.post_prio[2] = Mx['QSO'].priorities['MORE_MIDZQSO']  # lowz QSO
-        self.post_prio[3] = Mx['QSO'].priorities['MORE_MIDZQSO']  # midz QSO
-        self.post_prio[4] = Mx['QSO'].priorities['MORE_ZGOOD']  # highz QSO
+        self.post_prio[0] = Mx['ELG_LOP'].priorities['DONE']  # ELG.
+        self.post_prio[1] = Mx['LRG'].priorities['DONE']  # LRG...all one-pass.
+        self.post_prio[2] = Mx['QSO'].priorities['MORE_MIDZQSO']  # lowz/tracer QSO.
+        self.post_prio[3] = Mx['QSO'].priorities['MORE_MIDZQSO']  # true midz QSO.
+        self.post_prio[4] = Mx['QSO'].priorities['MORE_ZGOOD']  # highz QSO.
+        # ADM numobs_more after one pass through MTL.
+        self.post_nom = [Mx[t].numobs for t in self.types]
+        self.post_nom[0] = 0  # ELG gets 1 total observation.
+        self.post_nom[1] = 0  # LRG gets 1 total observation.
+        self.post_nom[2] = 1  # lowz/tracer QSO gets 2 total observations.
+        self.post_nom[3] = 3  # true midz QSO gets 4 total observations.
+        self.post_nom[4] = 3  # LyA QSO gets 4 total observations.
+        # ADM priorities after two passes through MTL.
+        self.post_prio_duo = [Mx[t].priorities['UNOBS'] for t in self.types]
+        self.post_prio_duo[0] = Mx['ELG_LOP'].priorities['DONE']  # ELG after second pass.
+        self.post_prio_duo[1] = Mx['LRG'].priorities['DONE']  # LRG...all one-pass.
+        self.post_prio_duo[2] = Mx['QSO'].priorities['DONE']  # lowz QSO after second pass.
+        self.post_prio_duo[3] = Mx['QSO'].priorities['MORE_MIDZQSO']  # true midz QSO after second pass.
+        self.post_prio_duo[4] = Mx['QSO'].priorities['MORE_ZGOOD']  # highz QSO no change after second pass.
+        # ADM numobs_more after two passes through MTL.
+        self.post_nom_duo = [Mx[t].numobs for t in self.types]
+        self.post_nom_duo[0] = 0  # ELG gets 1 total observation.
+        self.post_nom_duo[1] = 0  # LRG gets 1 total observation.
+        self.post_nom_duo[2] = 0  # lowz/tracer QSO gets 2 total observations.
+        self.post_nom_duo[3] = 2  # true midz QSO gets 4 total observations.
+        self.post_nom_duo[4] = 2  # LyA QSO gets 4 total observations.
+        # ADM priorities after everything is done.
+        self.post_prio_done = [Mx[t].priorities['UNOBS'] for t in self.types]
+        self.post_prio_done[0] = Mx['ELG_LOP'].priorities['DONE']  # ELG.
+        self.post_prio_done[1] = Mx['LRG'].priorities['DONE']  # LRG.
+        self.post_prio_done[2] = Mx['QSO'].priorities['DONE']  # lowz QSO.
+        self.post_prio_done[3] = Mx['QSO'].priorities['DONE']  # true midz.
+        self.post_prio_done[4] = Mx['QSO'].priorities['DONE']  # highz QSO.
+        # ADM numobs_more after two passes through MTL.
+        self.post_nom_done = [Mx[t].numobs for t in self.types]
+        self.post_nom_done[0] = 0
+        self.post_nom_done[1] = 0
+        self.post_nom_done[2] = 0
+        self.post_nom_done[3] = 0
+        self.post_nom_done[4] = 0
+
         nt = len(self.types)
         # ADM add some "extra" columns that are needed for observations.
         for col in ["RA", "DEC", "PARALLAX", "PMRA", "PMDEC", "REF_EPOCH"]:
@@ -57,6 +96,8 @@ class TestMTL(unittest.TestCase):
         # - reverse the order for zcat to make sure joins work
         self.zcat = Table()
         self.zcat['TARGETID'] = self.targets['TARGETID'][-2::-1]
+        # ADM in update_data_model, below, we set QN redshifts ('Z_QN')
+        # ADM to mimic redrock redshifts ('Z').
         self.zcat['Z'] = [2.5, 1.9, 0.5, 0.5, 1.0]
         self.zcat['ZWARN'] = [0, 0, 0, 0, 0]
         self.zcat['NUMOBS'] = [1, 1, 1, 1, 1]
@@ -69,11 +110,13 @@ class TestMTL(unittest.TestCase):
         _, _, survey = main_cmx_or_sv(cat)
         truedm = survey_data_model(cat, survey=survey)
         addedcols = list(set(truedm.dtype.names) - set(cat.dtype.names))
-        # ADM because we set columns like Z_QN and IS_QSO_QN to -1, midz
-        # ADM QSOs will have 1 more observation in these unit tests (LyA
-        # ADM QSOs will have 3 as the criterion is OR redrock Z > 2.1).
+        # ADM We set Main Survey QN columnsin the SetUp. Add any others.
         for col in addedcols:
             cat[col] = [-1] * len(cat)
+        # ADM Set QN redshifts ('Z_QN') to mimic redrock redshifts ('Z').
+        if 'Z' in cat.dtype.names:
+            cat['Z_QN'] = cat['Z']
+            cat['IS_QSO_QN'] = 1
 
         return cat
 
@@ -115,28 +158,53 @@ class TestMTL(unittest.TestCase):
         t = self.reset_targets("")
         t = self.update_data_model(t)
         mtl = make_mtl(t, "DARK")
-        mtl.sort(keys='TARGETID')
         self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [2, 2, 4, 4, 4, 2]))
         self.assertTrue(np.all(mtl['PRIORITY'] == self.priorities))
 
     def test_zcat(self):
-        """Test priorities, numobs, obscon, set correctly after zcat.
+        """Test priorities, numobs, set correctly after zcat.
         """
         t = self.reset_targets("")
         t = self.update_data_model(t)
         zcat = self.update_data_model(self.zcat.copy())
         mtl = make_mtl(t, "DARK", zcat=zcat, trim=False)
-        mtl.sort(keys='TARGETID')
-        pp = self.post_prio.copy()
-        nom = [0, 0, 1, 1, 3, 2]
+        pp = self.post_prio
+        nom = self.post_nom
         self.assertTrue(np.all(mtl['PRIORITY'] == pp))
         self.assertTrue(np.all(mtl['NUMOBS_MORE'] == nom))
         # - change one target to a SAFE (BADSKY) target and confirm priority=0 not 1
         t['DESI_TARGET'][0] = Mx.BAD_SKY
         zcat = self.update_data_model(self.zcat.copy())
         mtl = make_mtl(t, "DARK", zcat=zcat, trim=False)
-        mtl.sort(keys='TARGETID')
         self.assertEqual(mtl['PRIORITY'][0], 0)
+
+    def test_multiple_passes(self):
+        """Test priorities, numobs, correct after two or more MTL passes.
+        """
+        # ADM set up the MTL as for test_zcat.
+        t = self.reset_targets("")
+        t = self.update_data_model(t)
+        zcat = self.update_data_model(self.zcat.copy())
+        mtl = make_mtl(t, "DARK", zcat=zcat, trim=False)
+
+        # Add an observation.
+        zcat["NUMOBS"] += 1
+
+        # ADM repeat MTL to check that numobs and priorities are correct.
+        mtl = make_mtl(mtl, "DARK", zcat=zcat, trim=False)
+        pp = self.post_prio_duo
+        nom = self.post_nom_duo
+        self.assertTrue(np.all(mtl['PRIORITY'] == pp))
+        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == nom))
+
+        # ADM repeat until QSOs should be done, check everything IS done.
+        for i in range(Mx["QSO"].numobs - 2):
+            zcat["NUMOBS"] += 1
+            mtl = make_mtl(mtl, "DARK", zcat=zcat, trim=False)
+        pp = self.post_prio_done
+        nom = self.post_nom_done
+        self.assertTrue(np.all(mtl['PRIORITY'] == pp))
+        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == nom))
 
     def test_mtl_io(self):
         """Test MTL correctly handles masked NUMOBS quantities.
@@ -166,7 +234,9 @@ class TestMTL(unittest.TestCase):
 
         # ADM give them all a "tracer" redshift (below a mid-z QSO).
         qzcat = self.update_data_model(self.zcat.copy())
+        # ADM that this is a tracer should hold regardless of IS_QSO_QN.
         qzcat["Z"] = 0.5
+        qzcat["Z_QN"] = 0.5
 
         # ADM set their initial conditions to be that of a QSO.
         pinit, ninit = initial_priority_numobs(qtargets, obscon="DARK")

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -35,6 +35,7 @@ class TestMTL(unittest.TestCase):
         self.targets = Table()
         self.types = np.array(['ELG_LOP', 'LRG', 'QSO', 'QSO', 'QSO', 'ELG_LOP'])
         self.priorities = [Mx[t].priorities['UNOBS'] for t in self.types]
+        self.nom = [Mx[t].numobs for t in self.types]  # ADM the initial values of NUMOBS_MORE.
 
         # ADM checked-by-hand priorities and numbers of observations.
         # ADM priorities after one pass through MTL.
@@ -89,7 +90,6 @@ class TestMTL(unittest.TestCase):
                     'SUBPRIORITY', "PRIORITY"]:
             self.targets[col] = np.zeros(nt, dtype=mtldatamodel[col].dtype)
         n = len(self.targets)
-        self.targets['ZFLUX'] = 10**((22.5-np.linspace(20, 22, n))/2.5)
         self.targets['TARGETID'] = list(range(n))
         # ADM determine the initial PRIORITY and NUMOBS.
         pinit, ninit = initial_priority_numobs(self.targets, obscon="DARK")
@@ -160,7 +160,7 @@ class TestMTL(unittest.TestCase):
         t = self.reset_targets("")
         t = self.update_data_model(t)
         mtl = make_mtl(t, "DARK")
-        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == [2, 2, 4, 4, 4, 2]))
+        self.assertTrue(np.all(mtl['NUMOBS_MORE'] == self.nom))
         self.assertTrue(np.all(mtl['PRIORITY'] == self.priorities))
 
     def test_zcat(self):

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -106,7 +106,7 @@ class TestMTL(unittest.TestCase):
             self.assertEqual(refnames, mtlnames)
 
     def test_numobs(self):
-        """Test priorities, numobs, obscon, set correctly with no zcat.
+        """Test priorities, numobs, set correctly with no zcat.
         """
         t = self.reset_targets("")
         t = self.update_data_model(t)

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -43,7 +43,8 @@ class TestMTL(unittest.TestCase):
         for col in ["RA", "DEC", "PARALLAX", "PMRA", "PMDEC", "REF_EPOCH"]:
             self.targets[col] = np.zeros(nt, dtype=mtldatamodel[col].dtype)
         self.targets['DESI_TARGET'] = [Mx[t].mask for t in self.types]
-        for col in ['BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET', 'SUBPRIORITY']:
+        for col in ['BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET',
+                    'SUBPRIORITY', "PRIORITY"]:
             self.targets[col] = np.zeros(nt, dtype=mtldatamodel[col].dtype)
         n = len(self.targets)
         self.targets['ZFLUX'] = 10**((22.5-np.linspace(20, 22, n))/2.5)
@@ -68,6 +69,9 @@ class TestMTL(unittest.TestCase):
         _, _, survey = main_cmx_or_sv(cat)
         truedm = survey_data_model(cat, survey=survey)
         addedcols = list(set(truedm.dtype.names) - set(cat.dtype.names))
+        # ADM because we set columns like Z_QN and IS_QSO_QN to -1, midz
+        # ADM QSOs will have 1 more observation in these unit tests (LyA
+        # ADM QSOs will have 3 as the criterion is OR redrock Z > 2.1).
         for col in addedcols:
             cat[col] = [-1] * len(cat)
 
@@ -124,7 +128,7 @@ class TestMTL(unittest.TestCase):
         mtl = make_mtl(t, "DARK", zcat=zcat, trim=False)
         mtl.sort(keys='TARGETID')
         pp = self.post_prio.copy()
-        nom = [0, 0, 1, 3, 3, 2]
+        nom = [0, 0, 1, 1, 3, 2]
         self.assertTrue(np.all(mtl['PRIORITY'] == pp))
         self.assertTrue(np.all(mtl['NUMOBS_MORE'] == nom))
         # - change one target to a SAFE (BADSKY) target and confirm priority=0 not 1

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -357,11 +357,11 @@ class TestMTL(unittest.TestCase):
         qtargets["PRIORITY_INIT"] = pinit
         qtargets["NUMOBS_INIT"] = ninit
 
-        # ADM run through MTL.
-        mtl = make_mtl(qtargets, obscon="DARK", zcat=qzcat)
+        # ADM run through MTL, only return entries updated by the zcat.
+        mtl = make_mtl(qtargets, obscon="DARK", zcat=qzcat, trimtozcat=True)
 
         # ADM all confirmed tracer quasars should have NUMOBS_MORE=1.
-        self.assertTrue(np.all(qzcat["NUMOBS_MORE"] == 1))
+        self.assertTrue(np.all(mtl["NUMOBS_MORE"] == 1))
 
     @unittest.skip('This test is deprecated.')
     def test_endless_bgs(self):
@@ -381,11 +381,12 @@ class TestMTL(unittest.TestCase):
         # ADM create a copy of the zcat.
         bgszcat = self.update_data_model(self.zcat.copy())
 
-        # ADM run through MTL.
-        mtl = make_mtl(bgstargets, obscon="BRIGHT", zcat=bgszcat)
+        # ADM run through MTL, only return entries updated by the zcat.
+        mtl = make_mtl(bgstargets, obscon="BRIGHT", zcat=bgszcat,
+                       trimtozcat=True)
 
         # ADM all BGS targets should always have NUMOBS_MORE=1.
-        self.assertTrue(np.all(bgszcat["NUMOBS_MORE"] == 1))
+        self.assertTrue(np.all(mtl["NUMOBS_MORE"] == 1))
 
     @unittest.skipIf(norr, 'redrock not installed; skip ZWARN consistency check')
     def test_zwarn_in_sync(self):

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -31,7 +31,7 @@ class TestMTL(unittest.TestCase):
     def setUp(self):
         self.lyaz = zcut + 0.4  # ADM an appropriate redshift for a LyA QSO.
         self.midz = 0.5*(midzcut + zcut)  # ADM a redshift for a true mid-z QSO.
-        self.lowz = 0.5 # ADM an appropriate redshift for a tracer QSO.
+        self.lowz = 0.5  # ADM an appropriate redshift for a tracer QSO.
         self.targets = Table()
         self.types = np.array(['ELG_LOP', 'LRG', 'QSO', 'QSO', 'QSO', 'ELG_LOP'])
         self.priorities = [Mx[t].priorities['UNOBS'] for t in self.types]

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -181,6 +181,13 @@ class TestPriorities(unittest.TestCase):
         t = self.targets
         z = self.zcat
 
+        # ADM the data model is slightly different for the Main Survey.
+        truedm = survey_data_model(z, survey="main")
+        addedcols = list(set(truedm.dtype.names) - set(z.dtype.names))
+        for col in addedcols:
+            t[col] = -1
+            z[col] = -1
+
         t['DESI_TARGET'][0] = desi_mask.ELG
         t['DESI_TARGET'][1] = desi_mask.ELG | desi_mask.NEAR_BRIGHT_OBJECT
         t['DESI_TARGET'][2] = desi_mask.ELG | desi_mask.IN_BRIGHT_OBJECT

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -58,7 +58,7 @@ class TestPriorities(unittest.TestCase):
         # ADM retain an unaltered copy of z.
         zcat = z.copy()
 
-        # - No targeting bits set is priority=0
+        # - No targeting bits set if priority=0
         self.assertTrue(np.all(calc_priority(t, z, "BRIGHT") == 0))
 
         # ADM test QSO > LRG > ELG for main survey and SV.
@@ -176,8 +176,11 @@ class TestPriorities(unittest.TestCase):
         self.assertLess(lowest_bgs_priority_zgood, lowest_mws_priority)
 
     def test_bright_mask(self):
+        """Test that bright-object masking priorities are correctly set.
+        """
         t = self.targets
         z = self.zcat
+
         t['DESI_TARGET'][0] = desi_mask.ELG
         t['DESI_TARGET'][1] = desi_mask.ELG | desi_mask.NEAR_BRIGHT_OBJECT
         t['DESI_TARGET'][2] = desi_mask.ELG | desi_mask.IN_BRIGHT_OBJECT

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -24,7 +24,6 @@ class TestPriorities(unittest.TestCase):
             ('Z', np.float32),
             ('ZWARN', np.float32),
             ('NUMOBS', np.float32),
-            ('SPECTYPE', np.str),
             ('ZTILEID', np.int32)
         ]
 

--- a/py/desitarget/test/test_subpriority.py
+++ b/py/desitarget/test/test_subpriority.py
@@ -10,6 +10,7 @@ from astropy.table import Table
 
 import desitarget.subpriority
 
+
 class TestSubpriority(unittest.TestCase):
 
     @classmethod
@@ -26,13 +27,13 @@ class TestSubpriority(unittest.TestCase):
         targets['SUBPRIORITY'] = orig_subpriority.copy()
 
         override = Table()
-        override['TARGETID'] = np.array([3,2,20])
+        override['TARGETID'] = np.array([3, 2, 20])
         override['SUBPRIORITY'] = np.array([10.0, 20.0, 30.0])
 
         desitarget.subpriority.override_subpriority(targets, override)
 
-        #- Check that we overrode correctly; don't juse geomask.match
-        #- to avoid circularity of code and test
+        # - Check that we overrode correctly; don't use geomask.match
+        # - to avoid circularity of code and test
         for i, tid in enumerate(targets['TARGETID']):
             in_override = np.where(override['TARGETID'] == tid)[0]
             if len(in_override) > 0:
@@ -44,19 +45,19 @@ class TestSubpriority(unittest.TestCase):
     def test_override_duplicates(self):
         """Test subpriority override with duplicate input TARGETIDs"""
         targets = Table()
-        targets['TARGETID'] = [1,2,3,2,1,5]
+        targets['TARGETID'] = [1, 2, 3, 2, 1, 5]
         n = len(targets['TARGETID'])
         orig_subpriority = np.random.random(n)
         targets['SUBPRIORITY'] = orig_subpriority.copy()
 
         override = Table()
-        override['TARGETID'] = np.array([3,2,20])
+        override['TARGETID'] = np.array([3, 2, 20])
         override['SUBPRIORITY'] = np.array([10.0, 20.0, 30.0])
 
         desitarget.subpriority.override_subpriority(targets, override)
 
-        #- Check that we overrode correctly; don't juse geomask.match
-        #- to avoid circularity of code and test
+        # - Check that we overrode correctly; don't juse geomask.match
+        # - to avoid circularity of code and test
         for i, tid in enumerate(targets['TARGETID']):
             in_override = np.where(override['TARGETID'] == tid)[0]
             if len(in_override) > 0:


### PR DESCRIPTION
This PR should be the final piece needed for the full MTL loop for the Main Survey. It adds the logic for deciding which quasars are observed at high priority on repeat passes. To try to succinctly describe the logic:

- Let `Z` denote the redrock redshift.
- Let `Z_QN` denote the QuasarNP redshift.
- Let `IS_QSO_QN` denote the QuasarNP decision as to whether something is a quasar or not.

Then:

- If a QSO target has `Z > 2.1` OR (`Z_QN > 2.1` AND `IS_QSO_QN==1`) it is confirmed as a **LyA quasar**. It receives 3 more observations (for a total of 4 observations) at a very high priority (just below an unoberved quasar).
- If a QSO target has `Z < 1.6` OR `Z_QN < 1.6` OR `IS_QSO_QN !=1` it is confirmed as a (possible) **tracer quasar**. It receives 1 more observation (for a total of 2 observations) at a priority lower than all other targets but above "filler" targets.
- All other QSO targets are considered to be **"mid-z" quasars** (requested by a secondary program). They receive 3 more observations (for a total of 4 observations) at a priority lower than all other targets but above "filler" targets.

Additionally:

- LyA QSOs are "locked in" to their priority state as soon as they are determined to be a LyA quasar. This is to ameliorate a bout of unlucky spectroscopy consigning them to be tracer quasars from which it may be difficult to recover.
- All other quasar targets are allowed to be promoted to LyA quasars should they meet the LyA criteria on subsequent passes. No quasar target ever receives more than 4 total observations, though.
- "Standalone" secondary QSO programs (`WISE_VAR_QSO`, `QSO_RED`) share the same logic as for primary QSOs. Almost all (standalone) targets in these programs fall in the tracer category, though. This is generally because of the shallower WISE selection(s) used by these programs, which skews the redshift distribution to z~1 compared to quasars selected with more overall weight given to optical data.


I'll use this branch to make MTL ledgers for review once the zqso catalogs are ready at NERSC. I'll subsequently merge this PR if those MTL ledgers look reasonable to the Operations team and some select quasologists.