### PR TITLE
more robust to zqso failures

### DIFF
--- a/bin/make_zqso_files
+++ b/bin/make_zqso_files
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import os
+import sys
+import traceback
 from desitarget.mtl import get_zcat_dir
 from desitarget.lyazcat import get_qn_model_fname, load_qn_model
 from desitarget.lyazcat import get_sq_model_fname, load_sq_model
@@ -136,14 +138,24 @@ else:
     nights = [n for n in args.night.split(',')]
     petals = [p for p in args.petal.split(',')]
 
+    numerr = 0
     for tile, night in zip(tiles, nights):
         for pnum in petals:
             log.info("processing TILEID={}, NIGHTID={}, petal={}".format(
                 tile, night, pnum))
-            create_zcat(input_dir, output_dir, tile=tile,
+            try:
+                create_zcat(input_dir, output_dir, tile=tile,
                         night=night, petal_num=pnum, qn_flag=add_quasarnp,
                         qnp_model=qnp_model, qnp_model_file=args.qn_model_file,
                         qnp_lines=qnp_lines, qnp_lines_bal=qnp_lines_bal,
                         sq_flag=args.add_squeze, squeze_model=sq_model,
                         squeze_model_file=args.sq_model_file,
                         abs_flag=args.add_mgii, zcomb_flag=args.add_zcomb)
+            except Exception as err:
+                numerr += 1
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+                print(''.join(lines))
+                log.error(f'Tile {tile} night {night} petal {pnum} failed; continuing')
+
+    sys.exit(numerr)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desitarget Change Log
 1.1.2 (unreleased)
 ------------------
 
-* No changes yet.
+* ``make_zqso_files`` more robust to problems on individual tile,night,petal
+  while still processing the others [`PR #752`_].
+
+.. _`PR #752`: https://github.com/desihub/desitarget/pull/752
 
 1.1.1 (2021-05-29)
 ------------------


### PR DESCRIPTION
This PR adds robustness to make_zqso_files.  Previously if a call to `create_zcat` failed for a particular tile,night,petal it could cause the program to stop without processing the remaining tile,night,petals requested.  Now it prints the traceback, logs an error, then proceeds with the others.  The exit code is now the number of failures.

An example case for triggering this is tile 325 night 20210406 where the pipeline succeeded in making a zbest file but failed at making a coadd file for petal 2.  I'll separately investigate what happened there, but the point is that shouldn't block make_zqso_files from processing petals 3-9 just because it was missing inputs for petal 2.

```
<cori zqso> make_zqso_files -t 325 -n 20210406 -o $CSCRATCH/desi/qzsotest
...
INFO:make_zqso_files:144:<module>: processing TILEID=325, NIGHTID=20210406, petal=2
INFO:lyazcat.py:66:tmark: 
    Making redrock zcat: 2021-06-04 | 13:10:25
INFO:lyazcat.py:100:make_new_zcat: Read /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/325/20210406/zbest-2-325-thru20210406.fits
INFO:lyazcat.py:66:tmark: 
    Adding QuasarNP data: 2021-06-04 | 13:10:25
Traceback (most recent call last):
  File "/global/common/software/desi/users/sjbailey/desitarget/bin/make_zqso_files", line 147, in <module>
    create_zcat(input_dir, output_dir, tile=tile,
  File "/global/common/software/desi/users/sjbailey/desitarget/py/desitarget/lyazcat.py", line 775, in create_zcat
    zcat = add_qn_data(zcat, coaddfn, qnp_model, qnp_lines, qnp_lines_bal)
  File "/global/common/software/desi/users/sjbailey/desitarget/py/desitarget/lyazcat.py", line 244, in add_qn_data
    data, w = load_desi_coadd(coaddname)
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/QuasarNP/0.1.0/lib/python3.8/site-packages/quasarnp/io.py", line 428, in load_desi_coadd
    with fitsio.FITS(filename) as h:
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/conda/lib/python3.8/site-packages/fitsio/fitslib.py", line 477, in __init__
    self._FITS = _fitsio_wrap.FITS(filename, self.intmode, create)
OSError: FITSIO status = 104: could not open the named file
failed to find or open the following file: (ffopen)
/global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/325/20210406/coadd-2
-325-thru20210406.fits

ERROR:make_zqso_files:156:<module>: Tile 325 night 20210406 petal 2 failed; continuing
INFO:make_zqso_files:144:<module>: processing TILEID=325, NIGHTID=20210406, petal=3
INFO:lyazcat.py:66:tmark: 
    Making redrock zcat: 2021-06-04 | 13:10:25
INFO:lyazcat.py:100:make_new_zcat: Read /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/325/20210406/zbest-3-325-thru20210406.fits
...