### PR TITLE
add ZWARN bad QA bits

### DIFF
--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -223,6 +223,7 @@ targetid_mask:
 # ADM ZWARN mask (bits that can be set to warn that a redshift is bad).
 # ADM inherited from https://github.com/desihub/redrock/blob/master/py/redrock/zwarning.py
 zwarn_mask:
+    # SB bits 0-15 set by redrock
     - [SKY,                0, "sky fiber"]
     - [LITTLE_COVERAGE,    1, "too little wavelength coverage"]
     - [SMALL_DELTA_CHI2,   2, "chi-squared of best fit is too close to that of second best"]
@@ -234,8 +235,11 @@ zwarn_mask:
     - [BAD_TARGET,         8, "catastrophically bad targeting data"]
     - [NODATA,             9, "No data for this fiber, e.g. because spectrograph was broken during this exposure (ivar=0 for all pixels)"]
     - [BAD_MINFIT,        10, "Bad parabola fit to the chi2 minimum"]
+    # SB bits 16-24 available for DESI to set post-redrock
     - [LOW_DEL_CHI2,      16, "DELTACHI2 is lower than 25 for a DESI SV3 target"]
     - [LOW_DEL_CHI2_BGS,  17, "DELTACHI2 is lower than 40 for a DESI SV3 BGS target in bright time"]
+    - [BAD_SPECQA,        18, "QA rejected due to spectrum-level problems"]
+    - [BAD_PETALQA,       19, "QA rejected due to petal-level problems"]
 
 #- Priorities for each target bit
 #- Numerically larger priorities are higher priority to be observed first.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -413,7 +413,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
                 num_nod))
             zcat = zcat[~nodata]
         # SB ignore targets that failed QA: ZWARN bits BAD_SPECQA|BAD_PETALQA
-        badqa = zcat["ZWARN"] & zwarn_mask["BAD_SPECQA|BAD_PETALQA"] != 0
+        badqa = zcat["ZWARN"] & zwarn_mask.mask("BAD_SPECQA|BAD_PETALQA") != 0
         num_badqa = np.sum(badqa)
         if num_badqa > 0:
             log.info(f"Ignoring a further {num_badqa} zcat entries with BAD_SPECQA or BAD_PETALQA set")


### PR DESCRIPTION
This PR adds ZWARN bits BAD_SPECQA and BAD_PETALQA and updates the MTL logic to reject those in addition to NODATA.  I'll open a companion desispec PR after this to set those bits when making zmtl (formerly zqso formerly zcat) files.

Example desispec outputs are in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/zmtl, though I have not tested how mtl updates would use them.  Unit tests did catch some typos so the updates are at least somewhat tested.

@geordie666 please take a look.  I did *not* update the $ZCAT_DIR environment variable, but let's consider renaming that to $ZMTL_DIR too in both the code and etc/desitarget.module .

Also: I did *not* remove the zqso code from desitarget yet, even though it is moving over to desispec as part of the aforementioned PR.  Let's make sure it fully works there (as zmtl) before removing it from desitarget as a separate PR.