### PR TITLE
add redrock ZWARN bit 11=POORDATA

### DIFF
--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -235,6 +235,7 @@ zwarn_mask:
     - [BAD_TARGET,         8, "catastrophically bad targeting data"]
     - [NODATA,             9, "No data for this fiber, e.g. because spectrograph was broken during this exposure (ivar=0 for all pixels)"]
     - [BAD_MINFIT,        10, "Bad parabola fit to the chi2 minimum"]
+    - [POORDATA,          11, "Poor input data quality but try fitting anyway"]
     # SB bits 16-24 available for DESI to set post-redrock
     - [LOW_DEL_CHI2,      16, "DELTACHI2 is lower than 25 for a DESI SV3 target"]
     - [LOW_DEL_CHI2_BGS,  17, "DELTACHI2 is lower than 40 for a DESI SV3 BGS target in bright time"]


### PR DESCRIPTION
Adds ZWARN bit 11 "POORDATA" which was recently added to the redrock ZWARN bitmask, and which desitarget unit tests properly caught hadn't been updated here yet.  (background: desitarget doesn't depend upon redrock both to avoid circular dependencies and to simplify what is required for desitarget to run, but unit tests check that it's list of redrock ZWARN bits is current).

I think the equivalent of this bit is already propagated through tile QA and zmtl in FIBERSTATUS, so I don't think any change is needed on the MTL side, but I will leave this open for a cross check and/or a second look on a non-weekend day.  The change on the redrock side was to set the bit for positioner offset > 30 microns at the time of running redrock, and not just post-facto as part of tile QA.