### PR TITLE
Add a TIMESTAMP to the Main Survey Target of Opportunity Ledgers

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 1.2.3 (unreleased)
 ------------------
 
-* No changes yet.
+* Add a ``TIMESTAMP`` to the Main Survey ToO Ledgers [`PR #761`_].
+
+.. _`PR #761`: https://github.com/desihub/desitarget/pull/761
 
 1.2.2 (2021-07-08)
 ------------------

--- a/py/desitarget/ToO.py
+++ b/py/desitarget/ToO.py
@@ -14,6 +14,7 @@ from astropy.table import Table
 from desiutil.log import get_logger
 
 from desitarget import io
+from desitarget.mtl import get_utc_date
 # ADM the data model for ToO, similar to that of secondary targets...
 from desitarget.secondary import indatamodel
 from desitarget.secondary import outdatamodel
@@ -27,7 +28,7 @@ indatamodel = np.array([], dtype=indtype + [
     ('MJD_BEGIN', '>f8'), ('MJD_END', '>f8'), ('TOOID', '>i4')])
 outdatamodel = np.array([], dtype=outdtype + [
     ('CHECKER', '>U7'), ('TOO_TYPE', '>U5'),
-    ('TOO_PRIO', '>U2'), ('OCLAYER', '>U6'),
+    ('TOO_PRIO', '>U2'), ('OCLAYER', '>U6'), ('TIMESTAMP', 'U25'),
     ('MJD_BEGIN', '>f8'), ('MJD_END', '>f8'), ('TOOID', '>i4')])
 
 # ADM when using basic or csv ascii writes, specifying the formats of
@@ -447,6 +448,9 @@ def finalize_too(inledger, survey="main"):
     # ADM assign a SUBPRIORITY.
     np.random.seed(616)
     outdata["SUBPRIORITY"] = np.random.random(ntoo)
+
+    # ADM finally, add a processing timestamp.
+    outdata["TIMESTAMP"] = get_utc_date(survey="main")
 
     return outdata
 

--- a/py/desitarget/ToO.py
+++ b/py/desitarget/ToO.py
@@ -28,8 +28,10 @@ indatamodel = np.array([], dtype=indtype + [
     ('MJD_BEGIN', '>f8'), ('MJD_END', '>f8'), ('TOOID', '>i4')])
 outdatamodel = np.array([], dtype=outdtype + [
     ('CHECKER', '>U7'), ('TOO_TYPE', '>U5'),
-    ('TOO_PRIO', '>U2'), ('OCLAYER', '>U6'), ('TIMESTAMP', 'U25'),
+    ('TOO_PRIO', '>U2'), ('OCLAYER', '>U6'),
     ('MJD_BEGIN', '>f8'), ('MJD_END', '>f8'), ('TOOID', '>i4')])
+# ADM columns to only include in the output for Main Survey files.
+msaddcols = np.array([], dtype=[('TIMESTAMP', 'U25')])
 
 # ADM when using basic or csv ascii writes, specifying the formats of
 # ADM float32 columns can make things easier on the eye.
@@ -401,8 +403,13 @@ def finalize_too(inledger, survey="main"):
         A Table of targets generated from the ToO ledger, with the
         necessary columns added for fiberassign to run.
     """
+    # ADM add extra columns that are just for the Main Survey.
+    dt = outdatamodel.dtype.descr
+    if survey == 'main':
+        dt += msaddcols.dtype.descr
+
     # ADM create the output data table.
-    outdata = Table(np.zeros(len(inledger), dtype=outdatamodel.dtype))
+    outdata = Table(np.zeros(len(inledger), dtype=dt))
     # ADM change column names to reflect the survey.
     if survey[:2] == "sv":
         bitcols = [col for col in outdata.dtype.names if "_TARGET" in col]
@@ -450,7 +457,9 @@ def finalize_too(inledger, survey="main"):
     outdata["SUBPRIORITY"] = np.random.random(ntoo)
 
     # ADM finally, add a processing timestamp.
-    outdata["TIMESTAMP"] = get_utc_date(survey="main")
+    # ADM I only remembered to do this starting with the Main Survey.
+    if survey == 'main':
+        outdata["TIMESTAMP"] = get_utc_date(survey="main")
 
     return outdata
 


### PR DESCRIPTION
This PR adds a `TIMESTAMP` to the ToO Ledgers for `survey='main'`. The same `TIMESTAMP` as used elsewhere in the MTL loop is appropriated.

The justification for this addition is so that any fiber-override ToOs that are included in the future can be modeled in the alternative MTL ledgers, just as with any other target passed to fiberassign. It's possible that fiber-overrides for ToOs won't be necessary, but if they are adopted, having a `TIMESTAMP` will be crucial.

This is a small change that should be uncontroversial. It only affects a single column in the ToO ledger, and is backwards-compatible from `main` to `sv3`. So, I'll merge it after the weekend.