### PR TITLE
Add functionality to override MTL ledger entries

### DIFF
--- a/bin/add_to_override_ledgers
+++ b/bin/add_to_override_ledgers
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+from desitarget.mtl import ledger_overrides
+from desiutil.log import get_logger
+import json
+log = get_logger()
+
+# ADM default number of times to override ledger entry.
+numoverride = 999
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Add entries to the ledgers used to override the standard MTL ledgers')
+ap.add_argument("overfn",
+                help="Full path to the filename that contains the override      \
+                information. Must contain at least RA, DEC, TARGETID and be in  \
+                a format that can be read by astropy.table.Table.read().")
+ap.add_argument("obscon",
+                help="String matching ONE obscondition in the desitarget yaml   \
+                bitmask file (i.e. in `desitarget.targetmask.obsconditions`).   \
+                Used to construct the directory to find Main Survey ledgers.")
+ap.add_argument("-c", "--colsub",
+                help="If passed, each key should correspond to the name of a    \
+                ledger column and each value to a column name in `overfn`. The  \
+                ledger columns are overwritten by the corresponding column in   \
+                `overfn` (for each TARGETID). FORMAT AS A DICTIONARY IN SINGLE  \
+                QUOTES WITH KEYS IN DOUBLE QUOTES, e.g. '{\"blat\": 1}' or      \
+                '{\"blat\": \"foo\"}'.",
+                default=None, type=json.loads)
+ap.add_argument("-v", "--valsub",
+                help="If passed, each key should correspond to the name of a    \
+                ledger column and each value to a single number or string. The  \
+                'value' will be overwritte into the 'key' column of the ledger. \
+                USE DICTIONARY FORMAT (as above). Takes precedence over colsub.",
+                default=None, type=json.loads)
+ap.add_argument('--mtldir',
+                help="Full path to the directory that hosts the MTL ledgers.    \
+                Default is to use the $MTL_DIR environment variable",
+                default=None)
+ap.add_argument("-s", "--secondary", action='store_true',
+                help="Process secondary targets instead of primaries")
+ap.add_argument("-n", "--numoverride",
+                help="The override ledger is read each time the MTL loop is run.\
+                This is the number of times to override the standard results in \
+                the MTL loop. Defaults to {}".format(numoverride),
+                default=numoverride)
+ns = ap.parse_args()
+
+outdir = ledger_overrides(
+    ns.overfn, ns.obscon, colsub=ns.colsub, valsub=ns.valsub,
+    mtldir=ns.mtldir, secondary=ns.secondary, numoverride=ns.numoverride)
+
+log.info("Augmented override ledgers in {}".format(outdir))

--- a/bin/force_mtl_overrides
+++ b/bin/force_mtl_overrides
@@ -10,11 +10,17 @@ ap.add_argument("hpdirname",
                 help="Full path to a directory containing MTL ledgers that are  \
                 partitioned by HEALPixel (i.e. as made by `make_ledger`). NOTE: \
                 send the directory of the MTL ledgers, NOT the override ledgers")
-ap.add_argument("pixlist", 
+ap.add_argument("pixlist",
                 help="A list of HEALPixels signifying the ledgers to be updated.\
                 Send as a comma-separated string (e.g. 12167,53,455,9)")
 
 ns = ap.parse_args()
+
+# ADM a check that we didn't accidentally pass the directory that hosts
+# ADM the override ledgers.
+if "override" in ns.hpdirname:
+    msg = "Did you pass the override directory instead of the MTL directory?"
+    log.warning(msg)
 
 hpxlist = [ pix for pix in ns.pixlist.split(',') ]
 

--- a/bin/force_mtl_overrides
+++ b/bin/force_mtl_overrides
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from desitarget.mtl import force_overrides
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Force override ledgers to be processed and added to the MTL ledgers without running the full MTL loop.')
+ap.add_argument("hpdirname",
+                help="Full path to a directory containing MTL ledgers that are  \
+                partitioned by HEALPixel (i.e. as made by `make_ledger`). NOTE: \
+                send the directory of the MTL ledgers, NOT the override ledgers")
+ap.add_argument("pixlist", 
+                help="A list of HEALPixels signifying the ledgers to be updated.\
+                Send as a comma-separated string (e.g. 12167,53,455,9)")
+
+ns = ap.parse_args()
+
+hpxlist = [ pix for pix in ns.pixlist.split(',') ]
+
+outdir = force_overrides(ns.hpdirname, hpxlist)
+
+log.info("Overrode ledgers in {}".format(outdir))

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -22,7 +22,7 @@ ap.add_argument('--zcatdir',
                 default=None)
 ap.add_argument('--mtldir',
                 help="Full path to the directory that hosts the MTL ledgers.    \
-                Default is to use the $ZCAT_DIR environment variable",
+                Default is to use the $MTL_DIR environment variable",
                 default=None)
 ap.add_argument("-n", "--numobsfromzcat", action='store_true',
                 help="If passed, the zcat includes a meaningful NUMOBS.         \

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,14 @@ desitarget Change Log
 1.2.3 (unreleased)
 ------------------
 
+* Functionality to override MTL ledger entries [`PR #763`_]. Includes:
+    * ``add_to_override_ledgers`` to create or expand override ledgers.
+    * ``force_mtl_overrides`` to force overrides into the MTL ledgers.
+    * Processing overrides automatically as part of the MTL loop.
 * Add a ``TIMESTAMP`` to the Main Survey ToO Ledgers [`PR #761`_].
 
 .. _`PR #761`: https://github.com/desihub/desitarget/pull/761
+.. _`PR #763`: https://github.com/desihub/desitarget/pull/763
 
 1.2.2 (2021-07-08)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -9,6 +9,7 @@ desitarget Change Log
     * ``add_to_override_ledgers`` to create or expand override ledgers.
     * ``force_mtl_overrides`` to force overrides into the MTL ledgers.
     * Processing overrides automatically as part of the MTL loop.
+    * Override ledgers can be read using MTL utilities in desitarget.io.
 * Add a ``TIMESTAMP`` to the Main Survey ToO Ledgers [`PR #761`_].
 
 .. _`PR #761`: https://github.com/desihub/desitarget/pull/761

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2867,7 +2867,10 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False, override=False):
     # ADM return the filename.
     fileform = os.path.join(hpdirname, os.path.basename(hugefn))
     if override:
+        # ADM be forgiving if the override directory itself was passed.
         fileform = os.path.join(hpdirname, "override", os.path.basename(hugefn))
+        if "override" in hpdirname:
+            fileform = os.path.join(hpdirname, os.path.basename(hugefn))
 
     if returnoc:
         return fileform, oc

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2320,7 +2320,7 @@ def _get_targ_dir():
 def find_target_files(targdir, dr='X', flavor="targets", survey="main",
                       obscon=None, hp=None, nside=None, resolve=True, supp=False,
                       mock=False, nohp=False, seed=None, region=None, epoch=None,
-                      maglim=None, override=None, ender="fits"):
+                      maglim=None, override=False, ender="fits"):
     """Build the name of an output target file (or directory).
 
     Parameters
@@ -2824,7 +2824,7 @@ def read_ecsv_header(filename):
     return hdr
 
 
-def find_mtl_file_format_from_header(hpdirname, returnoc=False):
+def find_mtl_file_format_from_header(hpdirname, returnoc=False, override=False):
     """Construct an MTL filename just from the header in the file
 
     Parameters
@@ -2837,6 +2837,9 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False):
     returnoc : :class:`bool`, optional, defaults to ``False``
         If ``True`` then also return the OBSCON header keyword
         for files in this directory.
+    override : :class:`bool`, optional, defaults to ``False``
+        If ``True``, return the file form for an override ledger instead
+        of a standard MTL ledger.
 
     Returns
     -------
@@ -2858,10 +2861,14 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False):
     ender = get_mtl_ledger_format()
 
     # ADM construct the full directory path.
-    hugefn = find_target_files(hpdirname, flavor="mtl", hp="{}",
-                               survey=surv, ender=ender, obscon=oc)
+    hugefn = find_target_files(hpdirname, flavor="mtl", hp="{}", survey=surv,
+                               ender=ender, obscon=oc, override=override)
+
     # ADM return the filename.
     fileform = os.path.join(hpdirname, os.path.basename(hugefn))
+    if override:
+        fileform = os.path.join(hpdirname, "override", os.path.basename(hugefn))
+
     if returnoc:
         return fileform, oc
     return fileform

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2830,16 +2830,18 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False, override=False):
     Parameters
     ----------
     hpdirname : :class:`str`
-        Full path to either a directory containing targets that
-        have been partitioned by HEALPixel (i.e. as made by
-        `select_targets` with the `bundle_files` option). Or the
-        name of a single file of targets.
+        Full path to either a directory containing MTL ledgers that have
+        been partitioned by HEALPixel. Or the name of a single ledger.
     returnoc : :class:`bool`, optional, defaults to ``False``
         If ``True`` then also return the OBSCON header keyword
         for files in this directory.
     override : :class:`bool`, optional, defaults to ``False``
         If ``True``, return the file form for an override ledger instead
-        of a standard MTL ledger.
+        of a standard MTL ledger IF the location of a standard MTL ledger
+        or ledgers has been passed as `hpdirname`. If the location of an
+        override ledger or ledgers has been passed as `hpdirname`, then
+        the fact that we're working with override ledgers is detected
+        automatically and `override`=``True`` does not need to be passed.
 
     Returns
     -------
@@ -2857,6 +2859,12 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False, override=False):
     # ADM grab information from the target directory.
     surv = read_keyword_from_mtl_header(hpdirname, "SURVEY")
     oc = read_keyword_from_mtl_header(hpdirname, "OBSCON")
+    # ADM detect whether we're working with the override ledgers.
+    try:
+        override = bool(read_keyword_from_mtl_header(hpdirname, "OVERRIDE"))
+    except KeyError:
+        pass
+
     from desitarget.mtl import get_mtl_ledger_format
     ender = get_mtl_ledger_format()
 

--- a/py/desitarget/lyazcat.py
+++ b/py/desitarget/lyazcat.py
@@ -21,7 +21,7 @@ from quasarnp.io import load_model
 from quasarnp.io import load_desi_coadd
 from quasarnp.utils import process_preds
 
-from prospect.mycoaddcam import coadd_brz_cameras
+from prospect.coaddcam import coadd_brz_cameras
 from operator import itemgetter
 from itertools import groupby
 from astropy.modeling import fitting

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -811,8 +811,8 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
     return
 
 
-def ledger_overrides(overfn, obscon, colsub=None, mtldir=None, secondary=False,
-                     numoverride=999):
+def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
+                     mtldir=None, secondary=False, numoverride=999):
     """
     Create (or append to) a ledger to override the standard ledgers.
 
@@ -822,15 +822,19 @@ def ledger_overrides(overfn, obscon, colsub=None, mtldir=None, secondary=False,
         Full path to the filename that contains the override information.
         Must contain at least `RA`, `DEC`, `TARGETID` and be in a format
         that can be read automatically by astropy.table.Table.read().
-    colsub : :class:`dict`
-        If passed, each key should correspond to the name of a ledger
-        column and each value should correspond to the name of a column
-        in `overfn`. The ledger columns are overwritten by the
-        corresponding column in `overfn` (for the appropriate TARGETID).
     obscon : :class:`str`
         A string matching ONE obscondition in the desitarget bitmask yaml
         file (i.e. in `desitarget.targetmask.obsconditions`), e.g. "DARK"
         Used to construct the directory to find the Main Survey ledgers.
+    colsub : :class:`dict`, optional
+        If passed, each key should correspond to the name of a ledger
+        column and each value should correspond to the name of a column
+        in `overfn`. The ledger columns are overwritten by the
+        corresponding column in `overfn` (for the appropriate TARGETID).
+    valsub : :class:`dict`, optional
+        If passed, each key should correspond to the name of a ledger
+        column and each value should correspond to a single number. The
+        "value" will be overwritten into the "key" column of the ledger.
     mtldir : :class:`str`, optional, defaults to ``None``
         Full path to the directory that hosts the MTL ledgers and the MTL
         tile file. If ``None``, then look up the MTL directory from the
@@ -905,6 +909,10 @@ def ledger_overrides(overfn, obscon, colsub=None, mtldir=None, secondary=False,
         if colsub is not None:
             for col in colsub:
                 entry[col] = objs[ii][colsub[col]]
+        # ADM overwrite ledger entries, where requested.
+        if valsub is not None:
+            for col, val in valsub.items():
+                entry[col] = val
         # ADM finally write out the override ledger entry, after first
         # ADM checking if the file exists.
         if os.path.exists(outfn):

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -908,10 +908,18 @@ def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
         ii = objs["TARGETID"] == tid
         if colsub is not None:
             for col in colsub:
+                if col not in ledger.colnames:
+                    msg = "column {} from colsub not in ledger!!!".format(col)
+                    log.error(msg)
+                    raise ValueError(msg)
                 entry[col] = objs[ii][colsub[col]]
         # ADM overwrite ledger entries, where requested.
         if valsub is not None:
             for col, val in valsub.items():
+                if col not in ledger.colnames:
+                    msg = "column {} from valsub not in ledger!!!".format(col)
+                    log.error(msg)
+                    raise ValueError(msg)
                 entry[col] = val
         # ADM finally write out the override ledger entry, after first
         # ADM checking if the file exists.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -860,6 +860,8 @@ def process_overrides(ledgerfn):
       TARGET_STATE updated to OVERRIDE, the git VERSION updated, and the
       ZTILEID updated to -1.
     """
+    log.info("Processing override ledgers")
+
     # ADM read in the relevant entries in the override ledger.
     mtl = Table(io.read_mtl_ledger(ledgerfn))
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -823,18 +823,25 @@ def process_overrides(ledgerfn):
     Returns
     -------
     :class:`~astropy.table.Table`
-        MTL entries from override ledger with NUMOVERRIDE column removed
-        and TIMESTAMP updated to now.
+        MTL entries from override ledger with NUMOVERRIDE column removed,
+        TIMESTAMP updated to now, the second part of TARGET_STATE
+        updated to be OVERRIDE, and the git VERSION updated.
 
     Notes
     -----
     - Rewrites entries to the override ledger with NUMOVERRIDE updated to
-      be NUMOVERRIDE - 1 and TIMESTAMP updated to now.
+      be NUMOVERRIDE - 1, TIMESTAMP updated to now, and the second part
+      of TARGET_STATE updated to OVERRIDE, and the git VERSION updated.
     """
     # ADM read in the relevant entries in the override ledger.
     mtl = Table(io.read_mtl_ledger(ledgerfn))
+
+    # ADM update column entries to add to the override ledger.
     mtl["NUMOVERRIDE"] -= 1
     mtl["TIMESTAMP"] = get_utc_date(survey="main")
+    newts = ["{}|OVERRIDE".format(t.split("|")[0]) for t in mtl["TARGET_STATE"]]
+    mtl["TARGET_STATE"] = np.array(newts)
+    mtl["VERSION"] = dt_version
 
     # ADM append the updated mtl entry to the override ledger.
     f = open(ledgerfn, "a")

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -837,7 +837,7 @@ def process_overrides(ledgerfn):
     mtl["TIMESTAMP"] = get_utc_date(survey="main")
 
     # ADM append the updated mtl entry to the override ledger.
-    f = open(fn, "a")
+    f = open(ledgerfn, "a")
     ascii.write(mtl, f, format='no_header', formats=mtlformatdict)
     f.close()
 
@@ -1065,10 +1065,10 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
 
         # ADM if an override ledger exists, update it and recover its
         # ADM relevant MTL entries.
-        overmtl = process_overrides(overfn)
-
-        # ADM add any override entries TO THE END OF THE LEDGER.
-        mtlpix = vstack(mtlpix, overmtl)
+        if os.path.exists(overfn):
+            overmtl = process_overrides(overfn)
+            # ADM add any override entries TO THE END OF THE LEDGER.
+            mtlpix = vstack([mtlpix, overmtl])
 
         # ADM if we're working with .ecsv, simply append to the ledger.
         if ender == 'ecsv':

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -833,8 +833,9 @@ def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
         corresponding column in `overfn` (for the appropriate TARGETID).
     valsub : :class:`dict`, optional
         If passed, each key should correspond to the name of a ledger
-        column and each value should correspond to a single number. The
-        "value" will be overwritten into the "key" column of the ledger.
+        column and each value to a single number or string. The "value"
+        will be overwritten into the "key" column of the ledger. Takes
+        precedence over colsub.
     mtldir : :class:`str`, optional, defaults to ``None``
         Full path to the directory that hosts the MTL ledgers and the MTL
         tile file. If ``None``, then look up the MTL directory from the
@@ -844,8 +845,8 @@ def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
         for passed `obscon`.
     numoverride : :class:`int`, optional, defaults to 999
         The override ledger is read every time the MTL loop is run. This
-        is the number of times to override the standard results from the
-        MTL loop. Defaults to 1000, i.e. essentially "always override."
+        is the number of times to override the standard results in the
+        MTL loop. Defaults to 999, i.e. essentially "always override."
 
     Returns
     -------
@@ -927,12 +928,13 @@ def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
             f = open(outfn, "a")
             ascii.write(entry, f, format='no_header', formats=mtlformatdict)
             f.close()
+            checkfn = outfn
         else:
             _, checkfn = io.write_mtl(
                 mtldir, entry.as_array(), indir=infn, ecsv=True, survey="main",
                 obscon=obscon, nsidefile=nside, hpxlist=pix, scnd=secondary,
                 override=True)
-            log.info('Wrote target {} to {}'.format(tid, checkfn))
+        log.info('Wrote target {} from {} to {}'.format(tid, overfn, checkfn))
 
     return outdir
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1039,17 +1039,19 @@ def force_overrides(hpdirname, pixlist):
         The directory containing the ledgers that were updated.
     """
     # ADM find the general format for the ledger files in `hpdirname`.
-    fileform, oc = io.find_mtl_file_format_from_header(hpdirname)
+    fileform = io.find_mtl_file_format_from_header(hpdirname)
     # ADM this is the format for any associated override ledgers.
     overrideff = io.find_mtl_file_format_from_header(hpdirname, override=True)
 
-    # ADM before making updates, check suggested override ledgers exist.
+    # ADM before making updates, check all suggested ledgers exist.
     for pix in pixlist:
         overfn = overrideff.format(pix)
-        if not os.path.exists(overfn):
-            msg = "no override ledger at: ".format(overfn)
-            log.error(msg)
-            raise OSError
+        fn = fileform.format(pix)
+        for f in overfn, fn:
+            if not os.path.exists(f):
+                msg = "no ledger exists at: {}".format(f)
+                log.error(msg)
+                raise OSError
 
     for pix in pixlist:
         # ADM the correct filenames for this pixel number.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1000,7 +1000,7 @@ def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
         # ADM add the number of times to override to the ledger entry.
         entry["NUMOVERRIDE"] = numoverride
         # ADM add some other standardized column information.
-        mtl = standard_override_columns(mtl)
+        entry = standard_override_columns(entry)
 
         # ADM finally write out the override ledger entry, after first
         # ADM checking if the file exists.
@@ -1015,6 +1015,8 @@ def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
                 obscon=obscon, nsidefile=nside, hpxlist=pix, scnd=secondary,
                 override=True)
         log.info('Wrote target {} from {} to {}'.format(tid, overfn, checkfn))
+
+    log.info("Touched pixels {}".format(",".join([str(pix) for pix in pixnum])))
 
     return outdir
 


### PR DESCRIPTION
This PR creates the concept of an "override ledger" that can be used to override entries in the standard MTL ledgers. The functionality includes:

- An `add_to_override_ledgers` script that can be used to create (or add to) a set of HEALPixel-split override ledgers. 
  * The override ledgers are created using information from a user-supplied file.
  * That file needs to be readable as an astropy Table and include, at a minimum, `RA`, `DEC`, `TARGETID` and any columns needed to override MTL ledger entries.
  * It should also be possible to just change the override ledgers by-hand for bespoke applications.
- A`force_mtl_overrides` script that can instantly force information from the override ledgers into the MTL ledgers.
  * This is useful to prevent having to wait until the MTL loop is run again before targets are overrode.
  * This concept is still WIP. We may or may not actually use it.
- The glue to process overrides automatically as part of the MTL loop.
  * Some targets (e.g. high-z quasars) will need to override the results from the pipeline every time through the loop...
  * ...otherwise information from the pipeline could reassert dominance over the override information.
