### PR TITLE
Add secondaries to MTL ledgers without merging with primaries

### DIFF
--- a/bin/add_secondary_no_merge
+++ b/bin/add_secondary_no_merge
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+from desitarget.secondary import select_secondary, _get_scxdir
+from desitarget.brightmask import is_in_bright_mask, get_recent_mask_dir
+from desitarget import io
+from time import time
+time0 = time()
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Generate file of secondary-only targets from $SCND_DIR without merging with primaries')
+ap.add_argument("dest",
+                help="Output secondary-only targets directory (the file names \
+                are built on-the-fly from other inputs")
+ap.add_argument("--scnddir",
+                help="Base directory of secondary target files (e.g.          \
+                '/project/projectdirs/desi/target/secondary' at NERSC).       \
+                Defaults to SCND_DIR environment variable.")
+ap.add_argument('-i','--iteration', default="2", 
+                help="Iteration of Main Survey target selection to run. Files \
+                of secondary targets are looked up in $SCND_DIR/mainX         \
+                [defaults to 2 for 'main2']")
+ap.add_argument('-d','--drint', default="9", 
+                help="Relevant Legacy Surveys Data Release to use for writing \
+                output files [defaults to '9' for 'dr9']")
+ap.add_argument("--nomasking", action='store_true',
+                help="Masking occurs by default. If this is set, do NOT use a \
+                bright star mask to mask the secondary targets")
+ap.add_argument("--maskdir",
+                help="Name of the directory (or file) containing the bright   \
+                star mask (defaults to most recent directory in $MASK_DIR)",
+                default=None)
+
+ns = ap.parse_args()
+do_mask = not(ns.nomasking)
+
+# ADM construct the input/output directory.
+surv = 'main' + ns.iteration
+
+# ADM find the SCND_DIR environment variable, if it wasn't passed.
+scxdir = _get_scxdir(ns.scnddir, survey=surv)
+# ADM and augment the scxdir.
+scxdir = os.path.join(scxdir, surv)
+
+# ADM select secondary targets, specifying the nomerge option.
+scx = select_secondary(None, scxdir=scxdir, nomerge=True)
+
+# ADM set up a header dictionary to write to the output file.
+hdr = {"nomerge": True}
+
+# ADM if secondaries need masked, grab the mask directory and find which
+# ADM targets are masked. Also add the masking information to the header.
+mdcomp = None
+if do_mask:
+    # ADM grab the mask directory
+    maskdir = get_recent_mask_dir(ns.maskdir)
+    log.info("Masking secondaries using bright star masks in {}".format(maskdir))
+    # ADM read in the masks across the entire sky.
+    Mx = io.read_targets_in_quick(maskdir, shape='box',
+                                  radecbox=[0.0, 360.0, -90.0, 90.0])
+    log.info("Checking {} targets against {} masks".format(len(scx), len(Mx)))
+    in_mask, _ = is_in_bright_mask(scx, Mx, inonly=True)
+    # ADM the output in_mask is a list. We want the array it contains.
+    in_mask = in_mask[0]
+    log.info("{} targets are in bright star masks".format(np.sum(in_mask)))
+    # ADM a compact version of the maskdir name.
+    md = maskdir.split("/")
+    mdcomp = "/".join(md[md.index("masks"):])
+hdr["masked"] = do_mask
+hdr["maskdir"] = mdcomp
+
+# ADM write out the secondary targets, with bright-time
+# ADM and dark-time targets written separately.
+obscons = ["BRIGHT", "DARK"]
+for obscon in obscons:
+    ntargs, outfile = io.write_secondary(ns.dest, scx[~in_mask],
+                                         primhdr=hdr, scxdir=scxdir,
+                                         obscon=obscon, drint=ns.drint)
+    log.info('{} standalone secondary targets written to {}...t={:.1f}mins'
+             .format(ntargs, outfile, (time()-time0)/60.))

--- a/bin/add_secondary_no_merge
+++ b/bin/add_secondary_no_merge
@@ -20,11 +20,11 @@ ap.add_argument("--scnddir",
                 help="Base directory of secondary target files (e.g.          \
                 '/project/projectdirs/desi/target/secondary' at NERSC).       \
                 Defaults to SCND_DIR environment variable.")
-ap.add_argument('-i','--iteration', default="2", 
+ap.add_argument('-i','--iteration', default="2",
                 help="Iteration of Main Survey target selection to run. Files \
                 of secondary targets are looked up in $SCND_DIR/mainX         \
                 [defaults to 2 for 'main2']")
-ap.add_argument('-d','--drint', default="9", 
+ap.add_argument('-d','--drint', default="9",
                 help="Relevant Legacy Surveys Data Release to use for writing \
                 output files [defaults to '9' for 'dr9']")
 ap.add_argument("--nomasking", action='store_true',
@@ -77,8 +77,8 @@ hdr["maskdir"] = mdcomp
 # ADM and dark-time targets written separately.
 obscons = ["BRIGHT", "DARK"]
 for obscon in obscons:
-    ntargs, outfile = io.write_secondary(ns.dest, scx[~in_mask],
-                                         primhdr=hdr, scxdir=scxdir,
-                                         obscon=obscon, drint=ns.drint)
+    ntargs, outfile = io.write_secondary(
+        ns.dest, scx[~in_mask], primhdr=hdr, scxdir=scxdir,
+        obscon=obscon, drint=ns.drint, iteration=ns.iteration)
     log.info('{} standalone secondary targets written to {}...t={:.1f}mins'
              .format(ntargs, outfile, (time()-time0)/60.))

--- a/bin/make_initial_mtl_ledger
+++ b/bin/make_initial_mtl_ledger
@@ -41,6 +41,9 @@ ap.add_argument('--timestamp',
                 help="Override the TIMESTAMP created by make_mtl, and use this  \
                 time instead",
                 default=None)
+ap.add_argument('--append', action='store_true',
+                help="Append to existing ledgers, instead of writing new ones.  \
+                Particularly useful when adding new secondary targets")
 
 ns = ap.parse_args()
 
@@ -50,4 +53,4 @@ if pixlist is not None:
     pixlist = [int(pix) for pix in pixlist.split(',')]
 
 make_ledger(ns.targdir, ns.dest, pixlist=pixlist, obscon=ns.obscon,
-            numproc=ns.numproc, timestamp=ns.timestamp)
+            numproc=ns.numproc, timestamp=ns.timestamp, append=ns.append)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,16 @@ desitarget Change Log
 1.2.3 (unreleased)
 ------------------
 
+* Add secondaries to MTL ledgers without merging [`PR #764`_]:
+    * Fix a bug reading ecsv headers with :func:`io.read_ecsv_header()`:
+        * Now strictly extracts dictionaries after the meta keyword.
+    * Add new targeting bits for ``RR_LYRAE`` and ``MWS_FAINT_*``.
+    * Update :func:`secondary.select_secondary()` to ignore primaries:
+        * Every target is effectively treated as an ``OVERRIDE`` target.
+        * Adds a ``TARGETID`` based on ``main2`` to prevent duplicates.
+    * Add a new ``add_secondary_no_merge`` script.
+    * Functionality to append to ledgers in :func:`io.write_mtl()`.
+    * Similarly, add an append option to ``make_initial_ledger`` script.
 * Functionality to override MTL ledger entries [`PR #763`_]. Includes:
     * ``add_to_override_ledgers`` to create or expand override ledgers.
     * ``force_mtl_overrides`` to force overrides into the MTL ledgers.
@@ -14,6 +24,7 @@ desitarget Change Log
 
 .. _`PR #761`: https://github.com/desihub/desitarget/pull/761
 .. _`PR #763`: https://github.com/desihub/desitarget/pull/763
+.. _`PR #764`: https://github.com/desihub/desitarget/pull/764
 
 1.2.2 (2021-07-08)
 ------------------

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -129,45 +129,48 @@ mws_mask:
 scnd_mask:
     - [VETO,                    0, "Never observe, even if a primary target bit is set.",
         {obsconditions: DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18, filename: 'veto', flavor: 'SPARE', downsample: 1, updatemws: False}]
-    - [UDG,                     1, "See $SCND_DIR/docs/UDG.txt",                 {obsconditions: DARK,        filename: 'UDG',                 flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [FIRST_MALS,              2, "See $SCND_DIR/docs/FIRST_MALS.txt",          {obsconditions: DARK,        filename: 'FIRST_MALS',          flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [QSO_RED,                 5, "See $SCND_DIR/docs/QSO_RED.ipynb",           {obsconditions: DARK,        filename: 'QSO_RED',             flavor: 'QSO',   updatemws: False, downsample: 1}]
-#   - [MWS_DDOGIANTS,           9, "See $SCND_DIR",                              {obsconditions: BRIGHT,      filename: 'MWS_DDOGIANTS',       flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [MWS_CLUS_GAL_DEEP,      10, "See $SCND_DIR/docs/MWS_CLUS_GAL_DEEP.txt",   {obsconditions: DARK,        filename: 'MWS_CLUS_GAL_DEEP',   flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [LOW_MASS_AGN,           11, "See $SCND_DIR/docs/LOW_MASS_AGN.txt",        {obsconditions: DARK,        filename: 'LOW_MASS_AGN',        flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [FAINT_HPM,              12, "See $SCND_DIR/docs/FAINT_HPM.txt",           {obsconditions: DARK,        filename: 'FAINT_HPM',           flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [LOW_Z_TIER1,            15, "See $SCND_DIR/docs/LOW_Z_TIER1.ipynb",       {obsconditions: DARK,        filename: 'LOW_Z_TIER1',         flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [LOW_Z_TIER2,            16, "See $SCND_DIR/docs/LOW_Z_TIER2.ipynb",       {obsconditions: DARK,        filename: 'LOW_Z_TIER2',         flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [LOW_Z_TIER3,            17, "See $SCND_DIR/docs/LOW_Z_TIER3.ipynb",       {obsconditions: DARK,        filename: 'LOW_Z_TIER3',         flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [BHB,                    18, "See $SCND_DIR/docs/BHB.txt",                 {obsconditions: DARK,        filename: 'BHB',                 flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [SPCV,                   19, "See $SCND_DIR/docs/SPCV.txt",                {obsconditions: DARK,        filename: 'SPCV',                flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [DC3R2_GAMA,             20, "See $SCND_DIR/docs/DC3R2_GAMA.ipynb",        {obsconditions: DARK,        filename: 'DC3R2_GAMA',          flavor: 'SPARE', updatemws: False, downsample: 0.085}]
-    - [PSF_OUT_BRIGHT,         25, "See $SCND_DIR/docs/PSF_OUT_BRIGHT.txt",      {obsconditions: BRIGHT,      filename: 'PSF_OUT_BRIGHT',      flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [PSF_OUT_DARK,           26, "See $SCND_DIR/docs/PSF_OUT_DARK.txt",        {obsconditions: DARK,        filename: 'PSF_OUT_DARK',        flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [HPM_SOUM,               27, "See $SCND_DIR/docs/HPM_SOUM.txt",            {obsconditions: DARK,        filename: 'HPM_SOUM',            flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [SN_HOSTS,               28, "See $SCND_DIR/docs/SN_HOSTS.txt",            {obsconditions: DARK,        filename: 'SN_HOSTS',            flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [GAL_CLUS_BCG,           29, "See $SCND_DIR/docs/GAL_CLUS_BCG.txt",        {obsconditions: DARK,        filename: 'GAL_CLUS_BCG',        flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [GAL_CLUS_2ND,           30, "See $SCND_DIR/docs/GAL_CLUS_2ND.txt",        {obsconditions: DARK,        filename: 'GAL_CLUS_2ND',        flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [GAL_CLUS_SAT,           31, "See $SCND_DIR/docs/GAL_CLUS_SAT.txt",        {obsconditions: DARK,        filename: 'GAL_CLUS_SAT',        flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [STRONG_LENS,            34, "See $SCND_DIR/docs/STRONG_LENS.txt",         {obsconditions: DARK,        filename: 'STRONG_LENS',         flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [WISE_VAR_QSO,           35, "See $SCND_DIR/docs/WISE_VAR_QSO.txt",        {obsconditions: DARK,        filename: 'WISE_VAR_QSO',        flavor: 'QSO',   updatemws: False, downsample: 1}]
-    - [Z5_QSO,                 36, "See $SCND_DIR/docs/Z5_QSO.txt",              {obsconditions: DARK,        filename: 'Z5_QSO',              flavor: 'QSO',   updatemws: False, downsample: 1}]
-    - [MWS_MAIN_CLUSTER_SV,    38, "See $SCND_DIR/docs/MWS_MAIN_CLUSTER_SV.txt", {obsconditions: DARK|BRIGHT, filename: 'MWS_MAIN_CLUSTER_SV', flavor: 'SPARE', updatemws: True,  downsample: 1}]
-    - [BRIGHT_HPM,             40, "See $SCND_DIR/docs/BRIGHT_HPM.txt",          {obsconditions: BRIGHT,      filename: 'BRIGHT_HPM',          flavor: 'SPARE', updatemws: True,  downsample: 1}]
-    - [WD_BINARIES_BRIGHT,     41, "See $SCND_DIR/docs/WD_BINARIES_BRIGHT.txt",  {obsconditions: BRIGHT,      filename: 'WD_BINARIES_BRIGHT',  flavor: 'SPARE', updatemws: True,  downsample: 1}]
-    - [WD_BINARIES_DARK,       42, "See $SCND_DIR/docs/WD_BINARIES_DARK.txt",    {obsconditions: DARK,        filename: 'WD_BINARIES_DARK',    flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [PV_BRIGHT_HIGH,         43, "See $SCND_DIR/docs/PV_BRIGHT_HIGH.ipynb",    {obsconditions: BRIGHT,      filename: 'PV_BRIGHT_HIGH',      flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [PV_BRIGHT_MEDIUM,       44, "See $SCND_DIR/docs/PV_BRIGHT_MEDIUM.ipynb",  {obsconditions: BRIGHT,      filename: 'PV_BRIGHT_MEDIUM',    flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [PV_BRIGHT_LOW,          45, "See $SCND_DIR/docs/PV_BRIGHT_LOW.ipynb",     {obsconditions: BRIGHT,      filename: 'PV_BRIGHT_LOW',       flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [PV_DARK_HIGH,           46, "See $SCND_DIR/docs/PV_DARK_HIGH.ipynb",      {obsconditions: DARK,        filename: 'PV_DARK_HIGH',        flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [PV_DARK_MEDIUM,         47, "See $SCND_DIR/docs/PV_DARK_MEDIUM.ipynb",    {obsconditions: DARK,        filename: 'PV_DARK_MEDIUM',      flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [PV_DARK_LOW,            48, "See $SCND_DIR/docs/PV_DARK_LOW.ipynb",       {obsconditions: DARK,        filename: 'PV_DARK_LOW',         flavor: 'SPARE', updatemws: False, downsample: 1}]
-    - [GC_BRIGHT,              49, "See $SCND_DIR/docs/GC_BRIGHT.txt",           {obsconditions: BRIGHT,      filename: 'GC_BRIGHT',           flavor: 'SPARE', updatemws: True,  downsample: 1}]
-    - [GC_DARK,                50, "See $SCND_DIR/docs/GC_DARK.txt",             {obsconditions: DARK,        filename: 'GC_DARK',             flavor: 'SPARE', updatemws: True,  downsample: 1}]
-    - [DWF_BRIGHT_HI,          51, "See $SCND_DIR/docs/DWF_BRIGHT_HI.txt",       {obsconditions: BRIGHT,      filename: 'DWF_BRIGHT_HI',       flavor: 'SPARE', updatemws: True,  downsample: 1}]
-    - [DWF_BRIGHT_LO,          52, "See $SCND_DIR/docs/DWF_BRIGHT_LO.txt",       {obsconditions: BRIGHT,      filename: 'DWF_BRIGHT_LO',       flavor: 'SPARE', updatemws: True,  downsample: 1}]
-    - [DWF_DARK_HI,            53, "See $SCND_DIR/docs/DWF_DARK_HI.txt",         {obsconditions: DARK,        filename: 'DWF_DARK_HI',         flavor: 'SPARE', updatemws: True,  downsample: 1}]
-    - [DWF_DARK_LO,            54, "See $SCND_DIR/docs/DWF_DARK_LO.txt",         {obsconditions: DARK,        filename: 'DWF_DARK_LO',         flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [UDG,                     1, "See $SCND_DIR/docs/UDG.txt",                  {obsconditions: DARK,        filename: 'UDG',                 flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [FIRST_MALS,              2, "See $SCND_DIR/docs/FIRST_MALS.txt",           {obsconditions: DARK,        filename: 'FIRST_MALS',          flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [QSO_RED,                 5, "See $SCND_DIR/docs/QSO_RED.ipynb",            {obsconditions: DARK,        filename: 'QSO_RED',             flavor: 'QSO',   updatemws: False, downsample: 1}]
+#   - [MWS_DDOGIANTS,           9, "See $SCND_DIR",                               {obsconditions: BRIGHT,      filename: 'MWS_DDOGIANTS',       flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [MWS_CLUS_GAL_DEEP,      10, "See $SCND_DIR/docs/MWS_CLUS_GAL_DEEP.txt",    {obsconditions: DARK,        filename: 'MWS_CLUS_GAL_DEEP',   flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [LOW_MASS_AGN,           11, "See $SCND_DIR/docs/LOW_MASS_AGN.txt",         {obsconditions: DARK,        filename: 'LOW_MASS_AGN',        flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [FAINT_HPM,              12, "See $SCND_DIR/docs/FAINT_HPM.txt",            {obsconditions: DARK,        filename: 'FAINT_HPM',           flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [LOW_Z_TIER1,            15, "See $SCND_DIR/docs/LOW_Z_TIER1.ipynb",        {obsconditions: DARK,        filename: 'LOW_Z_TIER1',         flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [LOW_Z_TIER2,            16, "See $SCND_DIR/docs/LOW_Z_TIER2.ipynb",        {obsconditions: DARK,        filename: 'LOW_Z_TIER2',         flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [LOW_Z_TIER3,            17, "See $SCND_DIR/docs/LOW_Z_TIER3.ipynb",        {obsconditions: DARK,        filename: 'LOW_Z_TIER3',         flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [BHB,                    18, "See $SCND_DIR/docs/BHB.txt",                  {obsconditions: DARK,        filename: 'BHB',                 flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [SPCV,                   19, "See $SCND_DIR/docs/SPCV.txt",                 {obsconditions: DARK,        filename: 'SPCV',                flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [DC3R2_GAMA,             20, "See $SCND_DIR/docs/DC3R2_GAMA.ipynb",         {obsconditions: DARK,        filename: 'DC3R2_GAMA',          flavor: 'SPARE', updatemws: False, downsample: 0.085}]
+    - [PSF_OUT_BRIGHT,         25, "See $SCND_DIR/docs/PSF_OUT_BRIGHT.txt",       {obsconditions: BRIGHT,      filename: 'PSF_OUT_BRIGHT',      flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [PSF_OUT_DARK,           26, "See $SCND_DIR/docs/PSF_OUT_DARK.txt",         {obsconditions: DARK,        filename: 'PSF_OUT_DARK',        flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [HPM_SOUM,               27, "See $SCND_DIR/docs/HPM_SOUM.txt",             {obsconditions: DARK,        filename: 'HPM_SOUM',            flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [SN_HOSTS,               28, "See $SCND_DIR/docs/SN_HOSTS.txt",             {obsconditions: DARK,        filename: 'SN_HOSTS',            flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [GAL_CLUS_BCG,           29, "See $SCND_DIR/docs/GAL_CLUS_BCG.txt",         {obsconditions: DARK,        filename: 'GAL_CLUS_BCG',        flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [GAL_CLUS_2ND,           30, "See $SCND_DIR/docs/GAL_CLUS_2ND.txt",         {obsconditions: DARK,        filename: 'GAL_CLUS_2ND',        flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [GAL_CLUS_SAT,           31, "See $SCND_DIR/docs/GAL_CLUS_SAT.txt",         {obsconditions: DARK,        filename: 'GAL_CLUS_SAT',        flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [MWS_FAINT_BLUE,         32, "See $SCND_DIR/main2/docs/MWS_FAINT_BLUE.txt", {obsconditions: BRIGHT,      filename: 'MWS_FAINT_BLUE',      flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [MWS_FAINT_RED,          33, "See $SCND_DIR/main2/docs/MWS_FAINT_RED.txt",  {obsconditions: BRIGHT,      filename: 'MWS_FAINT_RED',       flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [STRONG_LENS,            34, "See $SCND_DIR/docs/STRONG_LENS.txt",          {obsconditions: DARK,        filename: 'STRONG_LENS',         flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [WISE_VAR_QSO,           35, "See $SCND_DIR/docs/WISE_VAR_QSO.txt",         {obsconditions: DARK,        filename: 'WISE_VAR_QSO',        flavor: 'QSO',   updatemws: False, downsample: 1}]
+    - [Z5_QSO,                 36, "See $SCND_DIR/docs/Z5_QSO.txt",               {obsconditions: DARK,        filename: 'Z5_QSO',              flavor: 'QSO',   updatemws: False, downsample: 1}]
+    - [MWS_RR_LYRAE,           37, "See $SCND_DIR/main2/docs/MWS_RR_LYRAE.txt",   {obsconditions: DARK,        filename: 'MWS_RR_LYRAE',        flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [MWS_MAIN_CLUSTER_SV,    38, "See $SCND_DIR/docs/MWS_MAIN_CLUSTER_SV.txt",  {obsconditions: DARK|BRIGHT, filename: 'MWS_MAIN_CLUSTER_SV', flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [BRIGHT_HPM,             40, "See $SCND_DIR/docs/BRIGHT_HPM.txt",           {obsconditions: BRIGHT,      filename: 'BRIGHT_HPM',          flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [WD_BINARIES_BRIGHT,     41, "See $SCND_DIR/docs/WD_BINARIES_BRIGHT.txt",   {obsconditions: BRIGHT,      filename: 'WD_BINARIES_BRIGHT',  flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [WD_BINARIES_DARK,       42, "See $SCND_DIR/docs/WD_BINARIES_DARK.txt",     {obsconditions: DARK,        filename: 'WD_BINARIES_DARK',    flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [PV_BRIGHT_HIGH,         43, "See $SCND_DIR/docs/PV_BRIGHT_HIGH.ipynb",     {obsconditions: BRIGHT,      filename: 'PV_BRIGHT_HIGH',      flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [PV_BRIGHT_MEDIUM,       44, "See $SCND_DIR/docs/PV_BRIGHT_MEDIUM.ipynb",   {obsconditions: BRIGHT,      filename: 'PV_BRIGHT_MEDIUM',    flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [PV_BRIGHT_LOW,          45, "See $SCND_DIR/docs/PV_BRIGHT_LOW.ipynb",      {obsconditions: BRIGHT,      filename: 'PV_BRIGHT_LOW',       flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [PV_DARK_HIGH,           46, "See $SCND_DIR/docs/PV_DARK_HIGH.ipynb",       {obsconditions: DARK,        filename: 'PV_DARK_HIGH',        flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [PV_DARK_MEDIUM,         47, "See $SCND_DIR/docs/PV_DARK_MEDIUM.ipynb",     {obsconditions: DARK,        filename: 'PV_DARK_MEDIUM',      flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [PV_DARK_LOW,            48, "See $SCND_DIR/docs/PV_DARK_LOW.ipynb",        {obsconditions: DARK,        filename: 'PV_DARK_LOW',         flavor: 'SPARE', updatemws: False, downsample: 1}]
+    - [GC_BRIGHT,              49, "See $SCND_DIR/docs/GC_BRIGHT.txt",            {obsconditions: BRIGHT,      filename: 'GC_BRIGHT',           flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [GC_DARK,                50, "See $SCND_DIR/docs/GC_DARK.txt",              {obsconditions: DARK,        filename: 'GC_DARK',             flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [DWF_BRIGHT_HI,          51, "See $SCND_DIR/docs/DWF_BRIGHT_HI.txt",        {obsconditions: BRIGHT,      filename: 'DWF_BRIGHT_HI',       flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [DWF_BRIGHT_LO,          52, "See $SCND_DIR/docs/DWF_BRIGHT_LO.txt",        {obsconditions: BRIGHT,      filename: 'DWF_BRIGHT_LO',       flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [DWF_DARK_HI,            53, "See $SCND_DIR/docs/DWF_DARK_HI.txt",          {obsconditions: DARK,        filename: 'DWF_DARK_HI',         flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [DWF_DARK_LO,            54, "See $SCND_DIR/docs/DWF_DARK_LO.txt",          {obsconditions: DARK,        filename: 'DWF_DARK_LO',         flavor: 'SPARE', updatemws: True,  downsample: 1}]
 
 
 # ADM reserve 59-62 in scnd_mask for Targets of Opportunity in both SV and the Main Survey.
@@ -378,9 +381,12 @@ priorities:
         GAL_CLUS_BCG:           {UNOBS: 1025, MORE_ZGOOD: 1015, MORE_ZWARN: 1015, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         GAL_CLUS_2ND:           {UNOBS: 1020, MORE_ZGOOD: 2,    MORE_ZWARN: 2,    DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         GAL_CLUS_SAT:           {UNOBS: 1000, MORE_ZGOOD: 2,    MORE_ZWARN: 2,    DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_FAINT_BLUE:         {UNOBS: 50,   MORE_ZGOOD: 50,   MORE_ZWARN: 50,   DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        MWS_FAINT_RED:          SAME_AS_MWS_FAINT_BLUE
         STRONG_LENS:            {UNOBS: 4000, MORE_ZGOOD: 2,    MORE_ZWARN: 2,    DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         WISE_VAR_QSO:           SAME_AS_QSO_RED
         Z5_QSO:                 SAME_AS_QSO_RED
+        MWS_RR_LYRAE:           {UNOBS: 1950, MORE_ZGOOD: 2,    MORE_ZWARN: 2,    DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         MWS_MAIN_CLUSTER_SV:    {UNOBS: 1450, MORE_ZGOOD: 2,    MORE_ZWARN: 2,    DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         BRIGHT_HPM:             SAME_AS_STRONG_LENS
         WD_BINARIES_BRIGHT:     {UNOBS: 1998, MORE_ZGOOD: 2,    MORE_ZWARN: 2,    DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
@@ -523,9 +529,12 @@ numobs:
         GAL_CLUS_BCG:           2
         GAL_CLUS_2ND:           1
         GAL_CLUS_SAT:           1
+        MWS_FAINT_BLUE:         2
+        MWS_FAINT_RED:          2
         STRONG_LENS:            1
         WISE_VAR_QSO:           4
         Z5_QSO:                 4
+        MWS_RR_LYRAE:           1
         MWS_MAIN_CLUSTER_SV:    1
         BRIGHT_HPM:             1
         WD_BINARIES_BRIGHT:     1

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -154,7 +154,7 @@ scnd_mask:
     - [STRONG_LENS,            34, "See $SCND_DIR/docs/STRONG_LENS.txt",          {obsconditions: DARK,        filename: 'STRONG_LENS',         flavor: 'SPARE', updatemws: False, downsample: 1}]
     - [WISE_VAR_QSO,           35, "See $SCND_DIR/docs/WISE_VAR_QSO.txt",         {obsconditions: DARK,        filename: 'WISE_VAR_QSO',        flavor: 'QSO',   updatemws: False, downsample: 1}]
     - [Z5_QSO,                 36, "See $SCND_DIR/docs/Z5_QSO.txt",               {obsconditions: DARK,        filename: 'Z5_QSO',              flavor: 'QSO',   updatemws: False, downsample: 1}]
-    - [MWS_RR_LYRAE,           37, "See $SCND_DIR/main2/docs/MWS_RR_LYRAE.txt",   {obsconditions: DARK,        filename: 'MWS_RR_LYRAE',        flavor: 'SPARE', updatemws: True,  downsample: 1}]
+    - [MWS_RR_LYRAE,           37, "See $SCND_DIR/main2/docs/MWS_RR_LYRAE.txt",   {obsconditions: DARK|BRIGHT, filename: 'MWS_RR_LYRAE',        flavor: 'SPARE', updatemws: True,  downsample: 1}]
     - [MWS_MAIN_CLUSTER_SV,    38, "See $SCND_DIR/docs/MWS_MAIN_CLUSTER_SV.txt",  {obsconditions: DARK|BRIGHT, filename: 'MWS_MAIN_CLUSTER_SV', flavor: 'SPARE', updatemws: True,  downsample: 1}]
     - [BRIGHT_HPM,             40, "See $SCND_DIR/docs/BRIGHT_HPM.txt",           {obsconditions: BRIGHT,      filename: 'BRIGHT_HPM',          flavor: 'SPARE', updatemws: True,  downsample: 1}]
     - [WD_BINARIES_BRIGHT,     41, "See $SCND_DIR/docs/WD_BINARIES_BRIGHT.txt",   {obsconditions: BRIGHT,      filename: 'WD_BINARIES_BRIGHT',  flavor: 'SPARE', updatemws: True,  downsample: 1}]

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2811,7 +2811,8 @@ def read_ecsv_header(filename):
                 hdr += line.rstrip("\n").lstrip("#")
 
     # ADM extract the meta keyword dictionary or dictionaries.
-    alldicts = re.findall("({.*?})", hdr)
+    # ADM and possibly anything else in the header after "meta".
+    alldicts = re.findall("({.*?})", hdr.split("meta")[-1])
     # ADM loop in case header info comprises several dictionaries.
     hdr = {}
     for d in alldicts:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -875,17 +875,25 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None, scnd=False,
     data = data[np.argsort(data["TARGETID"])]
 
     # ADM if append was sent, check if the file exists. If it doesn't,
-    # ADM write it, if it does, append to it.
-    if append and os.path.isfile(fn):
-        if not ecsv:
-            msg = "Appending is only currently coded up for .ecsv ledgers"
+    # ADM write it, if it does, append to it. Be particularly careful to
+    # ADM not overwrite files if append wasn't sent!
+    if os.path.isfile(fn):
+        if append:
+            if not ecsv:
+                msg = "Appending is only currently coded up for .ecsv ledgers"
+                log.error(msg)
+                raise IOError(msg)
+            # ADM append the data to the existing mtl ledger.
+            f = open(fn, "a")
+            from desitarget.mtl import mtlformatdict
+            ascii.write(data, f, format='no_header', formats=mtlformatdict)
+            f.close()
+        else:
+            msg = "Cowardly refusal to overwrite {} ".format(fn)
+            msg += "(did you mean to send append? If so, check "
+            msg += "you haven't created any unexpected ledgers)!"
             log.error(msg)
             raise IOError(msg)
-        # ADM append the data to the existing mtl ledger.
-        f = open(fn, "a")
-        from desitarget.mtl import mtlformatdict
-        ascii.write(data, f, format='no_header', formats=mtlformatdict)
-        f.close()
     else:
         write_with_units(fn, data, extname='MTL', header=hdrdict, ecsv=ecsv)
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -662,10 +662,11 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
             nt, fn = io.write_mtl(
                 outdirname, mtl[inpix].as_array(), indir=indirname, ecsv=ecsv,
                 survey=survey, obscon=obscon, nsidefile=nside, hpxlist=pix,
-                scnd=scnd, extra=hdr)
+                scnd=scnd, extra=hdr, append=append)
             if verbose:
-                log.info('{} targets written to {}...t={:.1f}s'.format(
-                    nt, fn, time()-t0))
+                writ = int(append)*"appended" + int(not(append))*"written"
+                log.info('{} targets {} to {}...t={:.1f}s'.format(
+                    nt, writ, fn, time()-t0))
 
     return
 
@@ -794,13 +795,15 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
     # ADM this is just to count pixels in _update_status.
     npix = np.ones((), dtype='i8')
     t0 = time()
+    # ADM this is just to log whether we're in write or append mode.
+    writ = int(append)*"Appending" + int(not(append))*"Writing"
 
     def _update_status(result):
         """wrap key reduction operation on the main parallel process"""
         if npix % 2 == 0 and npix > 0:
             rate = (time() - t0) / npix
-            log.info('{}/{} HEALPixels; {:.1f} secs/pixel...t = {:.1f} mins'.
-                     format(npix, npixels, rate, (time()-t0)/60.))
+            log.info('{} {}/{} HEALPixels; {:.1f} secs/pixel...t = {:.1f} mins'.
+                     format(writ, npix, npixels, rate, (time()-t0)/60.))
         npix[...] += 1
         return result
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -593,7 +593,7 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
 
 def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
                       indirname=None, verbose=True, scnd=False,
-                      timestamp=None):
+                      timestamp=None, append=False):
     """
     Make an initial MTL ledger file for targets in a set of HEALPixels.
 
@@ -622,6 +622,10 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
         If ``True`` then this is a ledger of secondary targets.
     timestamp : :class:`str`, optional
         A timestamp to use in place of that assigned by `make_mtl`.
+    append : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then append to any existing ledgers rather than
+        creating new ones. In this mode, if a ledger exists it will be
+        appended to and if it doesn't exist it will be created.
 
     Returns
     -------
@@ -667,7 +671,7 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
 
 
 def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
-                numproc=1, timestamp=None):
+                numproc=1, timestamp=None, append=False):
     """
     Make initial MTL ledger files for HEALPixels, in parallel.
 
@@ -682,7 +686,7 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
         Output directory to which to write the MTL (the file name is
         constructed on the fly).
     pixlist : :class:`list` or `int`, defaults to ``None``
-        (Nested) HEALPixels at which to write the MTLs at the default
+        (Nested) HEALPixels for which to write the MTLs at the default
         `nside` (which is `_get_mtl_nside()`). Defaults to ``None``,
         which runs all of the pixels at `_get_mtl_nside()`.
     obscon : :class:`str`, optional, defaults to "DARK"
@@ -694,6 +698,10 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
         Number of processes to parallelize across.
     timestamp : :class:`str`, optional
         A timestamp to use in place of that assigned by `make_mtl`.
+    append : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then append to any existing ledgers rather than
+        creating new ones. In this mode, if a ledger exists it will be
+        appended to and if it doesn't exist it will be created.
 
     Returns
     -------
@@ -781,7 +789,7 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
         return make_ledger_in_hp(
             targs, outdirname, mtlnside, pix, obscon=obscon,
             indirname=hpdirname, verbose=False, scnd=scnd,
-            timestamp=timestamp)
+            timestamp=timestamp, append=append)
 
     # ADM this is just to count pixels in _update_status.
     npix = np.ones((), dtype='i8')


### PR DESCRIPTION
This PR sets up the infrastructure for (occasionally) adding new secondary targets without merging with primary targets. A guiding principle is that the new secondaries will always have a different `TARGETID` to prevent their behavior ever affecting a primary (and vice-versa). The PR includes:

- New targeting bits for the ``RR_LYRAE`` and ``MWS_FAINT_*`` secondary targets.
- Updates to `secondary.select_secondary()` to completely ignore primary targets, if requested.
  * Every target is then effectively treated as an `OVERRIDE` target.
  * A new value of `TARGETID` is created based on writing secondaries to a `main2` directory.
    - This `TARGETID` can never duplicate a previously used primary or secondary `TARGETID`.
- A top-line `add_secondary_no_merge` script to run `secondary.select_secondary()` without considering primaries.
- Functionality to append to ledgers instead of writing new ones in `io.write_mtl()`.
  * With an associated `append` option in the `make_initial_ledger` script.

Also, along for the ride, I fixed a minor bug when reading headers of `.ecsv` files with the function `io.read_ecsv_header()`. That function was reading information about columns prior to the official header information, now it strictly extracts only dictionaries after the `meta` keyword.

