### PR TITLE
Change the location of the (zdone) tile file for SV

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 1.3.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Also use the ops/tiles-specstatus.ecsv tile file for SV [`PR #765`_].
+
+.. _`PR #765`: https://github.com/desihub/desitarget/pull/765
 
 1.3.0 (2021-09-20)
 ------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1414,9 +1414,8 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey):
     ztilefn = get_ztile_file_name(survey=survey)
     # ADM directory structure used to be different for sv and main.
     if survey[:2] == 'sv' or survey == 'main':
-         
-        if os.path.basename(os.path.dirname(mtltilefn)) == 'mtl':
-            opsdir = os.path.join(os.path.dirname(os.path.dirname(mtltilefn)), 'ops')
+        if os.path.dirname(mtltilefn)[-3:] == 'mtl':
+            opsdir = os.path.join(os.path.dirname(mtltilefn)[:-3], 'ops')
         else:
             opsdir = os.path.dirname(mtltilefn)
         ztilefn = os.path.join(opsdir, ztilefn)
@@ -1747,7 +1746,10 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     ztilefn = get_ztile_file_name(survey=survey)
     # ADM directory structure used to be different for sv and main.
     if survey[:2] == 'sv' or survey == 'main':
-        opsdir = os.path.dirname(mtltilefn).replace("mtl", "ops")
+        if os.path.dirname(mtltilefn)[-3:] == 'mtl':
+            opsdir = os.path.join(os.path.dirname(mtltilefn)[:-3], 'ops')
+        else:
+            opsdir = os.path.dirname(mtltilefn)
         ztilefn = os.path.join(opsdir, ztilefn)
 
     # ADM stop if there are no tiles to process.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1414,8 +1414,15 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey):
     ztilefn = get_ztile_file_name(survey=survey)
     # ADM directory structure used to be different for sv and main.
     if survey[:2] == 'sv' or survey == 'main':
-        opsdir = os.path.dirname(mtltilefn).replace("mtl", "ops")
+         
+        if os.path.basename(os.path.dirname(mtltilefn)) == 'mtl':
+            opsdir = os.path.join(os.path.dirname(os.path.dirname(mtltilefn)), 'ops')
+        else:
+            opsdir = os.path.dirname(mtltilefn)
         ztilefn = os.path.join(opsdir, ztilefn)
+        print(mtltilefn)
+        print(opsdir)
+        print(ztilefn)
     else:
         msg = "Allowed 'survey' inputs are sv(X) or main, not {}".format(survey)
         log.critical(msg)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -265,9 +265,8 @@ def get_ztile_file_name(survey='main'):
     :class:`str`
         The name of the ZTILE file.
     """
-    if survey[:2] == 'sv':
-        fn = "tiles.csv"
-    elif survey == 'main':
+    # ADM tile file name used to be different for sv and main.
+    if survey[:2] == 'sv' or survey == 'main':
         fn = "tiles-specstatus.ecsv"
     else:
         msg = "Allowed 'survey' inputs are sv(X) or main, not {}".format(survey)
@@ -1413,10 +1412,8 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey):
     """
     # ADM read in the ZTILE file.
     ztilefn = get_ztile_file_name(survey=survey)
-    # ADM directory structure is different for SV and the Main Survey.
-    if survey[:2] == 'sv':
-        ztilefn = os.path.join(zcatdir, ztilefn)
-    elif survey == 'main':
+    # ADM directory structure used to be different for sv and main.
+    if survey[:2] == 'sv' or survey == 'main':
         opsdir = os.path.dirname(mtltilefn).replace("mtl", "ops")
         ztilefn = os.path.join(opsdir, ztilefn)
     else:
@@ -1744,10 +1741,8 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
 
     # ADM contruct the ZTILE filename, for logging purposes.
     ztilefn = get_ztile_file_name(survey=survey)
-    # ADM directory structure is different for SV and the Main Survey.
-    if survey[:2] == 'sv':
-        ztilefn = os.path.join(zcatdir, ztilefn)
-    elif survey == 'main':
+    # ADM directory structure used to be different for sv and main.
+    if survey[:2] == 'sv' or survey == 'main':
         opsdir = os.path.dirname(mtltilefn).replace("mtl", "ops")
         ztilefn = os.path.join(opsdir, ztilefn)
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1420,9 +1420,6 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey):
         else:
             opsdir = os.path.dirname(mtltilefn)
         ztilefn = os.path.join(opsdir, ztilefn)
-        print(mtltilefn)
-        print(opsdir)
-        print(ztilefn)
     else:
         msg = "Allowed 'survey' inputs are sv(X) or main, not {}".format(survey)
         log.critical(msg)


### PR DESCRIPTION
This PR updates the MTL loop to use `surveyops/ops/tiles-specstatus.ecsv` as the location of the tile file that contains `zdone` information for SV. 

We'd already updated the location of this tile file for the Main Survey, and were searching for a legacy copy of `tiles.csv` for SV. With this PR, we should no longer need to rely on `tiles.csv` at all.