### PR TITLE
No override sv3

### DIFF
--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2910,35 +2910,27 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False, override=False):
     # ADM detect whether we're working with the override ledgers.
     try:
         override = bool(read_keyword_from_mtl_header(hpdirname, "OVERRIDE"))
-        print('hpdir from which OVERRIDE was taken')
-        print(hpdirname)
+        
     except KeyError:
         pass
-    print('orig override keyword')
-    print(override)
-    #override = False
+    
     from desitarget.mtl import get_mtl_ledger_format
     ender = get_mtl_ledger_format()
-    print('ender')
-    print(ender)
+    
     # ADM construct the full directory path.
     hugefn = find_target_files(hpdirname, flavor="mtl", hp="{}", survey=surv,
                                ender=ender, obscon=oc, override=override)
-    print('hugefn')
-    print(hugefn)
+    
     # ADM return the filename.
     fileform = os.path.join(hpdirname, os.path.basename(hugefn))
-    print('fileform')
-    print(fileform)
+    
     if override:
         # ADM be forgiving if the override directory itself was passed.
         fileform = os.path.join(hpdirname, "override", os.path.basename(hugefn))
-        print('more fileform')
-        print(fileform)
+        
         if "override" in hpdirname:
             fileform = os.path.join(hpdirname, os.path.basename(hugefn))
-            print('even more fileform')
-            print(fileform)
+            
 
     if returnoc:
         return fileform, oc

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -804,8 +804,14 @@ def write_mtl(mtldir, data, indir=None, survey="main", obscon=None, scnd=False,
         The name of the file to which targets were written.
     """
     # ADM begin to construct a dictionary of header keys and values.
-    keys = ["INDIR", "SURVEY", "OBSCON", "SCND", "OVERRIDE"]
-    vals = [indir, survey, obscon, scnd, override]
+    if ('sv' in survey.lower()) or ('cmx' in survey.lower()):
+        keys = ["INDIR", "SURVEY", "OBSCON", "SCND"]
+        vals = [indir, survey, obscon, scnd]
+    elif survey.lower() == 'main':
+        keys = ["INDIR", "SURVEY", "OBSCON", "SCND", "OVERRIDE"]
+        vals = [indir, survey, obscon, scnd, override]
+    else:
+        raise ValueError('survey must be cmx svN or main')
 
     # ADM hpxlist and nsidefile need to be passed together.
     if hpxlist is not None or nsidefile is not None:
@@ -2904,23 +2910,35 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False, override=False):
     # ADM detect whether we're working with the override ledgers.
     try:
         override = bool(read_keyword_from_mtl_header(hpdirname, "OVERRIDE"))
+        print('hpdir from which OVERRIDE was taken')
+        print(hpdirname)
     except KeyError:
         pass
-
+    print('orig override keyword')
+    print(override)
+    #override = False
     from desitarget.mtl import get_mtl_ledger_format
     ender = get_mtl_ledger_format()
-
+    print('ender')
+    print(ender)
     # ADM construct the full directory path.
     hugefn = find_target_files(hpdirname, flavor="mtl", hp="{}", survey=surv,
                                ender=ender, obscon=oc, override=override)
-
+    print('hugefn')
+    print(hugefn)
     # ADM return the filename.
     fileform = os.path.join(hpdirname, os.path.basename(hugefn))
+    print('fileform')
+    print(fileform)
     if override:
         # ADM be forgiving if the override directory itself was passed.
         fileform = os.path.join(hpdirname, "override", os.path.basename(hugefn))
+        print('more fileform')
+        print(fileform)
         if "override" in hpdirname:
             fileform = os.path.join(hpdirname, os.path.basename(hugefn))
+            print('even more fileform')
+            print(fileform)
 
     if returnoc:
         return fileform, oc

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2910,27 +2910,20 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False, override=False):
     # ADM detect whether we're working with the override ledgers.
     try:
         override = bool(read_keyword_from_mtl_header(hpdirname, "OVERRIDE"))
-        
     except KeyError:
         pass
-    
     from desitarget.mtl import get_mtl_ledger_format
     ender = get_mtl_ledger_format()
-    
     # ADM construct the full directory path.
     hugefn = find_target_files(hpdirname, flavor="mtl", hp="{}", survey=surv,
                                ender=ender, obscon=oc, override=override)
-    
     # ADM return the filename.
     fileform = os.path.join(hpdirname, os.path.basename(hugefn))
-    
     if override:
         # ADM be forgiving if the override directory itself was passed.
         fileform = os.path.join(hpdirname, "override", os.path.basename(hugefn))
-        
         if "override" in hpdirname:
-            fileform = os.path.join(hpdirname, os.path.basename(hugefn))
-            
+            fileform = os.path.join(hpdirname, os.path.basename(hugefn))     
 
     if returnoc:
         return fileform, oc

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2923,7 +2923,7 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False, override=False):
         # ADM be forgiving if the override directory itself was passed.
         fileform = os.path.join(hpdirname, "override", os.path.basename(hugefn))
         if "override" in hpdirname:
-            fileform = os.path.join(hpdirname, os.path.basename(hugefn))     
+            fileform = os.path.join(hpdirname, os.path.basename(hugefn))
 
     if returnoc:
         return fileform, oc

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1054,7 +1054,9 @@ def force_overrides(hpdirname, pixlist):
     fileform = io.find_mtl_file_format_from_header(hpdirname)
     # ADM this is the format for any associated override ledgers.
     overrideff = io.find_mtl_file_format_from_header(hpdirname, override=True)
-
+    print('overrideff')
+    print(hpdirname)
+    print(overrideff)
     # ADM before making updates, check all suggested ledgers exist.
     for pix in pixlist:
         overfn = overrideff.format(pix)
@@ -1081,8 +1083,7 @@ def force_overrides(hpdirname, pixlist):
     return hpdirname
 
 
-def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
-                  numobs_from_ledger=False):
+def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",numobs_from_ledger=False):
     """
     Update relevant HEALPixel-split ledger files for some targets.
 
@@ -1172,6 +1173,8 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
 
         # ADM if an override ledger exists, update it and recover its
         # ADM relevant MTL entries.
+        #print('overfn')
+        #print(overfn)
         if os.path.exists(overfn):
             overmtl = process_overrides(overfn)
             # ADM add any override entries TO THE END OF THE LEDGER.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1171,7 +1171,6 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",numobs_from_ledge
 
         # ADM if an override ledger exists, update it and recover its
         # ADM relevant MTL entries.
-        
         if os.path.exists(overfn):
             overmtl = process_overrides(overfn)
             # ADM add any override entries TO THE END OF THE LEDGER.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1054,9 +1054,7 @@ def force_overrides(hpdirname, pixlist):
     fileform = io.find_mtl_file_format_from_header(hpdirname)
     # ADM this is the format for any associated override ledgers.
     overrideff = io.find_mtl_file_format_from_header(hpdirname, override=True)
-    print('overrideff')
-    print(hpdirname)
-    print(overrideff)
+
     # ADM before making updates, check all suggested ledgers exist.
     for pix in pixlist:
         overfn = overrideff.format(pix)
@@ -1173,8 +1171,7 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",numobs_from_ledge
 
         # ADM if an override ledger exists, update it and recover its
         # ADM relevant MTL entries.
-        #print('overfn')
-        #print(overfn)
+        
         if os.path.exists(overfn):
             overmtl = process_overrides(overfn)
             # ADM add any override entries TO THE END OF THE LEDGER.


### PR DESCRIPTION
Stops adding the OVERRIDE keyword to the meta dictionary for the SV3(and 2 and 1) and CMX MTLs since the presence of that keyword causes problems downstream in the alternate MTL code.

I would prefer to wait on merging this pull request until I have confirmed that it doesn't create undesired effects in the final alternate MTL bitweight products, but I can confirm that it does have the desired effect in the initial and intermediate stages of the alternate MTL pipeline. 