### PR TITLE
Find and remove MTL-processed tiles that don't overlap future tiles

### DIFF
--- a/bin/purge_mtl
+++ b/bin/purge_mtl
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+from desitarget.mtl import find_non_overlap_tiles, purge_tiles
+from desitarget.mtl import get_mtl_tile_file_name, get_mtl_dir
+from desitarget.io import find_target_files
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Determine which tiles are not overlapped by future tiles, and remove those tiles from all MTL files')
+ap.add_argument("obscon",
+                help="String matching ONE obscondition in the bitmask yaml file \
+                (e.g. 'BRIGHT'). Controls priorities when merging targets,      \
+                which tiles to process, etc.")
+ap.add_argument('--purge', action='store_true',
+                help="By default, for safety, this code only prints the tiles" +
+                "that WOULD be purged. Pass this to ACTUALLY purge the tiles.")
+ap.add_argument('--mtldir',
+                help="Full path to the directory that hosts the MTL ledgers.    \
+                Default is to use the $MTL_DIR environment variable.",
+                default=None)
+ap.add_argument("-i", "--isodate",
+                help="A date in ISO format, such as returned mtl.get_utc_date().\
+                Only tiles processed AFTER OR EXACTLY ON `isodate` are used to  \
+                construct the list of non-overlapping tiles. If isodate isn't   \
+                passed, then no date restrictions are applied.",
+                default=None)
+ap.add_argument("-nosec", "--nosecondary", action='store_true',
+                help="By default, this code always purges secondary files in    \
+                addition to the primary files so they keep pace. Pass this if   \
+                there are no secondaries to process.")
+
+ns = ap.parse_args()
+
+mtldir = get_mtl_dir(ns.mtldir)
+log.info("MTL directory is {}".format(mtldir))
+
+# ADM first find the tiles to be purged.
+tiles = find_non_overlap_tiles(ns.obscon, mtldir=mtldir, isodate=ns.isodate)
+
+log.info("The following {} tiles will be purged:".format(len(tiles)))
+# ADM pprint(nlines) allows n lines of a table to be displayed.
+log.info(tiles.pprint(len(tiles)+2))
+
+scndstates = [False]
+# ADM for programs that actually have secondary ledgers (BRIGHT/DARK).
+if ns.obscon in ["BRIGHT", "DARK"]:
+    if not(ns.nosecondary):
+        scndstates = [True, False]
+
+if ns.purge:
+    for secondary in scndstates:
+        # ADM recover some useful file names for logging...
+        mtltilefn = os.path.join(mtldir, get_mtl_tile_file_name(
+            secondary=secondary))
+        resolve = True
+        if secondary:
+            resolve=None
+        ledgerdir = find_target_files(mtldir, flavor="mtl", resolve=resolve,
+                                      obscon=obscon)
+
+        # ADM ...now actually purge the tiles.
+        gonetargs, gonetiles = purge_tiles(tiles, ns.obscon, mtldir=mtldir,
+                                           secondary=secondary)
+      
+        log.info("Removed {} targets from ledgers in {}".format(
+            len(gonetargs), ledgerdir))
+        log.info("Remover {} tiles from MTL tile file ({})".format(
+            len(gonetiles), mtltilefn))
+else:
+    log.info("pass --purge to actually remove them")

--- a/bin/purge_mtl
+++ b/bin/purge_mtl
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 from desitarget.mtl import find_non_overlap_tiles, purge_tiles
 from desitarget.mtl import get_mtl_tile_file_name, get_mtl_dir
 from desitarget.io import find_target_files
@@ -40,7 +41,7 @@ tiles = find_non_overlap_tiles(ns.obscon, mtldir=mtldir, isodate=ns.isodate)
 
 log.info("The following {} tiles will be purged:".format(len(tiles)))
 # ADM pprint(nlines) allows n lines of a table to be displayed.
-log.info(tiles.pprint(len(tiles)+2))
+tiles.pprint(len(tiles)+2)
 
 scndstates = [False]
 # ADM for programs that actually have secondary ledgers (BRIGHT/DARK).
@@ -57,15 +58,15 @@ if ns.purge:
         if secondary:
             resolve=None
         ledgerdir = find_target_files(mtldir, flavor="mtl", resolve=resolve,
-                                      obscon=obscon)
+                                      obscon=ns.obscon)
 
         # ADM ...now actually purge the tiles.
         gonetargs, gonetiles = purge_tiles(tiles, ns.obscon, mtldir=mtldir,
-                                           secondary=secondary)
-      
+                                           secondary=secondary, verbose=False)
+
         log.info("Removed {} targets from ledgers in {}".format(
             len(gonetargs), ledgerdir))
-        log.info("Remover {} tiles from MTL tile file ({})".format(
+        log.info("Removed {} tiles from MTL tile file ({})".format(
             len(gonetiles), mtltilefn))
 else:
-    log.info("pass --purge to actually remove them")
+    log.info("pass --purge to actually remove these tiles")

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ desitarget Change Log
 
 * Find MTL-processed tiles that don't overlap future tiles [`PR #768`_]:
     * Add code to purge such tiles from the MTL done files and ledgers.
+    * Also improve reading headers and header values from .ecsv files.
 * Also use the ops/tiles-specstatus.ecsv tile file for SV [`PR #765`_].
 
 .. _`PR #765`: https://github.com/desihub/desitarget/pull/765

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,7 @@ desitarget Change Log
 * Find MTL-processed tiles that don't overlap future tiles [`PR #768`_]:
     * Add code to purge such tiles from the MTL done files and ledgers.
     * Also improve reading headers and header values from .ecsv files.
+    * Also update GAIA EDR3 files to include RA/Dec errors and REF_EPOCH.
 * Also use the ops/tiles-specstatus.ecsv tile file for SV [`PR #765`_].
 
 .. _`PR #765`: https://github.com/desihub/desitarget/pull/765

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,12 @@ desitarget Change Log
 1.3.1 (unreleased)
 ------------------
 
+* Find MTL-processed tiles that don't overlap future tiles [`PR #768`_]:
+    * Add code to purge such tiles from the MTL done files and ledgers.
 * Also use the ops/tiles-specstatus.ecsv tile file for SV [`PR #765`_].
 
 .. _`PR #765`: https://github.com/desihub/desitarget/pull/765
+.. _`PR #768`: https://github.com/desihub/desitarget/pull/768
 
 1.3.0 (2021-09-20)
 ------------------

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -68,7 +68,8 @@ gaiadatamodel = np.array([], dtype=[
 
 # ADM the current data model for READING from Gaia EDR3 files.
 inedr3datamodel = np.array([], dtype=[
-    ('SOURCE_ID', '>i8'), ('REF_CAT', 'S2'), ('RA', '>f8'), ('DEC', '>f8'),
+    ('SOURCE_ID', '>i8'), ('REF_CAT', 'S2'), ('REF_EPOCH', '>f4'), ('RA', '>f8'),
+    ('RA_ERROR', '>f8'), ('DEC', '>f8'), ('DEC_ERROR', '>f8'),
     ('PHOT_G_MEAN_MAG', '>f4'), ('PHOT_G_MEAN_FLUX_OVER_ERROR', '>f4'),
     ('PHOT_BP_MEAN_MAG', '>f4'), ('PHOT_BP_MEAN_FLUX_OVER_ERROR', '>f4'),
     ('PHOT_RP_MEAN_MAG', '>f4'), ('PHOT_RP_MEAN_FLUX_OVER_ERROR', '>f4'),
@@ -84,7 +85,8 @@ inedr3datamodel = np.array([], dtype=[
 
 # ADM the current data model for WRITING to Gaia EDR3 files.
 edr3datamodel = np.array([], dtype=[
-    ('REF_ID', '>i8'), ('REF_CAT', 'S2'), ('EDR3_RA', '>f8'), ('EDR3_DEC', '>f8'),
+    ('REF_ID', '>i8'), ('REF_CAT', 'S2'), ('REF_EPOCH', '>f4'), ('EDR3_RA', '>f8'),
+    ('EDR3_RA_IVAR', '>f8'), ('EDR3_DEC', '>f8'), ('EDR3_DEC_IVAR', '>f8'),
     ('EDR3_PHOT_G_MEAN_MAG', '>f4'), ('EDR3_PHOT_G_MEAN_FLUX_OVER_ERROR', '>f4'),
     ('EDR3_PHOT_BP_MEAN_MAG', '>f4'), ('EDR3_PHOT_BP_MEAN_FLUX_OVER_ERROR', '>f4'),
     ('EDR3_PHOT_RP_MEAN_MAG', '>f4'), ('EDR3_PHOT_RP_MEAN_FLUX_OVER_ERROR', '>f4'),
@@ -886,9 +888,10 @@ def read_gaia_file(filename, header=False, addobjid=False, dr="dr2"):
             raise ValueError(msg)
         outdata.dtype.names = edr3datamodel.dtype.names
         prefix = "EDR3"
-        # ADM the proper motion ERRORS need to be converted to IVARs.
+        # ADM the ERRORS need to be converted to IVARs.
         # ADM remember to leave 0 entries as 0.
-        for col in ['PMRA_IVAR', 'PMDEC_IVAR', 'PARALLAX_IVAR']:
+        for col in ['RA_IVAR', 'DEC_IVAR',
+                    'PMRA_IVAR', 'PMDEC_IVAR', 'PARALLAX_IVAR']:
             outcol = "{}_{}".format(prefix, col)
             w = np.where(outdata[outcol] != 0)[0]
             outdata[outcol][w] = 1./(outdata[outcol][w]**2.)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2828,13 +2828,18 @@ def read_keyword_from_mtl_header(hpdirname, keyword):
     return hdr[keyword]
 
 
-def read_ecsv_header(filename):
+def read_ecsv_header(filename, cleanup=False):
     """Read header info from an ecsv file without reading the whole file.
 
     Parameters
     ----------
     filename : :class:`str`
         The full path to the .ecsv file of interest.
+    cleanup : :class:`bool`, optional, defaults to ``False``
+        If passed, perform some syntax cleanup to convert strings to more
+        likely types. Integer strings will be changed to integer type,
+        Quotation marks inside of strings will be removed, and instances
+        of 'false' or 'true' will be changed to Boolean types.
 
     Returns
     -------
@@ -2861,6 +2866,17 @@ def read_ecsv_header(filename):
         keyvals = d.split("{")[-1].strip("}").replace(" ", "").split(",")
         for keyval in keyvals:
             key, val = keyval.split(":", maxsplit=1)
+            # ADM syntax clean-up to convert strings to likely types.
+            if cleanup:
+                val = val.replace("'", "").replace('"', '')
+                try:
+                    val = int(val)
+                except ValueError:
+                    pass
+                if val == 'false':
+                    val = False
+                if val == 'true':
+                    val = True
             hdr[key] = val
 
     return hdr

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -608,7 +608,7 @@ def find_non_overlap_tiles(obscon, mtldir=None, isodate=None, check=False):
     isodate : :class:`str`, optional, defaults to ``None``
         A date in ISO format, such as returned by
         :func:`desitarget.mtl.get_utc_date() `. Only tiles processed
-        AFTER THEN OR EQUAL TO `isodate` are considered. If ``None`` then
+        AFTER OR EXACTLY ON `isodate` are considered. If ``None`` then
         no date restrictions are applied.
     check : :class:`bool`, optional, defaults to ``False``
         If ``True``, then instead of a list of non-overlapping tiles,

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -646,12 +646,14 @@ def find_non_overlap_tiles(obscon, mtldir=None, isodate=None, check=False):
     tiles = tiles[ii]
 
     # ADM grab the ops directory to retrieve the full tile information.
-    opsdir = os.path.join(os.path.dirname(mtltilefn)[:-3], 'ops')
+    opsdir = os.path.join(mtldir[:-3], 'ops')
     opstilefn = os.path.join(opsdir, "tiles-main.ecsv")
     alltileinfo = Table.read(opstilefn)
     # ADM restrict to tiles that have been observed in specified obscon.
     ii = alltileinfo["PROGRAM"] == obscon.upper()
     ii &= alltileinfo["STATUS"] != "unobs"
+    # ADM remove any potentially retired tiles.
+    ii &= alltileinfo["IN_DESI"]
     alltileinfo = alltileinfo[ii]
 
     # ADM retrieve observed tiles that have not been processed by MTL.
@@ -675,11 +677,6 @@ def find_non_overlap_tiles(obscon, mtldir=None, isodate=None, check=False):
         len(aii), time()-t0))
     alltileinfo = alltileinfo[aii]
 
-    # ADM *************************************************************
-    # ADM here, strictly, we should read fiberassign files to retrieve
-    # ADM targets _actually_ observed. But, this is quicker and would
-    # ADM only _not_ work for tiles where we never reobserved a target.
-    # ADM *************************************************************
     # ADM read in the potential additional targets that could have been
     # ADM observed since MTL was last run...
     ledgerdir = os.path.join(mtldir, "main", obscon.lower())

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -837,7 +837,7 @@ def purge_tiles(tiles, obscon, mtldir=None, secondary=False, verbose=True):
 
     # ADM the filename format and the HEALPixel nside for the ledgers.
     fileform = io.find_mtl_file_format_from_header(ledgerdir)
-    nside = int(io.read_keyword_from_mtl_header(ledgerdir, "FILENSID"))
+    nside = io.read_keyword_from_mtl_header(ledgerdir, "FILENSID")
 
     # ADM generate the ledger names from the input tiles.
     pixlist = tiles2pix(nside, tiles=tiles)


### PR DESCRIPTION
This PR introduces functionality to: 

- Find tiles that _have_ been processed through MTL but for which we have _not yet_ observed an overlapping tile. 
    * Such tiles can be removed from MTL completely as if they hadn't yet been processed.
- Purge those tiles completely from the MTL record, which involves removing corresponding targets from:
    * Primary and secondary ledgers.
    * The `mtl-done-tiles.ecsv` and `scnd-mtl-done-tiles.ecsv` files.

The process operates per-program (i.e. it needs to be run once for `BRIGHT` and once for `DARK`).

Example commands:

```
purge_mtl DARK --isodate 2021-09-24T19:36:28+00:00 --mtldir /global/cscratch1/sd/adamyers/fakesurveyops/mtl 
purge_mtl BRIGHT --isodate 2021-09-24T19:36:28+00:00 --mtldir /global/cscratch1/sd/adamyers/fakesurveyops/mtl
```
Where `--isodate` specifies that the code should only consider tiles after a specific date and `--mtldir` uses a different directory to the standard `$MTL_DIR` environment variable. You'd need to add `--purge` to these commands to actually remove entries from files (but be _really_ careful if you try that!). Without `--purge` the code just prints the list of non-overlapping tiles.

I've created an example run of `purge_mtl` (for both `DARK` and `BRIGHT`) in `/global/cscratch1/sd/adamyers/fakesurveyops/mtl `. The top line results were:

DARK
------
1163 targets were removed from the ledgers in `/global/cscratch1/sd/adamyers/fakesurveyops/mtl/main/secondary/dark`
32141 targets were removed from the ledgers in `/global/cscratch1/sd/adamyers/fakesurveyops/mtl/main/dark`
8 tiles were removed from the MTL tile file at `/global/cscratch1/sd/adamyers/fakesurveyops/mtl/scnd-mtl-done-tiles.ecsv`
8 tiles were removed from the MTL tile file at `/global/cscratch1/sd/adamyers/fakesurveyops/mtl/mtl-done-tiles.ecsv`

BRIGHT
--------
2500 targets were removed from the ledgers in `/global/cscratch1/sd/adamyers/fakesurveyops/mtl/main/secondary/bright`
227982 targets were removed from the ledgers in `/global/cscratch1/sd/adamyers/fakesurveyops/mtl/main/bright`
56 tiles were removed from the MTL tile file at `/global/cscratch1/sd/adamyers/fakesurveyops/mtl/scnd-mtl-done-tiles.ecsv`
56 tiles were removed from the MTL tile file at `/global/cscratch1/sd/adamyers/fakesurveyops/mtl/mtl-done-tiles.ecsv`