### PR TITLE
Add an ARCHIVEDATE column to the mtl done files and data model 

### DIFF
--- a/bin/add_archive_to_mtl
+++ b/bin/add_archive_to_mtl
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+from astropy.table import Table
+
+from desitarget.mtl import get_mtl_dir, get_mtl_tile_file_name, mtltilefiledm
+from desitarget.mtl import get_ztile_file_name
+from desitarget.geomask import match_to
+from desitarget import io
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description='Convenience script to look up initial ARCHIVEDATE in the tiles-specstatus file and add to the mtl-done-tiles and scnd-mtl-done-tiles files')
+ap.add_argument('--mtldir',
+                help="Full path to the directory that hosts the MTL ledgers.    \
+                Default is to use the $MTL_DIR environment variable.",
+                default=None)
+
+ns = ap.parse_args()
+
+# ADM grab the MTL directory (in case None was passed).
+mtldir = get_mtl_dir(ns.mtldir)
+log.info("MTL directory is {}".format(mtldir))
+
+# ADM determine the ops directory and ztile file.
+opsdir = os.path.join(mtldir[:-3], 'ops')
+ztilefn = os.path.join(opsdir, get_ztile_file_name())
+ztiles = Table.read(ztilefn)
+
+# ADM for both the secondary and primary done files...
+for sec in True, False:
+    # ADM ...derive the done file name and read in the tiles.
+    mtltilefn = os.path.join(mtldir, get_mtl_tile_file_name(secondary=sec))
+    tiles = io.read_mtl_tile_file(mtltilefn)
+
+    # ADM now match to the tiles-specstatus file on TILEID.
+    ii = match_to(ztiles["TILEID"], tiles["TILEID"])
+    # ADM and check we've matched everything.
+    if len(tiles) != len(ii):
+        msg = "{} tiles in {} only matched to {} tiles in {}!!!".format(
+            len(tiles), mtltilefn, len(ii), ztilefn)
+        log.critical(msg)
+        raise RuntimeError(msg)
+
+    # ADM set up a new array copy to ensure the dtype is correct.
+    newtiles = np.zeros(len(tiles), dtype=mtltilefiledm.dtype)
+    for col in tiles.dtype.names:
+        newtiles[col] = tiles[col]
+        # ADM add the matching ARCHIVEDATEs.
+        newtiles["ARCHIVEDATE"] = ztiles[ii]["ARCHIVEDATE"]
+
+    # ADM write to a new location, or the info would be appended.
+    io.write_mtl_tile_file(mtltilefn + ".tmp", newtiles)
+
+    # ADM then copy the new file into the old location, first we
+    # ADM may as well check for sure if we want to proceed.
+    msg = "About to copy {} over {}. Proceed (y/n)?".format(
+        mtltilefn + ".tmp", mtltilefn)
+    yorn = input(msg).lower()
+    if yorn == 'y':
+        os.rename(mtltilefn+'.tmp', mtltilefn)
+        log.info("{} copied over {}".format(mtltilefn + ".tmp", mtltilefn))
+    else:
+        log.info("{} NOT copied over {}".format(mtltilefn + ".tmp", mtltilefn))
+        os.remove(mtltilefn + ".tmp")
+        log.info("{} was removed, instead.".format(mtltilefn + ".tmp"))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,9 +2,12 @@
 desitarget Change Log
 =====================
 
-1.3.1 (unreleased)
+2.0.0 (unreleased)
 ------------------
 
+* Add ``ARCHIVEDATE`` to the mtl done files and data model [`PR #773`_].
+* Fix some variable name typos in the target selection code [`PR #770`_].
+  All of those likely never were triggered in production.
 * Find MTL-processed tiles that don't overlap future tiles [`PR #768`_]:
     * Add code to purge such tiles from the MTL done files and ledgers.
     * Also improve reading headers and header values from .ecsv files.
@@ -12,13 +15,12 @@ desitarget Change Log
 * Update targetmask and cuts for backup program [`PR #766`_]:
     * Matches description in backup program document.
 * Also use the ops/tiles-specstatus.ecsv tile file for SV [`PR #765`_].
-* Fix a few variable name typos in the target selection code [`PR #770`_].
-  All of those likely never were triggered in production.
 
 .. _`PR #765`: https://github.com/desihub/desitarget/pull/765
 .. _`PR #766`: https://github.com/desihub/desitarget/pull/766
 .. _`PR #768`: https://github.com/desihub/desitarget/pull/768
 .. _`PR #770`: https://github.com/desihub/desitarget/pull/770
+.. _`PR #773`: https://github.com/desihub/desitarget/pull/773
 
 
 1.3.0 (2021-09-20)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ desitarget Change Log
 
 * Add ``ARCHIVEDATE`` to the mtl done files and data model [`PR #773`_].
     * Also change the type of ``ZDATE`` to int64.
+    * These changes will not generally be backward compatible for MTL.
 * Fix some variable name typos in the target selection code [`PR #770`_].
   All of those likely never were triggered in production.
 * Find MTL-processed tiles that don't overlap future tiles [`PR #768`_]:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desitarget Change Log
 ------------------
 
 * Add ``ARCHIVEDATE`` to the mtl done files and data model [`PR #773`_].
+    * Also change the type of ``ZDATE`` to int64.
 * Fix some variable name typos in the target selection code [`PR #770`_].
   All of those likely never were triggered in production.
 * Find MTL-processed tiles that don't overlap future tiles [`PR #768`_]:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -60,7 +60,7 @@ zcatdatamodel = np.array([], dtype=[
 
 mtltilefiledm = np.array([], dtype=[
     ('TILEID', '>i4'), ('TIMESTAMP', 'U25'), ('VERSION', 'U14'),
-    ('PROGRAM', 'U6'), ('ZDATE', 'U8'), ('ARCHIVEDATE', 'U8')
+    ('PROGRAM', 'U6'), ('ZDATE', '>i8'), ('ARCHIVEDATE', '>i8')
     ])
 
 
@@ -1815,7 +1815,7 @@ def make_zcat(zcatdir, tiles, obscon, survey):
     for tile in tiles:
         # ADM build the correct directory structure.
         tiledir = os.path.join(rootdir, str(tile["TILEID"]))
-        ymdir = os.path.join(tiledir, tile["ZDATE"])
+        ymdir = os.path.join(tiledir, str(tile["ZDATE"]))
         # ADM and retrieve the zmtl catalog (orig name zqso/lyazcat)
         qsozcatfns = sorted(glob(os.path.join(ymdir, "zmtl*fits")))
         for qsozcatfn in qsozcatfns:
@@ -1890,7 +1890,7 @@ def make_zcat_rr_backstop(zcatdir, tiles, obscon, survey):
     for tile in tiles:
         # ADM build the correct directory structure.
         tiledir = os.path.join(rootdir, str(tile["TILEID"]))
-        ymdir = os.path.join(tiledir, tile["ZDATE"])
+        ymdir = os.path.join(tiledir, str(tile["ZDATE"]))
         # ADM and retrieve the redshifts.
         zbestfns = sorted(glob(os.path.join(ymdir, "zbest*")))
         for zbestfn in zbestfns:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1766,6 +1766,8 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey):
     newtiles["PROGRAM"] = obscon
     # ADM the final processed date for the redshifts.
     newtiles["ZDATE"] = tiles["LASTNIGHT"]
+    # ADM the date the tile was archived.
+    newtiles["ARCHIVEDATE"] = tiles["ARCHIVEDATE"]
 
     return newtiles
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -59,8 +59,8 @@ zcatdatamodel = np.array([], dtype=[
     ])
 
 mtltilefiledm = np.array([], dtype=[
-    ('TILEID', '>i4'), ('TIMESTAMP', 'U25'),
-    ('VERSION', 'U14'), ('PROGRAM', 'U6'), ('ZDATE', 'U8')
+    ('TILEID', '>i4'), ('TIMESTAMP', 'U25'), ('VERSION', 'U14'),
+    ('PROGRAM', 'U6'), ('ZDATE', 'U8'), ('ARCHIVEDATE', 'U8')
     ])
 
 


### PR DESCRIPTION
This PR adds an `ARCHIVEDATE` column to the data model for the MTL done files (`mtl-done-tiles.ecsv` and `scnd-mtl-done-tiles.ecsv`). 

It also includes the convenience script that was used to add the intial `ARCHIVEDATE` values to the MTL done files.