### PR TITLE
Add SCND_TARGET column to BACKUP targets, even when nosec is passed

### DIFF
--- a/bin/select_targets
+++ b/bin/select_targets
@@ -251,7 +251,7 @@ if ns.bundlefiles is None:
             maskbits=not(ns.nomaskbits), indir=ns.sweepdir, indir2=ns.sweepdir2,
             obscon=obscon, scndout=scndout, survey="main", nsidefile=ns.nside,
             hpxlist=pixlist, supp=supp, qso_selection=ns.qsoselection,
-            extra=extra, extradeps=extradeps,
+            extra=extra, extradeps=extradeps, nosec=ns.nosecondary,
             infiles=shatab, checkbright=ns.checkbright
         )
         log.info('{} targets written to {}...t={:.1f}s'.format(ntargs, outfile, time()-start))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,17 @@ desitarget Change Log
 2.1.1 (unreleased)
 ------------------
 
+* Add ``SCND_TARGET`` for backup targets if nosec is passed [`PR #775`_].
+* Add another MWS backup object type BACKUP_GIANT_LOP. The default
+  BACKUP_GIANT category is now downsampled with galactic latitude to
+  avoid having large densities [`PR #772`_].
+* Change backup target priorities to be between 15-30 to be able to place
+  new object types in between [`PR #772`_].
 * Use Gaia to look up good sky positions for stuck fibers [`PR #771`_].
 
 .. _`PR #771`: https://github.com/desihub/desitarget/pull/771
+.. _`PR #772`: https://github.com/desihub/desitarget/pull/772
+.. _`PR #775`: https://github.com/desihub/desitarget/pull/775
 
 2.1.0 (2021-11-16)
 ------------------
@@ -43,17 +51,11 @@ desitarget Change Log
 * Also use the ops/tiles-specstatus.ecsv tile file for SV [`PR #765`_].
 * Fix a few variable name typos in the target selection code [`PR #770`_].
   All of those likely never were triggered in production.
-* Add another MWS backup object type BACKUP_GIANT_LOP. The default
-  BACKUP_GIANT category is now downsampled with galactic latitude to
-  avoid having large densities [`PR #772`_].
-* Change backup target priorities to be between 15-30 to be able to place
-  new object types in between [`PR #772`_].
 
 .. _`PR #765`: https://github.com/desihub/desitarget/pull/765
 .. _`PR #766`: https://github.com/desihub/desitarget/pull/766
 .. _`PR #768`: https://github.com/desihub/desitarget/pull/768
 .. _`PR #770`: https://github.com/desihub/desitarget/pull/770
-.. _`PR #772`: https://github.com/desihub/desitarget/pull/772
 .. _`PR #773`: https://github.com/desihub/desitarget/pull/773
 
 1.3.0 (2021-09-20)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -337,9 +337,10 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
 
     return std_faint, std_bright, std_wd
 
+
 def backupGiantDownsample(l, b):
     """
-    Return the downsampling factor as a function of l,b 
+    Return the downsampling factor as a function of l,b
 
     Parameters
     ----------
@@ -351,7 +352,7 @@ def backupGiantDownsample(l, b):
     Returns
     -------
     frac: array
-         The fraction of objects to select        
+         The fraction of objects to select
     """
     p = [6.9529434, 0.18786695, -2.6621607, -3.05095354, 8.10060927]
 
@@ -367,7 +368,6 @@ def backupGiantDownsample(l, b):
 
     subsamp = np.minimum(100 / 10**mapper(ldens, .1, .0), 1)
     return subsamp
-
 
 
 def isBACKUP(ra=None, dec=None,
@@ -445,7 +445,7 @@ def isBACKUP(ra=None, dec=None,
 
     # APC and are likely giants
     gal = SkyCoord(ra*u.degree, dec*u.degree).galactic
-    l, b = gal.l.to_value(u.degree), gal.b.to_value(u.degree)    
+    l, b = gal.l.to_value(u.degree), gal.b.to_value(u.degree)
 
     lowlat_fraction = backupGiantDownsample(l, b)
     giant_hpsub_sel = random_fraction_of_trues(lowlat_fraction, giant_hp_sel)
@@ -454,7 +454,7 @@ def isBACKUP(ra=None, dec=None,
     is_backup_lowp_giant &= (giant_sel & (~giant_hpsub_sel))
     # do not select low priority distant giants in the galactic plane
     is_backup_lowp_giant &= (~in_gal)
-    
+
     # APC faint targets are 16 < G < 18
     isbackupfaint &= gaiagmag >= 16.0
     isbackupfaint &= gaiagmag < 18.0
@@ -2797,7 +2797,6 @@ def apply_cuts_gaia(numproc=4, survey='main', nside=None, pixlist=None,
         (backup_bright, backup_faint, backup_very_faint) = targcuts.isBACKUP(
             ra=ra, dec=dec, gaiagmag=gaiagmag,
             primary=primary)
-        
 
     # ADM determine if a target is a Gaia-only standard.
     primary = np.ones_like(gaiaobjs, dtype=bool)
@@ -2814,8 +2813,8 @@ def apply_cuts_gaia(numproc=4, survey='main', nside=None, pixlist=None,
     mws_target |= backup_faint * mws_mask.BACKUP_FAINT
     mws_target |= backup_very_faint * mws_mask.BACKUP_VERY_FAINT
     if survey == 'main':
-      mws_target |= backup_hip_giant * mws_mask.BACKUP_GIANT
-      mws_target |= backup_lowp_giant * mws_mask.BACKUP_GIANT_LOP
+        mws_target |= backup_hip_giant * mws_mask.BACKUP_GIANT
+        mws_target |= backup_lowp_giant * mws_mask.BACKUP_GIANT_LOP
     mws_target |= std_faint * mws_mask.GAIA_STD_FAINT
     mws_target |= std_bright * mws_mask.GAIA_STD_BRIGHT
     mws_target |= std_wd * mws_mask.GAIA_STD_WD

--- a/py/desitarget/skyhealpixs.py
+++ b/py/desitarget/skyhealpixs.py
@@ -11,6 +11,7 @@ Scripts based on desitarget.skybricks, adapted for healpix split.
 import os
 import numpy as np
 
+
 class Skyhealpixs(object):
     '''
     This class handles dynamic lookup of whether a given (RA,Dec)


### PR DESCRIPTION
This PR adds a `SCND_TARGET` column to files of `BACKUP` targets, even when the `--nosecondary` argument is passed. This should ensure that `BACKUP` targets have the same data model as `BRIGHT` and `DARK` targets, even though there are typically no secondary targets in the `BACKUP` program.