### PR TITLE
Skyhealpixs gaia v2

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 2.2.1 (unreleased)
 ------------------
 
-* Small modification on skyhealpixs.py [`PR #776`]:
+* Small modification on skyhealpixs.py [`PR #776`_]:
     * adjust the per-healpix file name
     * set (nside, nest) arguments, defaulting to (64, True)
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ desitarget Change Log
 2.2.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Small modification on skyhealpixs.py [`PR #776`]:
+    * adjust the per-healpix file name
+    * set (nside, nest) arguments, defaulting to (64, True)
+
+.. _`PR #776`: https://github.com/desihub/desitarget/pull/776
 
 2.2.0 (2021-11-21)
 ------------------

--- a/py/desitarget/skyhealpixs.py
+++ b/py/desitarget/skyhealpixs.py
@@ -61,6 +61,17 @@ class Skyhealpixs(object):
         import healpy as hp
         log = get_logger()
 
+        # AR infos
+        log.info(
+            'settings : skyhealpixs_dir={}, nside={}, nest={}'.format(
+                self.skyhealpixs_dir, self.nside, self.nest,
+            )
+        )
+        log.info('the code will look for {} files'.format(
+                os.path.join(self.skyhealpixs_dir, 'skymap-?????.fits.gz'),
+            )
+        )
+
         # handle non-array iterables (eg lists) as inputs
         ras = np.array(ras)
         decs = np.array(decs)

--- a/py/desitarget/skyhealpixs.py
+++ b/py/desitarget/skyhealpixs.py
@@ -73,7 +73,7 @@ class Skyhealpixs(object):
             log.debug('Skyhealpixs: %i locations overlap healpix pixel %s' % (len(I), pix))
 
             # Read healpix file
-            fn = os.path.join(self.skyhealpixs_dir, 'gaia_skymap-{:05d}.fits.gz'.format(pix))
+            fn = os.path.join(self.skyhealpixs_dir, 'skymap-{:05d}.fits.gz'.format(pix))
             if not os.path.exists(fn):
                 log.warning('Missing "skyhealpix" file: {}'.format(fn))
                 continue


### PR DESCRIPTION
This PR is a small modification of the PR https://github.com/desihub/desitarget/pull/771.
It introduces the following changes in `skyhealpixs.py`:
- the healpix file basename now is `skymap*`, instead of `gaia_skymap*` (see [desi-survey 3412]);
- the `(nside, nest)` values are now arguments, defaulting to the previously hard-coded values `(64,True)` (in case we want to test a different healpix scheme);
- adds some log infos, expliciting the settings.