### PR TITLE
Finalize the MTL logic for reprocessed tiles

### DIFF
--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -6,6 +6,8 @@ log = get_logger()
 
 # ADM default survey to run.
 survey = "main"
+# ADM default delay to allow between QA and MTL.
+delay = 3
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Make an initial HEALPixel-split ledger for a Merged Target List based on a directory of targets')
@@ -36,6 +38,10 @@ ap.add_argument("--reprocess", action='store_true',
 ap.add_argument("-b", "--batch", type=int,
                 help='If passed, run BATCH tiles rather than all tiles',
                 default=None)
+ap.add_argument("-d", "--delay", type=int,
+                help="Number of days since QA was done to delay before running  \
+                MTL. Defaults to [{}]".format(delay),
+                default=delay)
 
 ns = ap.parse_args()
 
@@ -56,7 +62,7 @@ for secondary in scndstates:
     hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
         ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
         numobs_from_ledger=numobs_from_ledger, secondary=secondary,
-        reprocess=ns.reprocess, batch=ns.batch)
+        reprocess=ns.reprocess, batch=ns.batch, delay=ns.delay)
 
     log.info("MTL ledger directory: {}".format(hpdirname))
     log.info("MTL tile file: {}".format(mtltilefn))

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -24,9 +24,6 @@ ap.add_argument('--mtldir',
                 help="Full path to the directory that hosts the MTL ledgers.    \
                 Default is to use the $MTL_DIR environment variable",
                 default=None)
-ap.add_argument("-n", "--numobsfromzcat", action='store_true',
-                help="If passed, the zcat includes a meaningful NUMOBS.         \
-                Otherwise, NUMOBS is looked up from the ledger itself")
 ap.add_argument("-nosec", "--nosecondary", action='store_true',
                 help="By default, we always process the ledger of secondaries   \
                 in addition to the primaries so they keep pace. Pass this if    \
@@ -35,8 +32,6 @@ ap.add_argument("--reprocess", action='store_true',
                 help="Run reprocessed tiles (instead of the standard loop)")
 
 ns = ap.parse_args()
-
-numobs_from_ledger = not(ns.numobsfromzcat)
 
 scndstates = [False]
 
@@ -52,8 +47,7 @@ for secondary in scndstates:
     # ADM run through the regular loop once.
     hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
         ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
-        numobs_from_ledger=numobs_from_ledger, secondary=secondary,
-        reprocess=ns.reprocess)
+        secondary=secondary, reprocess=ns.reprocess)
 
     log.info("MTL ledger directory: {}".format(hpdirname))
     log.info("MTL tile file: {}".format(mtltilefn))

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -6,8 +6,6 @@ log = get_logger()
 
 # ADM default survey to run.
 survey = "main"
-# ADM default delay to allow between QA and MTL.
-delay = 3
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Make an initial HEALPixel-split ledger for a Merged Target List based on a directory of targets')
@@ -35,13 +33,6 @@ ap.add_argument("-nosec", "--nosecondary", action='store_true',
                 there are no secondaries to process")
 ap.add_argument("--reprocess", action='store_true',
                 help="Run reprocessed tiles (instead of the standard loop)")
-ap.add_argument("-b", "--batch", type=int,
-                help='If passed, run BATCH tiles rather than all tiles',
-                default=None)
-ap.add_argument("-d", "--delay", type=int,
-                help="Number of days since QA was done to delay before running  \
-                MTL. Defaults to [{}]".format(delay),
-                default=delay)
 
 ns = ap.parse_args()
 
@@ -62,7 +53,7 @@ for secondary in scndstates:
     hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
         ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
         numobs_from_ledger=numobs_from_ledger, secondary=secondary,
-        reprocess=ns.reprocess, batch=ns.batch, delay=ns.delay)
+        reprocess=ns.reprocess)
 
     log.info("MTL ledger directory: {}".format(hpdirname))
     log.info("MTL tile file: {}".format(mtltilefn))

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -31,8 +31,11 @@ ap.add_argument("-nosec", "--nosecondary", action='store_true',
                 help="By default, we always process the ledger of secondaries   \
                 in addition to the primaries so they keep pace. Pass this if    \
                 there are no secondaries to process")
-ap.add_argument("-reproc", "--reprocess", action='store_true',
+ap.add_argument("--reprocess", action='store_true',
                 help="Run reprocessed tiles (instead of the standard loop)")
+ap.add_argument("-b", "--batch", type=int,
+                help='If passed, run BATCH tiles rather than all tiles',
+                default=None)
 
 ns = ap.parse_args()
 
@@ -47,12 +50,13 @@ if ns.obscon in ["BRIGHT", "DARK"]:
         scndstates = [True, False]
 
 premsg = ["Processed", "REprocessed"][ns.reprocess]
+
 for secondary in scndstates:
     # ADM run through the regular loop once.
     hpdirname, mtltilefn, tilefn, tiles = loop_ledger(
         ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir, mtldir=ns.mtldir,
         numobs_from_ledger=numobs_from_ledger, secondary=secondary,
-        reprocess=ns.reprocess)
+        reprocess=ns.reprocess, batch=ns.batch)
 
     log.info("MTL ledger directory: {}".format(hpdirname))
     log.info("MTL tile file: {}".format(mtltilefn))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,23 @@ desitarget Change Log
 2.1.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Finalize MTL logic for reprocessed tiles [`PR #780`_]. Logic is:
+    * Assemble all previous observations that touch a reprocessed tile.
+        * Include any new, reprocessed observations.
+        * Find the most recent for unique ``TILEID`` + ``TARGETID``.
+        * Store these in a redshift catalog (an "all-zcat").
+    * Determine the order in which tiles were originally processed.
+    * Loop through the tiles in this original order.
+        * Start with the ``UNOBS`` state.
+        * Update the ``UNOBS`` state with entries in the "all-zcat".
+        * Recover the final state for each ``TARGETID``.
+        * Add the progression, WITH ``BAD`` observations, to the ledgers.
+    * Also includees:
+        * Mock-up (unique) ``TIMESTAMPs`` instead of delaying the code.
+        * Deprecate ``numobsfromzcat`` as a user-specified option.
+	    * as we now always retrieve ``NUMOBS`` from the ledger.
+
+.. _`PR #780`: https://github.com/desihub/desitarget/pull/780
 
 2.1.0 (2021-11-16)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -16,10 +16,10 @@ desitarget Change Log
         * Update the ``UNOBS`` state with entries in the "all-zcat".
         * Recover the final state for each ``TARGETID``.
         * Add the progression, WITH ``BAD`` observations, to the ledgers.
-    * Also includees:
+    * Also includes:
         * Mock-up (unique) ``TIMESTAMPs`` instead of delaying the code.
         * Deprecate ``numobsfromzcat`` as a user-specified option.
-	    * as we now always retrieve ``NUMOBS`` from the ledger.
+            * as we now always retrieve ``NUMOBS`` from the ledger.
 
 .. _`PR #780`: https://github.com/desihub/desitarget/pull/780
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2561,13 +2561,17 @@ def find_target_files(targdir, dr='X', flavor="targets", survey="main",
     return fn
 
 
-def read_mtl_tile_file(filename):
+def read_mtl_tile_file(filename, unique=True):
     """Read which tiles have been processed by MTL from the tile file.
 
     Parameters
     ----------
     filename : :class:`str`
         The full path to the MTL tile file.
+    unique : :class:`bool`, optional, defaults to ``True``
+        If ``True`` then only read entires with unique `TILEID`, where
+        the last occurrence of the TILEID in the file is the one that
+        is retained. If ``False`` then read the entire file.
 
     Returns
     -------
@@ -2575,6 +2579,16 @@ def read_mtl_tile_file(filename):
         A structured numpy array of the MTL tile file.
     """
     mtltiles = Table.read(filename, comment="#", delimiter=" ")
+
+    if unique:
+        # ADM the flip is because np.unique retains the FIRST unique
+        # ADM entry and we want the LAST unique entry.
+        mtltiles = np.flip(mtltiles)
+        _, ii = np.unique(mtltiles["TILEID"], return_index=True)
+        # ADM sort on ii to retain the exact original order...
+        ii = sorted(ii)
+        # ADM ...and flip back to the original ordering
+        return np.flip(mtltiles[ii])
 
     return mtltiles
 
@@ -2718,7 +2732,7 @@ def read_mtl_ledger(filename, unique=True, isodate=None,
         mtl = mtl[ii]
 
     if unique or initial:
-        # ADM the reverse is because np.unique retains the FIRST unique
+        # ADM the flip is because np.unique retains the FIRST unique
         # ADM entry and we want the LAST unique entry.
         if not initial:
             mtl = np.flip(mtl)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -901,7 +901,7 @@ def purge_tiles(tiles, obscon, mtldir=None, secondary=False, verbose=True):
 
     # ADM second, remove the tiles from the done file.
     # ADM to store the removed tiles.
-    inmtltiles = io.read_mtl_tile_file(mtltilefn)
+    inmtltiles = io.read_mtl_tile_file(mtltilefn, unique=False)
     # ADM guarantee that the output Table will be in the required format.
     mtltiles = np.empty_like(mtltilefiledm, shape=len(inmtltiles))
     for col in mtltilefiledm.dtype.names:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -2088,6 +2088,9 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey, reprocess=False):
     zdone = np.array(["true" in row for row in tilelookup["ZDONE"]])
     # ADM redshift processing must be complete.
     ii = zdone
+    if survey == "main":
+        # ADM tile must have been archived.
+        ii &= tilelookup["ARCHIVEDATE"] > 0
     alltiles = tilelookup[ii]
 
     # ADM read in the MTL tile file, guarding against it not having being

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -786,8 +786,8 @@ def find_non_overlap_tiles(obscon, mtldir=None, isodate=None, check=False):
     # ADM observed since MTL was last run...
     ledgerdir = os.path.join(mtldir, "main", obscon.lower())
     obstargs = io.read_targets_in_tiles(ledgerdir, tiles=obstileinfo, mtl=True)
-    # ADM ...and restrict to just overlapping targets that have been
-    # ADM processed through MTL at least once before.
+    # ADM ...and restrict to just overlapping targets that have passed
+    # ADM through MTL before (and registered a GOOD observation).
     ii = obstargs["ZTILEID"] != -1
     obstargs = obstargs[ii]
     log.info("Read {} potentially observed targets in {} tiles...t={:.1f}s"
@@ -1597,8 +1597,11 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
     log.info("Retained {}/{} targets with {} unique TARGETIDs...t={:.1f}s"
              .format(len(targets), ntargs, nuniq, time()-t0))
 
-    # ADM split off the updated target states from the unobserved state.
-    unobs = targets[targets["ZTILEID"] == -1]
+    # ADM split off the updated target states from the unobserved states.
+    _, ii = np.unique(targets["TARGETID"], return_index=True)
+    unobs = targets[sorted(ii)]
+    # ADM this should remove both original UNOBS states and any resets
+    # ADM to UNOBS due to reprocessing data that turned out to be bad.
     targets = targets[targets["ZTILEID"] != -1]
     # ADM every target should have been unobserved at some point.
     if len(set(targets["TARGETID"]) - set(unobs["TARGETID"])) != 0:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1467,8 +1467,6 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
     # ADM find the general format for the ledger files in `hpdirname`.
     # ADM also returning the obsconditions.
     fileform, oc = io.find_mtl_file_format_from_header(hpdirname, returnoc=True)
-    # ADM this is the format for any associated override ledgers.
-    overrideff = io.find_mtl_file_format_from_header(hpdirname, override=True)
 
     # ADM check the obscondition is as expected.
     if obscon != oc:
@@ -1633,16 +1631,8 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
         # ADM necessary when using io.read_mtl_ledger(unique=True)).
         mtlpix = mtlpix[np.argsort(mtlpix["TARGETID"])]
 
-        # ADM the correct filenames for this pixel number.
+        # ADM the correct filename for this pixel number.
         fn = fileform.format(pix)
-        overfn = overrideff.format(pix)
-
-        # ADM if an override ledger exists, update it and recover its
-        # ADM relevant MTL entries.
-        if os.path.exists(overfn):
-            overmtl = process_overrides(overfn)
-            # ADM add any override entries TO THE END OF THE LEDGER.
-            mtlpix = vstack([mtlpix, overmtl])
 
         # ADM if we're working with .ecsv, simply append to the ledger.
         if ender == 'ecsv':

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -2135,11 +2135,12 @@ def tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey, reprocess=False):
         ii = np.array([tid in newtids for tid in alltiles["TILEID"]])
         tiles = alltiles[ii]
 
-    # ADM restrict the tiles to be processed to the correct survey.
+    # ADM restrict the tiles to be processed to the correct survey...
     ii = tiles["SURVEY"] == survey
-    # ADM also must match the correct lower- or upper-case (OBSCON).
+    # ADM ...and the correct lower- or upper-case program (OBSCON).
     ii &= ((tiles["FAPRGRM"] == obscon.lower()) |
            (tiles["FAPRGRM"] == obscon.upper()))
+    tiles = tiles[ii]
 
     # ADM initialize the output array and add the tiles.
     newtiles = np.zeros(len(tiles), dtype=mtltilefiledm.dtype)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1571,6 +1571,24 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
     targets = remove_overrides(targets)
     # ADM sort by TIMESTAMP to ensure tiles are listed chronologically.
     targets = targets[np.argsort(targets["TIMESTAMP"])]
+    # ADM for speed, we only need to work with targets with a zcat entry.
+    ii = np.array([tid in s for tid in targets["TARGETID"]])
+    targets = targets[ii]
+
+    # ADM calculate which of the targets have good/bad redshifts.
+    Mxbad = "BAD_SPECQA|BAD_PETALQA|NODATA"
+    bad = targets["ZWARN"] & zwarn_mask.mask(Mxbad) != 0
+    good = ~bad
+    # ADM determine if any final entries for a target on a tile are good.
+    # ADM first, create a unique hash of TILEID and TARGETID.
+    tiletarg = [str(t["ZTILEID"]) + "-" + str(t["TARGETID"]) for t in targets]
+    # ADM find the final unique combination of TILEID and TARGETID. We
+    # ADM have to flip, here, as np.unique find the first unique entries.
+    tiletarg = np.flip(tiletarg)
+    _, ii = np.unique(tiletarg, return_index=True)
+    # ADM make sure to retain overall reverse-ordering.
+    ii = sorted(ii)
+    # ADM 
 
     # ADM need to know which targets were first observed on which tiles.
     obs = targets[targets["ZTILEID"] != -1]


### PR DESCRIPTION
This PR extends #774 by including the actual, final logic for reprocessing tiles. This logic is to:

- Assemble all previous observations that touch the set of reprocessed tiles including any "new" observations from the reprocessed tiles.
- Find the most recent observations for unique combinations of `TILEID` + `TARGETID` and store these in a redshift catalog (which I'll refer to as the "all-zcat" below).
- Determine the order in which tiles were originally processed and loop through the tiles in this original order:
  * Start with the `UNOBS` state for a given `TARGETID`.
  * Update the `UNOBS` state (progressively, in tile order) using entries from the "all-zcat" for a given `TARGETID`.
  * Hence, recover the final state for each `TARGETID` with the reprocessed observations substituted for the "orginal" observations.
- The full progression of states for each `TARGETID` is then appended to the ledgers, _including_ `BAD` observations (which, previously, never appeared in the ledgers).

This PR also includes:

- During reprocessing, `TIMESTAMP`s are mocked up in advance for speed. 
  * i.e. instead of having to delay the code by 1 second for each tile so as to ensure a unique `TIMESTAMP`.
- The `numobsfromzcat` flag is deprecated as a user-specified option when executing `run_mtl_loop`.
  * as we have always, in actuality, retrieved `NUMOBS` from the ledgers themselves rather than the redshift catalog.
  * it seemed increasingly fragile to retain an option we've never used.
