### PR TITLE
Fix ragged array warning in geomask.circle_boundaries()

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ desitarget Change Log
 2.2.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix ragged array warning in geomask.circle_boundaries() [`PR #781`_]:
+        * Addresses `issue #779`_.
+
+.. _`issue #779`: https://github.com/desihub/desitarget/issues/779
+.. _`PR #781`: https://github.com/desihub/desitarget/pull/781
 
 2.2.1 (2021-11-22)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desitarget Change Log
 ------------------
 
 * Fix ragged array warning in geomask.circle_boundaries() [`PR #781`_]:
-        * Addresses `issue #779`_.
+    * Addresses `issue #779`_.
 
 .. _`issue #779`: https://github.com/desihub/desitarget/issues/779
 .. _`PR #781`: https://github.com/desihub/desitarget/pull/781

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -762,24 +762,26 @@ def circle_boundaries(RAcens, DECcens, r, nloc):
 
     # ADM nloc Dec offsets equally spaced around the circle perimeter.
     offdec = np.array([rad*np.sin(np.arange(ns)*2*np.pi/ns)
-                       for ns, rad in zip(nloc, radius)]).transpose()
+                       for ns, rad in zip(nloc, radius)], dtype=object).transpose()
 
     # ADM use offsets to determine DEC positions.
     decs = DECcens + offdec
 
     # ADM offsets in RA at these Decs given the mask center Dec.
-    offrapos = [sphere_circle_ra_off(th, cen, declocs)
+    # ADM astype, here, to ensure inputs are floats rather than objects.
+    offrapos = [sphere_circle_ra_off(th, cen, declocs.astype('<f8'))
                 for th, cen, declocs in zip(radius, DECcens, decs.transpose())]
 
     # ADM determine which RA offsets are in the positive direction.
     sign = [np.sign(np.cos(np.arange(ns)*2*np.pi/ns)) for ns in nloc]
 
     # ADM add RA offsets with the right sign to the the circle center.
-    offra = np.array([o*s for o, s in zip(offrapos, sign)]).transpose()
+    offra = np.array([o*s for o, s in zip(offrapos, sign)],
+                     dtype=object).transpose()
     ras = RAcens + offra
 
-    # ADM return the results as 1-D arrays.
-    return np.hstack(ras), np.hstack(decs)
+    # ADM return results as 1-D arrays, converting from object to float.
+    return np.hstack(ras).astype('<f8'), np.hstack(decs).astype('<f8')
 
 
 def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',


### PR DESCRIPTION
This PR fixes a ragged array deprecation warning in [geomask.circle_boundaries()](https://github.com/desihub/desitarget/blob/6a2c55c6725279608e848fcbff43833998455548/py/desitarget/geomask.py#L736).

The fix was to convert the ragged arrays to `dtype=object` while being careful to convert them back to `dtype=float` when needed.

This addresses #779.