### PR TITLE
Extra functionality for splitting random catalogs by HEALPixel

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 2.3.1 (unreleased)
 ------------------
 
+* Extra functionality for splitting randoms by HEALPixel [`PR #785`_]:
+    * Correctly process catalogs with an existing ``HPXPIXEL`` column.
 * Functionality to split random catalogs by HEALPixel [`PR #783`_].
     * Allows the io/reading utilities to be used on the resulting files.
 * More accurately round pixel coordinates for randoms [`PR #782`_].
@@ -12,6 +14,7 @@ desitarget Change Log
 
 .. _`PR #782`: https://github.com/desihub/desitarget/pull/782
 .. _`PR #783`: https://github.com/desihub/desitarget/pull/783
+.. _`PR #785`: https://github.com/desihub/desitarget/pull/785
 
 2.3.0 (2021-12-14)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1485,9 +1485,10 @@ def write_randoms_in_hp(randoms, outdirname, nside, pixlist, hpx=None,
 
     Notes
     -------
-        - A new column HPXPIXEL is added to `randoms`. HPXNSIDE=`nside`
-          and FILENSID=`nside` and "HPXNEST"=``True`` are added to the
-          output header (or overwritten, if they already exist).
+        - A new column HPXPIXEL is added to `randoms` (or overwritten if
+          it already exists). HPXNSIDE=`nside` and FILENSID=`nside` and
+          "HPXNEST"=``True`` are added to the output header (or
+          overwritten, if they already exist).
     """
     t0 = time()
 
@@ -1516,7 +1517,10 @@ def write_randoms_in_hp(randoms, outdirname, nside, pixlist, hpx=None,
             # ADM set up a new array restricted to just the pixel of
             # ADM interest and add the HPXPIXEL column.
             nrows = np.sum(inpix)
-            dt = randoms.dtype.descr + [('HPXPIXEL', '>i8')]
+            if "HPXPIXEL" in randoms.dtype.names:
+                dt = randoms.dtype.descr
+            else:
+                dt = randoms.dtype.descr + [('HPXPIXEL', '>i8')]
             outran = np.zeros(nrows, dtype=dt)
             outran["HPXPIXEL"] = pix
             for col in randoms.dtype.names:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1522,9 +1522,9 @@ def write_randoms_in_hp(randoms, outdirname, nside, pixlist, hpx=None,
             else:
                 dt = randoms.dtype.descr + [('HPXPIXEL', '>i8')]
             outran = np.zeros(nrows, dtype=dt)
-            outran["HPXPIXEL"] = pix
-            for col in randoms.dtype.names:
+            for col in outran.dtype.names:
                 outran[col] = randoms[col][inpix]
+            outran["HPXPIXEL"] = pix
             # ADM add the pixel to the output file hdr. dict is in case
             # ADM hdr was passed as a FITSHDR, which can't be copied.
             outhdr = dict(hdr).copy()

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1530,8 +1530,9 @@ def write_randoms_in_hp(randoms, outdirname, nside, pixlist, hpx=None,
             outhdr = dict(hdr).copy()
             outhdr["FILEHPX"] = pix
             # ADM write out the randoms in this pixel.
-            nt, fn = write_randoms(outdirname, outran, indir=infile,
-                                   nsidefile=nside, hpxlist=pix, extra=outhdr)
+            nt, fn = write_randoms(
+                outdirname, outran, indir=infile, nsidefile=nside, hpxlist=pix,
+                extra=outhdr, hpxsplit=True)
             if verbose:
                 log.info('{} targets written to {}...t={:.1f}s'.format(
                     nt, fn, time()-t0))
@@ -1541,7 +1542,7 @@ def write_randoms_in_hp(randoms, outdirname, nside, pixlist, hpx=None,
 
 def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
                   nsidefile=None, hpxlist=None, resolve=True, north=None,
-                  extra=None):
+                  extra=None, hpxsplit=False):
     """Write a catalogue of randoms and associated pixel-level info.
 
     Parameters
@@ -1581,6 +1582,9 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
     extra : :class:`dict`, optional
         If passed (and not ``None``), write these extra dictionary keys
         and values to the output header.
+    hpxsplit : :class:`bool`, optional, defaults to ``False``
+        If ``True`` use the "INFILE" key in `hdr` to determine an extra,
+        final, directory to add to the output path.
 
     Returns
     -------
@@ -1687,6 +1691,18 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
 
     # ADM add whether or not the randoms were resolved to the header.
     hdr["RESOLVE"] = resolve
+
+    # ADM if performing a split-by-HEALPixel, add an extra directory.
+    if hpxsplit:
+        if "INFILE" in hdr:
+            # ADM determine an extra directory to add to the output path.
+            xdirname = os.path.splitext(os.path.basename(hdr["INFILE"]))[0]
+            dirname, basename = os.path.split(filename)
+            filename = os.path.join(dirname, xdirname, basename)
+        else:
+            msg = "hpxsplit is True: hdr must include the INFILE key!!!"
+            log.error(msg)
+            raise RuntimeError(msg)
 
     # ADM create necessary directories, if they don't exist.
     os.makedirs(os.path.dirname(filename), exist_ok=True)


### PR DESCRIPTION
This PR is an extension to #783.

Certain random catalogs already include an `HPXPIXEL` column, which #783 also added. This PR checks for the existence of an `HPXPIXEL` column before attempting to add it.

In addition, as random catalogs can be split in various ways, this PR adds a new directory name — based on the input random catalog filename — to the output HEALPixel-split directory structure. This makes it easier to track the location of — and better facilitates applying the `desitarget.io` reading routines to — HEALPixel-split random catalogs.