### PR TITLE
add [grz]fiberflux optional arguments to fix (now-broken) desisim/templates code

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -104,7 +104,7 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel docutils\<0.18 Sphinx==3.1.2
+              run: python -m pip install --upgrade pip wheel Sphinx
             - name: Test the documentation
               run: sphinx-build -W --keep-going -b html doc doc/_build/html
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,10 +17,11 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.7, 3.8]  # fitsio does not like Python < 3.7
-                # astropy-version: ['<3.0', '<4.1']  #, '<5.0']
+                python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
+                astropy-version: ['==4.0.1.post1', '==5.0']  # everest & fuji versions
+                fitsio-version: ['==1.1.2', '==1.1.6']  # everest & fuji versions
         env:
-            DESIUTIL_VERSION: 3.1.0
+            DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
 
         steps:
@@ -38,6 +39,9 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip cache remove fitsio
+                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test
               run: DESIMODEL=$(pwd) pytest
@@ -50,8 +54,9 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]
+                fitsio-version: ['==1.1.2']  # everest version
         env:
-            DESIUTIL_VERSION: 3.1.0
+            DESIUTIL_VERSION: 3.2.3
             DESIMODEL_DATA: branches/test-0.12
 
         steps:
@@ -69,6 +74,8 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip cache remove fitsio
+                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
             - name: Run the test with coverage
               run: DESIMODEL=$(pwd) pytest --cov
@@ -97,7 +104,7 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel Sphinx
+              run: python -m pip install --upgrade pip wheel docutils\<0.18 Sphinx==3.1.2
             - name: Test the documentation
               run: sphinx-build -W --keep-going -b html doc doc/_build/html
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,16 @@ desitarget Change Log
 2.3.1 (unreleased)
 ------------------
 
+* Add optional ``[grz]fiberflux`` arguments to the ``ELG``, ``LRG``, and ``BGS`` 
+  color-cut selection functions to support the `desisim` template-generating
+  code (see `desisim/PR #556`) [`PR #786`].
 * Fix a bug in the randoms due to inaccrate rounding of pixel coordinates [`PR #782`_].
     * This change will affect brick-based values in randoms (e.g.,
       NOBS, MASKBITS and PSFSIZE).
 
 .. _`PR #782`: https://github.com/desihub/desitarget/pull/782
+.. _`PR #786`: https://github.com/desihub/desitarget/pull/786
+.. _`desisim/PR #556`: https://github.com/desihub/desisim/pull/556
 
 2.3.0 (2021-12-14)
 ------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -150,7 +150,8 @@ for missing in ('astropy', 'desimodel', 'desisim', 'desispec', 'desiutil',
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#html_theme = 'alabaster'
+#html_theme = 'default'
+#html_theme = 'haiku'
 try:
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -537,11 +537,6 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
         primary = np.ones_like(rflux, dtype='?')
     lrg = primary.copy()
 
-    # ADM to maintain backwards-compatibility with mocks.
-    if zfiberflux is None:
-        log.warning('Setting zfiberflux to zflux!!!')
-        zfiberflux = zflux.copy()
-
     lrg &= (rfluxivar > 0) & (rflux > 0)   # ADM quality in r.
     lrg &= (zfluxivar > 0) & (zflux > 0) & (zfiberflux > 0)   # ADM quality in z.
     lrg &= (w1fluxivar > 0) & (w1flux > 0)  # ADM quality in W1.
@@ -572,11 +567,6 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
     lrg = primary.copy()
-
-    # ADM to maintain backwards-compatibility with mocks.
-    if zfiberflux is None:
-        log.warning('Setting zfiberflux to zflux!!!')
-        zfiberflux = zflux.copy()
 
     gmag = 22.5 - 2.5 * np.log10(gflux.clip(1e-7))
     # ADM safe as these fluxes are set to > 0 in notinLRG_mask.
@@ -1463,11 +1453,6 @@ def isBGS(rfiberflux=None, gflux=None, rflux=None, zflux=None, rfibertotflux=Non
     """
     _check_BGS_targtype(targtype)
 
-    # ADM to maintain backwards-compatibility with mocks.
-    if rfiberflux is None:
-        log.warning('Setting rfiberflux to rflux!!!')
-        rfiberflux = rflux.copy()
-
     # ------ Bright Galaxy Survey
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
@@ -1531,17 +1516,12 @@ def notinBGS_mask(gnobs=None, rnobs=None, znobs=None, primary=None,
 
 
 def isBGS_colors(rfiberflux=None, gflux=None, rflux=None, zflux=None,
-                 w1flux=None, rfibertotflux=None, maskbits=None,
+                 w1flux=None, w2flux=None, rfibertotflux=None, maskbits=None,
                  south=True, targtype=None, primary=None):
     """Standard color-based cuts used by all BGS target selection classes
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
     _check_BGS_targtype(targtype)
-
-    # ADM to maintain backwards-compatibility with mocks.
-    if rfiberflux is None:
-        log.warning('Setting rfiberflux to rflux!!!')
-        rfiberflux = rflux.copy()
 
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')
@@ -1621,11 +1601,6 @@ def isBGS_wise(rfiberflux=None, gflux=None, rflux=None, zflux=None, w1flux=None,
     (see, e.g., :func:`~desitarget.cuts.isBGS` for parameters).
     """
     _check_BGS_targtype(targtype)
-
-    # ADM to maintain backwards-compatibility with mocks.
-    if rfiberflux is None:
-        log.warning('Setting rfiberflux to rflux!!!')
-        rfiberflux = rflux.copy()
 
     if primary is None:
         primary = np.ones_like(rflux, dtype='?')

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -561,8 +561,8 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
 
 
 def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
-                 zfiberflux=None, ggood=None,
-                 w2flux=None, primary=None, south=True):
+                 gfiberflux=None, rfiberflux=None, zfiberflux=None,
+                 ggood=None, w2flux=None, primary=None, south=True):
     """(see, e.g., :func:`~desitarget.cuts.isLRG`).
 
     Notes:
@@ -653,8 +653,9 @@ def notinELG_mask(maskbits=None, gsnr=None, rsnr=None, zsnr=None,
     return elg
 
 
-def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
-                 w2flux=None, gfiberflux=None, south=True, primary=None):
+def isELG_colors(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
+                 gfiberflux=None, rfiberflux=None, zfiberflux=None,
+                 south=True, primary=None):
     """Color cuts for ELG target selection classes
     (see, e.g., :func:`~desitarget.cuts.set_target_bits` for parameters).
     """

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -150,32 +150,30 @@ class TestCuts(unittest.TestCase):
         else:
             primary = np.ones_like(gflux, dtype='?')
 
-        # ADM check for both defined fiberflux and fiberflux of None.
-        for ff in zfiberflux, None:
-            lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
-                              zflux=zflux, w1flux=w1flux, zfiberflux=ff,
-                              gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                              maskbits=maskbits, rfluxivar=rfluxivar,
-                              zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
-                              gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
-            lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux,
-                              zflux=zflux, w1flux=w1flux, zfiberflux=ff,
-                              gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                              maskbits=maskbits, rfluxivar=rfluxivar,
-                              zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
-                              gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
+        lrg1 = cuts.isLRG(primary=primary, gflux=gflux, rflux=rflux,
+                          zflux=zflux, w1flux=w1flux, zfiberflux=zfiberflux,
+                          gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                          maskbits=maskbits, rfluxivar=rfluxivar,
+                          zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
+                          gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
+        lrg2 = cuts.isLRG(primary=None, gflux=gflux, rflux=rflux,
+                          zflux=zflux, w1flux=w1flux, zfiberflux=zfiberflux,
+                          gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                          maskbits=maskbits, rfluxivar=rfluxivar,
+                          zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
+                          gaiagmag=gaiagmag, zfibertotflux=zfibertotflux)
 
-            self.assertTrue(np.all(lrg1 == lrg2))
+        self.assertTrue(np.all(lrg1 == lrg2))
 
-            # ADM check color selections alone work. Tripped us up once
-            # ADM when the mocks called a missing isLRG_colors function.
-            lrg1 = cuts.isLRG_colors(primary=primary, gflux=gflux,
-                                     rflux=rflux, zflux=zflux, zfiberflux=ff,
-                                     w1flux=w1flux, w2flux=w2flux)
-            lrg2 = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux,
-                                     zflux=zflux, zfiberflux=ff,
-                                     w1flux=w1flux, w2flux=w2flux)
-            self.assertTrue(np.all(lrg1 == lrg2))
+        # ADM check color selections alone work. Tripped us up once
+        # ADM when the mocks called a missing isLRG_colors function.
+        lrg1 = cuts.isLRG_colors(primary=primary, gflux=gflux,
+                                 rflux=rflux, zflux=zflux, zfiberflux=zfiberflux,
+                                 w1flux=w1flux, w2flux=w2flux)
+        lrg2 = cuts.isLRG_colors(primary=None, gflux=gflux, rflux=rflux,
+                                 zflux=zflux, zfiberflux=zfiberflux,
+                                 w1flux=w1flux, w2flux=w2flux)
+        self.assertTrue(np.all(lrg1 == lrg2))
 
         elg1, _ = cuts.isELG(gflux=gflux, rflux=rflux, zflux=zflux, gsnr=gsnr,
                              gfiberflux=gfiberflux, rsnr=rsnr, zsnr=zsnr,
@@ -193,23 +191,21 @@ class TestCuts(unittest.TestCase):
                                     gfiberflux=gfiberflux, primary=None)
         self.assertTrue(np.all(elg1 == elg2))
 
-        # ADM check for both defined fiberflux and fiberflux of None.
-        for ff in rfiberflux, None:
-            for targtype in ["bright", "faint", "wise"]:
-                bgs = []
-                for prim in [primary, None]:
-                    bgs.append(
-                        cuts.isBGS(
-                            rfiberflux=ff, gflux=gflux, rflux=rflux,
-                            rfibertotflux=rfibertotflux,
-                            zflux=zflux, w1flux=w1flux, w2flux=w2flux,
-                            gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                            gfluxivar=gfluxivar, rfluxivar=rfluxivar,
-                            zfluxivar=zfluxivar, maskbits=maskbits,
-                            Grr=Grr, w1snr=w1snr, w2snr=w2snr, gaiagmag=gaiagmag,
-                            objtype=objtype, primary=prim, targtype=targtype)
-                    )
-                self.assertTrue(np.all(bgs[0] == bgs[1]))
+        for targtype in ["bright", "faint", "wise"]:
+            bgs = []
+            for prim in [primary, None]:
+                bgs.append(
+                    cuts.isBGS(
+                        rfiberflux=rfiberflux, gflux=gflux, rflux=rflux,
+                        rfibertotflux=rfibertotflux,
+                        zflux=zflux, w1flux=w1flux, w2flux=w2flux,
+                        gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+                        gfluxivar=gfluxivar, rfluxivar=rfluxivar,
+                        zfluxivar=zfluxivar, maskbits=maskbits,
+                        Grr=Grr, w1snr=w1snr, w2snr=w2snr, gaiagmag=gaiagmag,
+                        objtype=objtype, primary=prim, targtype=targtype)
+                )
+            self.assertTrue(np.all(bgs[0] == bgs[1]))
 
         # ADM need to include RELEASE for quasar cuts, at least.
         release = targets['RELEASE']


### PR DESCRIPTION
Our `desisim.templates` code has been broken for some time (see https://github.com/desihub/desisim/issues/553) because `desisim` lagged behind the changes made to `desitarget`.

This PR is the minimal set of changes to get `desisim.templates` working again, although I want to add some additional tests on the `desisim` side (companion PR is forthcoming) so let's not merge yet.