### PR TITLE
A couple of MTL maintenance updates

### DIFF
--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -12,10 +12,10 @@ ap = ArgumentParser(description='Make an initial HEALPixel-split ledger for a Me
 ap.add_argument("obscon",
                 help="String matching ONE obscondition in the bitmask yaml file \
                 (e.g. 'BRIGHT'). Controls priorities when merging targets,      \
-                which tiles to process, etc.")
+                which tiles to process, etc.", choices=["DARK", "BRIGHT", "BACKUP"])
 ap.add_argument("-s", "--survey",
                 help="Flavor of survey to run. Defaults to [{}]".format(survey),
-                default=survey)
+                default=survey, choices=["main", "sv3", "sv2"])
 ap.add_argument('--zcatdir',
                 help="Full path to the directory that hosts the redshift        \
                 catalogs. Default is to use the $ZCAT_DIR environment variable",
@@ -32,6 +32,11 @@ ap.add_argument("--reprocess", action='store_true',
                 help="Run reprocessed tiles (instead of the standard loop)")
 
 ns = ap.parse_args()
+
+if ns.obscon == "BACKUP" and ns.survey == "main":
+    msg = "Updating BACKUP ledgers is not yet supported for the Main Survey!!!"
+    raise RuntimeError(msg)
+    log.error(msg)
 
 scndstates = [False]
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,13 @@ desitarget Change Log
 2.3.1 (unreleased)
 ------------------
 
-* Add optional ``[grz]fiberflux`` arguments to the ``ELG``, ``LRG``, and ``BGS`` 
-  color-cut selection functions to support the `desisim` template-generating
-  code (see `desisim/PR #556`) [`PR #786`].
+* A couple of MTL maintenance updates [`PR #789`_]. Includes:
+    * Turn off BACKUP MTL processing for the Main Survey (for now).
+    * Allow the file format for override ledgers to be forced.
+        * Addresses `issue #784`_.
+* Add optional ``[grz]fiberflux`` arguments to the ``ELG``, ``LRG``, and
+  ``BGS`` color-cut selection functions to support the `desisim`
+  template-generating code (see `desisim/PR #556`_) [`PR #786`_].
 * Extra functionality for splitting randoms by HEALPixel [`PR #785`_]:
     * Correctly process catalogs with an existing ``HPXPIXEL`` column.
 * Functionality to split random catalogs by HEALPixel [`PR #783`_].
@@ -19,7 +23,9 @@ desitarget Change Log
 .. _`PR #783`: https://github.com/desihub/desitarget/pull/783
 .. _`PR #785`: https://github.com/desihub/desitarget/pull/785
 .. _`desisim/PR #556`: https://github.com/desihub/desisim/pull/556
+.. _`issue #784`: https://github.com/desihub/desitarget/issues/784
 .. _`PR #786`: https://github.com/desihub/desitarget/pull/786
+.. _`PR #789`: https://github.com/desihub/desitarget/pull/789
 
 2.3.0 (2021-12-14)
 ------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1449,7 +1449,8 @@ def force_overrides(hpdirname, pixlist):
     # ADM find the general format for the ledger files in `hpdirname`.
     fileform = io.find_mtl_file_format_from_header(hpdirname)
     # ADM this is the format for any associated override ledgers.
-    overrideff = io.find_mtl_file_format_from_header(hpdirname, override=True)
+    overrideff = io.find_mtl_file_format_from_header(hpdirname,
+                                                     forceoverride=True)
 
     # ADM before making updates, check all suggested ledgers exist.
     for pix in pixlist:
@@ -1550,7 +1551,8 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
     # ADM also returning the obsconditions.
     fileform, oc = io.find_mtl_file_format_from_header(hpdirname, returnoc=True)
     # ADM also find the format for any associated override ledgers.
-    overrideff = io.find_mtl_file_format_from_header(hpdirname, override=True)
+    overrideff = io.find_mtl_file_format_from_header(hpdirname,
+                                                     forceoverride=True)
 
     # ADM check the obscondition is as expected.
     if obscon != oc:
@@ -1809,7 +1811,8 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
     # ADM also returning the obsconditions.
     fileform, oc = io.find_mtl_file_format_from_header(hpdirname, returnoc=True)
     # ADM this is the format for any associated override ledgers.
-    overrideff = io.find_mtl_file_format_from_header(hpdirname, override=True)
+    overrideff = io.find_mtl_file_format_from_header(hpdirname,
+                                                     forceoverride=True)
 
     # ADM check the obscondition is as expected.
     if obscon != oc:


### PR DESCRIPTION
This PR includes two MTL updates:
 - Turn off `BACKUP` MTL processing for the Main Survey (for now).
     * We'll turn this back on once the MWS group has finalized any logic changes for MTL for the `BACKUP` program.
 - Allow the file format for override ledgers to be forced (addresses #784).
     * This is achieved by adding a `forceoverride` kwarg to `io.find_mtl_file_format_from_header()` that, if specified, guarantees the filename/directory for override ledgers is returned.
     * That `forceoverride` kwarg is then passed as ``True`` in the necessary places in `mtl.py`. 