### PR TITLE
Better functionality for fiber-based ToOs and ledger overrides

### DIFF
--- a/bin/force_mtl_overrides
+++ b/bin/force_mtl_overrides
@@ -4,26 +4,38 @@ from desitarget.mtl import force_overrides
 from desiutil.log import get_logger
 log = get_logger()
 
+# ADM default survey to run.
+survey = "main"
+
 from argparse import ArgumentParser
 ap = ArgumentParser(description='Force override ledgers to be processed and added to the MTL ledgers without running the full MTL loop.')
-ap.add_argument("hpdirname",
-                help="Full path to a directory containing MTL ledgers that are  \
-                partitioned by HEALPixel (i.e. as made by `make_ledger`). NOTE: \
-                send the directory of the MTL ledgers, NOT the override ledgers")
-ap.add_argument("pixlist",
+ap.add_argument("obscon",
+                help="String matching ONE obscondition in the bitmask yaml file \
+                (e.g. 'BRIGHT'). Controls priorities when merging targets,      \
+                which tiles to process, etc.", choices=["DARK", "BRIGHT", "BACKUP"])
+ap.add_argument("-s", "--survey",
+                help="Flavor of survey to run. Defaults to [{}]".format(survey),
+                default=survey, choices=["main", "sv3", "sv2"])
+ap.add_argument('--mtldir',
+                help="Full path to the directory that hosts the MTL ledgers.    \
+                Default is to use the $MTL_DIR environment variable",
+                default=None)
+ap.add_argument("-sec", "--secondary", action='store_true',
+                help="Pass if overrides are being forced into secondary, rather \
+                than primary ledgers.")
+ap.add_argument("-p", "--pixlist",
                 help="A list of HEALPixels signifying the ledgers to be updated.\
-                Send as a comma-separated string (e.g. 12167,53,455,9)")
+                Send as a comma-separated string (e.g. 12167,53,455,9). The     \
+                default is to run all possible pixels.",
+                default=None)
 
 ns = ap.parse_args()
 
-# ADM a check that we didn't accidentally pass the directory that hosts
-# ADM the override ledgers.
-if "override" in ns.hpdirname:
-    msg = "Did you pass the override directory instead of the MTL directory?"
-    log.warning(msg)
+hpxlist = ns.pixlist
+if ns.pixlist is not None:
+    hpxlist = [ pix for pix in ns.pixlist.split(',') ]
 
-hpxlist = [ pix for pix in ns.pixlist.split(',') ]
-
-outdir = force_overrides(ns.hpdirname, hpxlist)
+outdir = force_overrides(ns.obscon, survey=ns.survey, secondary=ns.secondary,
+                         mtldir=ns.mtldir, pixlist=hpxlist)
 
 log.info("Overrode ledgers in {}".format(outdir))

--- a/bin/force_mtl_overrides
+++ b/bin/force_mtl_overrides
@@ -28,12 +28,20 @@ ap.add_argument("-p", "--pixlist",
                 Send as a comma-separated string (e.g. 12167,53,455,9). The     \
                 default is to run all possible pixels.",
                 default=None)
+ap.add_argument("--test", action="store_true",
+                help="In general, when we force overrides we want to do so for  \
+                all pixels so the Alternate MTLs can do the same. Therefore, to \
+                have a higher bar, this must be passed with pixlist.")
 
 ns = ap.parse_args()
 
 hpxlist = ns.pixlist
 if ns.pixlist is not None:
     hpxlist = [ pix for pix in ns.pixlist.split(',') ]
+    if not ns.test:
+        msg = "Passing a list of pixels is only for testing purposes!!!"
+        log.critical(msg)
+        raise ValueError
 
 outdir = force_overrides(ns.obscon, survey=ns.survey, secondary=ns.secondary,
                          mtldir=ns.mtldir, pixlist=hpxlist)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,20 @@ desitarget Change Log
 2.4.1 (unreleased)
 ------------------
 
+* Better functionality for fiber-based ToOs and overrides [`PR #795`_]:
+    * Append new ToOs to the ledger rather than fully overwriting it.
+    * Create a separate ToO-fiber file for ``TOO_TYPE==FIBER`` targets.
+    * Don't allow high-priority fiber-override ToOs in the Main Survey.
+        * Addresses `issue #794`_.
+    * Create new mtl-done files to log when MTL overrides were forced.
+    * When forcing MTL overrides, always process all ledgers:
+        * This makes reproducibility easier to track for alt MTL ledgers.
 * Added a notebook about running Main Survey targeting [`PR #791`_].
     * To accompany the DESI target selection pipeline paper.
 
 .. _`PR #791`: https://github.com/desihub/desitarget/pull/791
+.. _`issue #794`: https://github.com/desihub/desitarget/issues/794
+.. _`PR #795`: https://github.com/desihub/desitarget/pull/795
 
 2.4.0 (2022-01-20)
 ------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1511,6 +1511,21 @@ def force_overrides(obscon, survey='main', secondary=False, mtldir=None,
             ascii.write(overmtl, f, format='no_header', formats=mtlformatdict)
             f.close()
 
+    # ADM log the overrides version of the "done" file.
+    mtltilefn = os.path.join(mtldir, get_mtl_tile_file_name(secondary=secondary,
+                                                            override=True))
+
+    # ADM initialize the output array and add the tiles.
+    mocktiles = np.zeros(1, dtype=mtltilefiledm.dtype)
+    # ADM look up the time.
+    mocktiles["TIMESTAMP"] = get_utc_date(survey=survey)
+    # ADM add the version of desitarget.
+    mocktiles["VERSION"] = dt_version
+    # ADM add the program/obscon.
+    mocktiles["PROGRAM"] = obscon
+
+    io.write_mtl_tile_file(mtltilefn, mocktiles)
+
     return hpdirname
 
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1429,51 +1429,82 @@ def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
     return outdir
 
 
-def force_overrides(hpdirname, pixlist):
+def force_overrides(obscon, survey='main', secondary=False, mtldir=None,
+                    pixlist=None):
     """
     Force override ledgers to be processed and added to the MTL ledgers.
 
     Parameters
     ----------
-    hpdirname : :class:`str`
-        Full path to a directory containing an MTL ledger that has been
-        partitioned by HEALPixel (i.e. as made by `make_ledger`).
-    pixlist : :class:`list`
+    obscon : :class:`str`
+        A string matching ONE obscondition in the desitarget bitmask yaml
+        file (i.e. in `desitarget.targetmask.obsconditions`), e.g. "DARK"
+        Governs how priorities are set when merging targets.
+    survey : :class:`str`, optional, defaults to "main"
+        Used to look up the correct ledger, in combination with `obscon`.
+        Options are ``'main'`` and ``'svX``' (where X is 1, 2, 3 etc.)
+        for the main survey and different iterations of SV, respectively.
+    secondary : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then force overrides for secondary targets instead of
+        primaries for passed `survey` and `obscon`.
+    mtldir : :class:`str`, optional, defaults to ``None``
+        Full path to the directory that hosts the MTL ledgers and the MTL
+        tile file. If ``None``, then look up the MTL directory from the
+        $MTL_DIR environment variable.
+    pixlist : :class:`list`, optional, defaults to ``None``
         A list of HEALPixels corresponding to the ledgers to be updated.
+        If ``None`` is sent, then all possible ledgers are updated at
+        the default MTL `nside` (which is `_get_mtl_nside()`).
 
     Returns
     -------
     :class:`str`
         The directory containing the ledgers that were updated.
     """
+    # ADM first construct the directory name for ledgers.
+    # ADM grab the MTL directory (in case we're relying on $MTL_DIR).
+    mtldir = get_mtl_dir(mtldir)
+    # ADM construct the relevant sub-directory for this survey and
+    # ADM set of observing conditions..
+    resolve = True
+    msg = "running on {} ledger with obscon={} and survey={}"
+    if secondary:
+        log.info(msg.format("SECONDARY", obscon, survey))
+        resolve = None
+    else:
+        log.info(msg.format("PRIMARY", obscon, survey))
+    hpdirname = io.find_target_files(mtldir, flavor="mtl", resolve=resolve,
+                                     survey=survey, obscon=obscon)
+
     # ADM find the general format for the ledger files in `hpdirname`.
     fileform = io.find_mtl_file_format_from_header(hpdirname)
     # ADM this is the format for any associated override ledgers.
     overrideff = io.find_mtl_file_format_from_header(hpdirname,
                                                      forceoverride=True)
 
-    # ADM before making updates, check all suggested ledgers exist.
-    for pix in pixlist:
-        overfn = overrideff.format(pix)
-        fn = fileform.format(pix)
-        for f in overfn, fn:
-            if not os.path.exists(f):
-                msg = "no ledger exists at: {}".format(f)
-                log.error(msg)
-                raise OSError
+    # ADM default to running all pixels.
+    if pixlist is None:
+        pixlist = np.arange(hp.nside2npix(_get_mtl_nside()))
 
+    # ADM force in the overrides for every pixel. Where a ledger doesn't
+    # ADM exist, warn and take no action.
     for pix in pixlist:
         # ADM the correct filenames for this pixel number.
         fn = fileform.format(pix)
         overfn = overrideff.format(pix)
 
-        # ADM update override ledger and recover relevant MTL entries.
-        overmtl = process_overrides(overfn)
-
-        # ADM append override entries to the ledger.
-        f = open(fn, "a")
-        ascii.write(overmtl, f, format='no_header', formats=mtlformatdict)
-        f.close()
+        # ADM to check the files exist.
+        files_exist = os.path.exists(fn) and os.path.exists(overfn)
+        if not files_exist:
+            msg = "no ledger exists at either: {} or {}".format(fn, overfn)
+            log.warning(msg)
+        else:
+            # ADM update override ledger and recover relevant MTL entries.
+            overmtl = process_overrides(overfn)
+            # ADM append override entries to the ledger.
+            f = open(fn, "a")
+            ascii.write(overmtl, f, format='no_header', formats=mtlformatdict)
+            f.close()
 
     return hpdirname
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -332,7 +332,7 @@ def get_zcat_dir(zcatdir=None):
     return zcatdir
 
 
-def get_mtl_tile_file_name(secondary=False):
+def get_mtl_tile_file_name(secondary=False, override=False):
     """Convenience function to grab the name of the MTL tile file.
 
     Parameters
@@ -340,6 +340,9 @@ def get_mtl_tile_file_name(secondary=False):
     secondary : :class:`bool`, optional, defaults to ``False``
         If ``True`` return the name of the MTL tile file for secondary
         targets instead of the standard, primary MTL tile file.
+    override : :class:`bool`, optional, defaults to ``False``
+        If ``True`` return the name of the override tile file instead
+        of the mtl tile file.
 
     Returns
     -------
@@ -349,6 +352,8 @@ def get_mtl_tile_file_name(secondary=False):
     fn = "mtl-done-tiles.ecsv"
     if secondary:
         fn = "scnd-mtl-done-tiles.ecsv"
+    if override:
+        fn = fn.replace("tiles", "overrides")
 
     return fn
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1517,7 +1517,9 @@ def force_overrides(obscon, survey='main', secondary=False, mtldir=None,
 
     # ADM initialize the output array and add the tiles.
     mocktiles = np.zeros(1, dtype=mtltilefiledm.dtype)
-    # ADM look up the time.
+    # ADM look up the time. Remember to delay so done-time is later than
+    # ADM any ledger-time.
+    sleep(1)
     mocktiles["TIMESTAMP"] = get_utc_date(survey=survey)
     # ADM add the version of desitarget.
     mocktiles["VERSION"] = dt_version


### PR DESCRIPTION
This PR updates how ToOs with `TOO_TYPE=="FIBER"` are handled. It also adds some new functionality for the override ledgers that we use to modify targets that are already in the MTL ledgers. 

Updates to the ToO functionality include:

- New ToOs are now appended to the ledger rather than fully overwriting it. 
  * This preserves `TIMESTAMP`s for earlier ToOs.
- A separate `ToO-fiber.ecsv` file is now created for `TOO_TYPE==FIBER` ToOs. 
  * We'll retain the `ToO.ecsv` file for backwards-compatibility. 
  * The `ToO.ecsv` file will include all of the ToO observations to-date in the Main Survey, which have solely been `TOO_TYPE==TILE` observations. 
  * It's likely, in the future, that any `TOO_TYPE=TILE` observations will be scheduled through the more-flexible tertiary process.
- `TOO_PRIO==HI` observations are now forbidden for `TOO_TYPE==FIBER` ToOs in the Main Survey.
   * This addresses #794.

Updates to the override-ledger functionality include:

- New tracking files called `scnd-mtl-done-overrides.ecsv` and `mtl-done-overrides.ecsv` are now created/updated when  target states are forced into the MTL ledgers using the override process.
  * These resemble the more familiar `scnd-mtl-done-tiles.ecsv` and `mtl-done-tiles.ecsv` files, but have zeroed-out tile-based information (as when we force override information into the MTL ledgers, we don't use any tile-based redshifts).
  * These `done-overrides` files can be used by the alt MTLs to determine when forced overrides occurred, if needed.
- When forcing MTL overrides, we always process all of the ledgers, not just new overrides.
  * This is quick and harmless, but makes it easier for the alt MTLs to reproduce the process.