### PR TITLE
Functionality to download and reformat files for Gaia DR3

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 2.5.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Functionality to download and reformat files for Gaia DR3 [`PR #796`_]
+
+.. _`PR #796`: https://github.com/desihub/desitarget/pull/796
 
 2.5.0 (2022-04-22)
 ------------------

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -107,11 +107,11 @@ def check_gaia_survey(dr):
     Parameters
     ----------
     dr : :class:`str`
-        Name of a Gaia data release. Options are "dr2", "edr3". If one of
-        those options isn't passed, a ValueError is raised.
+        Name of a Gaia data release. Options are "dr2", "edr3", "dr3". If
+        one of those options isn't passed, a ValueError is raised.
     """
     # ADM allowed Data Releases for input.
-    droptions = ["dr2", "edr3"]
+    droptions = ["dr2", "edr3", "dr3"]
     if dr not in droptions:
         msg = "input dr must be one of {}".format(droptions)
         log.critical(msg)
@@ -124,7 +124,7 @@ def get_gaia_dir(dr="dr2"):
     Parameters
     ----------
     dr : :class:`str`, optional, defaults to "dr2"
-        Name of a Gaia data release. Options are "dr2", "edr3"
+        Name of a Gaia data release. Options are "dr2", "edr3", "dr3"
 
     Returns
     -------
@@ -418,7 +418,7 @@ def scrape_gaia(dr="dr2", nfiletest=None):
     Parameters
     ----------
     dr : :class:`str`, optional, defaults to "dr2"
-        Name of a Gaia data release. Options are "dr2", "edr3"
+        Name of a Gaia data release. Options are "dr2", "edr3", "dr3"
     nfiletest : :class:`int`, optional, defaults to ``None``
         If an integer is sent, only retrieve this number of files, for testing.
 
@@ -438,7 +438,8 @@ def scrape_gaia(dr="dr2", nfiletest=None):
     gaiadir = get_gaia_dir(dr)
 
     gdict = {"dr2": "http://cdn.gea.esac.esa.int/Gaia/gdr2/gaia_source/csv/",
-             "edr3": "http://cdn.gea.esac.esa.int/Gaia/gedr3/gaia_source/"}
+             "edr3": "http://cdn.gea.esac.esa.int/Gaia/gedr3/gaia_source/",
+             "dr3": "http://cdn.gea.esac.esa.int/Gaia/gdr3/gaia_source/"}
     url = gdict[dr]
 
     # ADM construct the directory to which to write files.
@@ -475,7 +476,7 @@ def scrape_gaia(dr="dr2", nfiletest=None):
         cmd = 'wget -q {}/GaiaSource{} -P {}'.format(url, fileinfo[:-2], csvdir)
         os.system(cmd)
         nfil = nfile + 1
-        if nfil % stepper == 0 or test:
+        if test or nfil % stepper == 0:
             elapsed = time() - t0
             rate = nfil / elapsed
             log.info(

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -612,7 +612,8 @@ def gaia_csv_to_fits(dr="dr2", numproc=32):
             else:
                 # ADM as of dr3, Gaia writes empty columns as "null".
                 if dr != "dr2" and dr != "edr3":
-                    ii = fitstable[col.lower()] == "null"
+                    ii = np.array([val == "null"
+                                   for val in fitstable[col.lower()]])
                     fitstable[col.lower()][ii] = 0
                 done[col] = fitstable[col.lower()]
         fitsio.write(outfile, done, extname='GAIAFITS')

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -542,6 +542,11 @@ def hpx_pickle_from_fits(dr="dr2"):
         nested scheme HEALPixel and each entry is a list of the FITS
         files that touch that HEALPixel is written to
         $GAIA_DIR/fits/hpx-to-files.pickle.
+
+    Notes
+    -----
+        - The environment variable $GAIA_DIR must be set.
+        - Runs in ~25 minutes for 3,386 Gaia DR3 files.
     """
     # ADM the resolution at which the Gaia HEALPix files should be stored.
     nside = _get_gaia_nside()
@@ -765,8 +770,9 @@ def gaia_fits_to_healpix(dr="dr2", numproc=32):
     Parameters
     ----------
     dr : :class:`str`, optional, defaults to "dr2"
-        Name of a Gaia data release. Options are "dr2", "edr3". For
-        "edr3" the directory used is actually $GAIA_DIR/../gaia_edr3
+        Name of a Gaia data release. Options are "dr2", "edr3", "dr3".
+        For "edr3" the directory used is actually $GAIA_DIR/../gaia_edr3
+        For "dr3" the directory used is actually $GAIA_DIR/../gaia_dr3
     numproc : :class:`int`, optional, defaults to 32
         The number of parallel processes to use.
 
@@ -785,6 +791,7 @@ def gaia_fits_to_healpix(dr="dr2", numproc=32):
         - if numproc==1, use the serial code instead of the parallel code.
         - Runs in 1-2 hours with numproc=32 for 61,234 Gaia DR2 files.
         - Runs in ~15 minutes with numproc=32 for 3,386 Gaia EDR3 files.
+        - Runs in ~20 minutes with numproc=32 for 3,386 Gaia DR3 files.
     """
     # ADM the resolution at which the Gaia HEALPix files should be stored.
     nside = _get_gaia_nside()


### PR DESCRIPTION
This PR augments existing functionality to download Gaia files (DR2/EDR3) to add Gaia DR3. Changes are fairly minimal, and are mostly to handle new Gaia syntax, so I'll self-merge in a day or two.

The only major addition is an option to "mop up" files when converting between the scraped Gaia csv files and FITS files (in the `gaia_csv_to_fits()` function). It's now possible to run that conversion piecemeal, which is convenient as it takes a little over 4 hours on an interactive node to process all of the Gaia DR3 files.