### PR TITLE
Remove deprecated np.int and np.float dependencies

### DIFF
--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -8,7 +8,7 @@ log = get_logger()
 survey = "main"
 
 from argparse import ArgumentParser
-ap = ArgumentParser(description='Make an initial HEALPixel-split ledger for a Merged Target List based on a directory of targets')
+ap = ArgumentParser(description='Update ledgers for the Merged Target based on new spectroscopic observations')
 ap.add_argument("obscon",
                 help="String matching ONE obscondition in the bitmask yaml file \
                 (e.g. 'BRIGHT'). Controls priorities when merging targets,      \

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ desitarget Change Log
 2.5.1 (unreleased)
 ------------------
 
+* Address deprecated np.int and np.float dependencies [`PR #797`_]
 * Functionality to download and reformat files for Gaia DR3 [`PR #796`_]
 
 .. _`PR #796`: https://github.com/desihub/desitarget/pull/796
+.. _`PR #797`: https://github.com/desihub/desitarget/pull/797
 
 2.5.0 (2022-04-22)
 ------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2201,7 +2201,7 @@ def _prepare_gaia(objects, colnames=None):
     Grr = gaiagmag - 22.5 + 2.5*np.log10(1e-16)
     ii = objects['FLUX_R'] > 0
     # ADM catch the case where Grr is a scalar.
-    if isinstance(Grr, np.float):
+    if isinstance(Grr, float):
         if ii:
             Grr = gaiagmag - 22.5 + 2.5*np.log10(objects['FLUX_R'])
     else:

--- a/py/desitarget/mock/build.py
+++ b/py/desitarget/mock/build.py
@@ -394,7 +394,7 @@ def density_fluctuations(data, log, nside, nside_chunk, seed=None):
     areaperpixel = hp.nside2pixarea(nside, degrees=True)
     areaperchunk = hp.nside2pixarea(nside_chunk, degrees=True)
 
-    nchunk = 4**np.int(np.log2(nside_chunk) - np.log2(nside))
+    nchunk = 4**int(np.log2(nside_chunk) - np.log2(nside))
     log.info('Dividing each nside={} healpixel ({:.2f} deg2) into {} nside={} healpixel(s) ({:.2f} deg2).'.format(
         nside, areaperpixel, nchunk, nside_chunk, areaperchunk))
 

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1205,11 +1205,6 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
     # ADM change target column names, and retrieve associated survey information.
     _, Mx, survey, targets = main_cmx_or_sv(targets, rename=True)
 
-    # ADM determine the areal coverage of the randoms at this nside.
-    log.info('Determining footprint...t = {:.1f}s'.format(time()-start))
-    pw = pixweight(randoms, rand_density, nside=nside)
-    npix = len(pw)
-
     # ADM areal coverage for some combinations of MASKBITS.
     mbcomb = []
     mbstore = []
@@ -1222,6 +1217,7 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
         mbstore.append(pixweight(randoms, rand_density,
                                  nside=nside, maskbits=bitint))
 
+    # ADM determine the areal coverage of the randoms at this nside.
     log.info('Determining footprint...t = {:.1f}s'.format(time()-start))
     pw = pixweight(randoms, rand_density, nside=nside)
     npix = len(pw)


### PR DESCRIPTION
This PR addresses #790 (as well as fixing another couple of minor issues).

Sorry this took so long, I was expecting to need to update many occurrences of `np.int` and `np.float` and hadn't realized there were only a few.

TMI: The code I ran to check my casting choices were correct for the specific examples mentioned in #790 was:
```
Grr1 = 45.6
Grr2 = np.array([45.6])
Grr3 = np.array([45.6, 65.7])

for Grr in [Grr1, Grr2, Grr3]:
    print(Grr, isinstance(Grr, np.float))

<ipython-input-12-f43a48c0ecf8>:2: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To sile
nce this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted
 the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecation
s
  print(Grr, isinstance(Grr, np.float))

45.6 True
[45.6] False
[45.6 65.7] False

for Grr in [Grr1, Grr2, Grr3]:
    print(Grr, isinstance(Grr, float))

45.6 True
[45.6] False
[45.6 65.7] False

for Grr in [Grr1, Grr2, Grr3]:
    print(Grr, isinstance(Grr, np.float64))

45.6 False
[45.6] False
[45.6 65.7] False
```

and

```
nside_chunk1, nside1 = np.array([32, 32, 64]), np.array([16, 8, 16])
nside_chunk2, nside2 = np.array([32]), np.array([16])
nside_chunk3, nside3 = 32, 16
for nside_chunk, nside in zip([nside_chunk1, nside_chunk2, nside_chunk3], [nside1, nside2, nside3]):
    try:
        nchunk = 4**np.int(np.log2(nside_chunk) - np.log2(nside))
        print(nside_chunk, nchunk)
    except TypeError:
        print("Casting {} and {} wasn't possible anyway".format(nside_chunk, nside))

<ipython-input-4-9ca0a781b651>:6: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  nchunk = 4**np.int(np.log2(nside_chunk) - np.log2(nside))
Casting [32 32 64] and [16  8 16] wasn't possible anyway
[32] 4
32 4

nside_chunk1, nside1 = np.array([32, 32, 64]), np.array([16, 8, 16])
nside_chunk2, nside2 = np.array([32]), np.array([16])
nside_chunk3, nside3 = 32, 16
for nside_chunk, nside in zip([nside_chunk1, nside_chunk2, nside_chunk3], [nside1, nside2, nside3]):
    try:
        nchunk = 4**int(np.log2(nside_chunk) - np.log2(nside))
        print(nside_chunk, nchunk)
    except TypeError:
        print("Casting {} and {} wasn't possible anyway".format(nside_chunk, nside))

Casting [32 32 64] and [16  8 16] wasn't possible anyway
[32] 4
32 4
```
