### PR TITLE
Run random catalogs for DR10 of the Legacy Surveys

### DIFF
--- a/bin/add_to_override_ledgers
+++ b/bin/add_to_override_ledgers
@@ -38,7 +38,7 @@ ap.add_argument('--mtldir',
                 default=None)
 ap.add_argument("-s", "--secondary", action='store_true',
                 help="Process secondary targets instead of primaries")
-ap.add_argument("-n", "--numoverride",
+ap.add_argument("-n", "--numoverride", type=int,
                 help="The override ledger is read each time the MTL loop is run.\
                 This is the number of times to override the standard results in \
                 the MTL loop. Defaults to {}".format(numoverride),

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,13 +5,16 @@ desitarget Change Log
 2.5.1 (unreleased)
 ------------------
 
+* Updates to run random catalogs for Legacy Surveys DR10 [`PR #800`_].
+    * Also stop applying override ledgers once ``NUMOVERRIDE`` is zero.
+* Restore coverage for svX code [`PR #799`_].
 * Address deprecated np.int and np.float dependencies [`PR #797`_].
 * Functionality to download and reformat files for Gaia DR3 [`PR #796`_].
-* Restore coverage for svX code [`PR #799`_].
 
 .. _`PR #796`: https://github.com/desihub/desitarget/pull/796
 .. _`PR #797`: https://github.com/desihub/desitarget/pull/797
 .. _`PR #799`: https://github.com/desihub/desitarget/pull/799
+.. _`PR #800`: https://github.com/desihub/desitarget/pull/800
 
 2.5.0 (2022-04-22)
 ------------------

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -942,7 +942,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     print('')
 
     # ADM extract the Data Release number from the survey directory
-    dr = surveydir.split('dr')[-1][0]
+    dr = surveydir.split("dr")[1].split(os.path.sep)[0]
     # ADM if an integer can't be extracted, use X instead.
     try:
         drstr = "-dr{}".format(int(dr))

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -942,7 +942,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     print('')
 
     # ADM extract the Data Release number from the survey directory
-    dr = surveydir.split("dr")[1].split(os.path.sep)[0]
+    dr = surveydir.split("dr")[-1].split(os.path.sep)[0]
     # ADM if an integer can't be extracted, use X instead.
     try:
         drstr = "-dr{}".format(int(dr))

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -1612,7 +1612,7 @@ def write_randoms(targdir, data, indir=None, hdr=None, nside=None, supp=False,
             depend.setdep(hdr, 'input-data-release', indir)
         # ADM use input directory to (try to) determine the Data Release.
         try:
-            drint = int(indir.split("dr")[1][0])
+            drint = int(indir.split("dr")[1].split(os.path.sep)[0])
             drstring = 'dr'+str(drint)
             depend.setdep(hdr, 'photcat', drstring)
         except (ValueError, IndexError, AttributeError):

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1270,13 +1270,18 @@ def process_overrides(ledgerfn):
       be NUMOVERRIDE - 1, TIMESTAMP updated to now, the second part of
       TARGET_STATE updated to OVERRIDE, the git VERSION updated, and the
       ZTILEID updated to -1.
+    - Will only update entries for which NUMOVERRIDE > 0.
     """
     log.info("Processing override ledgers")
 
     # ADM read in the relevant entries in the override ledger.
     mtl = Table(io.read_mtl_ledger(ledgerfn))
 
-    # ADM indicate that we've already overrode once.
+    # ADM limit to entries with NUMOVERRIDE > 0.
+    ii = mtl["NUMOVERRIDE"] > 0
+    mtl = mtl[ii]
+
+    # ADM indicate that we've overrode.
     mtl["NUMOVERRIDE"] -= 1
 
     # ADM update the standard information for override ledgers.

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -5,6 +5,8 @@ desitarget.randoms
 ==================
 
 Monte Carlo Legacy Surveys imaging at the pixel level to model the imaging footprint
+
+.. _`Legacy Surveys bitmasks`: https://www.legacysurvey.org/dr9/bitmasks/
 """
 import os
 import numpy as np
@@ -481,7 +483,7 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
     fileform = os.path.join(rootdir, 'legacysurvey-{}-{}-{}.fits.{}')
     # ADM loop through the filters and store the number of observations
     # ADM etc. at the RA and Dec positions of the passed points.
-    for filt in ['g', 'r', 'z']:
+    for filt in ['g', 'r', 'i', 'z']:
         # ADM the input file labels, and output column names and output
         # ADM formats for each of the quantities of interest.
         qnames = zip(['nexp', 'depth', 'galdepth', 'psfsize', 'image'],
@@ -792,35 +794,32 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
             Passed brick name.
         RA, DEC:
             Right Ascension, Declination of a random location.
-        NOBS_G, R, Z:
+        NOBS_G, R, I, Z:
             Number of observations in g, r, z-band.
-        PSFDEPTH_G, R, Z:
+        PSFDEPTH_G, R, I, Z:
             PSF depth at this location in g, r, z.
-        GALDEPTH_G, R, Z:
+        GALDEPTH_G, R, I, Z:
             Galaxy depth in g, r, z.
         PSFDEPTH_W1, W2:
             (PSF) depth in W1, W2 (AB mag system).
-        PSFSIZE_G, R, Z:
+        PSFSIZE_G, R, I, Z:
             Weighted average PSF FWHM (arcsec).
-        APFLUX_G, R, Z:
+        APFLUX_G, R, I, Z:
             Sky background extracted in `aprad`.
             Will be zero if `aprad` < 1e-8 is passed.
-        APFLUX_IVAR_G, R, Z:
+        APFLUX_IVAR_G, R, I, Z:
             Inverse variance of sky background.
             Will be zero if `aprad` < 1e-8 is passed.
         MASKBITS:
-            Mask information. See header of extension 1 of *e.g.*
-            ``coadd/132/1320p317/legacysurvey-1320p317-maskbits.fits.fz``
+            Mask information. See, e.g. the `Legacy Surveys bitmasks`_.
         WISEMASK_W1:
-            Mask information. See header of extension 2 of *e.g.*
-            ``coadd/132/1320p317/legacysurvey-1320p317-maskbits.fits.fz``
+            Mask information. See, e.g. the `Legacy Surveys bitmasks`_.
         WISEMASK_W2:
-            Mask information. See header of extension 3 of *e.g.*
-            ``coadd/132/1320p317/legacysurvey-1320p317-maskbits.fits.fz``
+            Mask information. See, e.g. the `Legacy Surveys bitmasks`_.
         EBV:
             E(B-V) at this location from the SFD dust maps.
         PHOTSYS:
-            resolved north/south ('N' for an MzLS/BASS location,
+            Resolved north/south ('N' for an MzLS/BASS location,
             'S' for a DECaLS location).
     """
     # ADM only intended to work on one brick, so die for larger arrays.
@@ -852,21 +851,21 @@ def get_quantities_in_a_brick(ramin, ramax, decmin, decmax, brickname,
             len(ras),
             dtype=[('RELEASE', '>i2'), ('BRICKID', '>i4'), ('BRICKNAME', 'S8'),
                    ('OBJID', '>i4'), ('RA', '>f8'), ('DEC', 'f8'),
-                   ('NOBS_G', 'i2'), ('NOBS_R', 'i2'), ('NOBS_Z', 'i2'),
-                   ('PSFDEPTH_G', 'f4'), ('PSFDEPTH_R', 'f4'), ('PSFDEPTH_Z', 'f4'),
-                   ('GALDEPTH_G', 'f4'), ('GALDEPTH_R', 'f4'), ('GALDEPTH_Z', 'f4'),
+                   ('NOBS_G', 'i2'), ('NOBS_R', 'i2'), ('NOBS_I', 'i2'), ('NOBS_Z', 'i2'),
+                   ('PSFDEPTH_G', 'f4'), ('PSFDEPTH_R', 'f4'), ('PSFDEPTH_I', 'f4'), ('PSFDEPTH_Z', 'f4'),
+                   ('GALDEPTH_G', 'f4'), ('GALDEPTH_R', 'f4'), ('GALDEPTH_I', 'f4'), ('GALDEPTH_Z', 'f4'),
                    ('PSFDEPTH_W1', 'f4'), ('PSFDEPTH_W2', 'f4'),
-                   ('PSFSIZE_G', 'f4'), ('PSFSIZE_R', 'f4'), ('PSFSIZE_Z', 'f4'),
-                   ('APFLUX_G', 'f4'), ('APFLUX_R', 'f4'), ('APFLUX_Z', 'f4'),
-                   ('APFLUX_IVAR_G', 'f4'), ('APFLUX_IVAR_R', 'f4'), ('APFLUX_IVAR_Z', 'f4'),
-                   ('MASKBITS', 'i2'), ('WISEMASK_W1', '|u1'), ('WISEMASK_W2', '|u1'),
+                   ('PSFSIZE_G', 'f4'), ('PSFSIZE_R', 'f4'), ('PSFSIZE_I', 'f4'), ('PSFSIZE_Z', 'f4'),
+                   ('APFLUX_G', 'f4'), ('APFLUX_R', 'f4'), ('APFLUX_I', 'f4'), ('APFLUX_Z', 'f4'),
+                   ('APFLUX_IVAR_G', 'f4'), ('APFLUX_IVAR_R', 'f4'), ('APFLUX_IVAR_I', 'f4'), ('APFLUX_IVAR_Z', 'f4'),
+                   ('MASKBITS', 'i4'), ('WISEMASK_W1', '|u1'), ('WISEMASK_W2', '|u1'),
                    ('EBV', 'f4'), ('PHOTSYS', '|S1')]
         )
     else:
         qinfo = np.zeros(
             len(ras),
             dtype=[('BRICKID', '>i4'), ('BRICKNAME', 'S8'), ('RA', 'f8'), ('DEC', 'f8'),
-                   ('NOBS_G', 'i2'), ('NOBS_R', 'i2'), ('NOBS_Z', 'i2'),
+                   ('NOBS_G', 'i2'), ('NOBS_R', 'i2'), ('NOBS_I', 'i2'), ('NOBS_Z', 'i2'),
                    ('EBV', 'f4')]
         )
 


### PR DESCRIPTION
This PR makes minor updates to the infrastructure for running random catalogs in preparation for DR10 of the Legacy Surveys. This PR also fixes a minor bug to ensure that overrides stop being applied to the MTL ledgers once the `NUMOVERRIDE` count has dropped to zero.

This is work-in-progress until the data model for DR10 of the Legacy Surveys is final.