### PR TITLE
Minor updates to allow targets to be processed for Legacy Surveys DR10

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,13 @@ desitarget Change Log
 2.6.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Updates to run targets for Legacy Surveys DR10 [`PR #801`_]. Includes:
+    * Add `RELEASE` number of `10000` (a "southern" release).
+    * DR10 has `REF_CAT == 'GE'` for Gaia EDR3 instead of `'G2`.
+    * Update data model to reflect altered columns in DR10.
+    * Parse both `drXX` and `drX` strings in output filenames.
+
+.. _`PR #801`: https://github.com/desihub/desitarget/pull/801
 
 2.6.0 (2022-12-08)
 ------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2171,6 +2171,8 @@ def _prepare_gaia(objects, colnames=None):
     gaia = objects['REF_ID'] > 0
     if "REF_CAT" in colnames:
         gaia = (objects['REF_CAT'] == b'G2') | (objects['REF_CAT'] == 'G2')
+        # ADM as of DR10, we use Gaia EDR3 rather than DR2.
+        gaia |= (objects['REF_CAT'] == b'GE') | (objects['REF_CAT'] == 'GE')
     pmra = objects['PMRA']
     pmdec = objects['PMDEC']
     pmraivar = objects['PMRA_IVAR']


### PR DESCRIPTION
This PR facilitates running the target selection algorithms on DR10 of the Legacy Surveys imaging. 

We're unlikely to ever formally release targets based on DR10, but processing DR10 targets can be useful for secondary/tertiary programs, to study targets outside of the DR9 imaging footprint, or to compare results for DR9 and DR10.