### PR TITLE
Fix bug where data types are altered when override MTLs are empty

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 2.6.1 (unreleased)
 ------------------
 
-* Fix bug where empty override MTLs can alter data types [`PR #802`_].
+* Fix bug where empty override MTLs can alter data types [`PR #803`_].
 * Updates to run targets for Legacy Surveys DR10 [`PR #801`_]. Includes:
     * Add `RELEASE` number of `10000` (a "southern" release).
     * DR10 has `REF_CAT == 'GE'` for Gaia EDR3 instead of `'G2`.
@@ -13,7 +13,7 @@ desitarget Change Log
     * Parse both `drXX` and `drX` strings in output filenames.
 
 .. _`PR #801`: https://github.com/desihub/desitarget/pull/801
-.. _`PR #802`: https://github.com/desihub/desitarget/pull/802
+.. _`PR #803`: https://github.com/desihub/desitarget/pull/803
 
 2.6.0 (2022-12-08)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 2.6.1 (unreleased)
 ------------------
 
+* Fix bug where empty override MTLs can alter data types [`PR #802`_].
 * Updates to run targets for Legacy Surveys DR10 [`PR #801`_]. Includes:
     * Add `RELEASE` number of `10000` (a "southern" release).
     * DR10 has `REF_CAT == 'GE'` for Gaia EDR3 instead of `'G2`.
@@ -12,6 +13,7 @@ desitarget Change Log
     * Parse both `drXX` and `drX` strings in output filenames.
 
 .. _`PR #801`: https://github.com/desihub/desitarget/pull/801
+.. _`PR #802`: https://github.com/desihub/desitarget/pull/802
 
 2.6.0 (2022-12-08)
 ------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1239,11 +1239,13 @@ def standard_override_columns(mtl):
         TARGET_STATE updated to be OVERRIDE, the git VERSION updated, and
         ZTILEID set to -1.
     """
-    mtl["TIMESTAMP"] = get_utc_date(survey="main")
-    newts = ["{}|OVERRIDE".format(t.split("|")[0]) for t in mtl["TARGET_STATE"]]
-    mtl["TARGET_STATE"] = np.array(newts)
-    mtl["VERSION"] = dt_version
-    mtl["ZTILEID"] = -1
+    # ADM this ensures that data types are not altered for empty arrays.
+    if len(mtl) > 0:
+        mtl["TIMESTAMP"] = get_utc_date(survey="main")
+        newts = ["{}|OVERRIDE".format(t.split("|")[0]) for t in mtl["TARGET_STATE"]]
+        mtl["TARGET_STATE"] = np.array(newts)
+        mtl["VERSION"] = dt_version
+        mtl["ZTILEID"] = -1
 
     return mtl
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ healpy
 speclite
 sqlalchemy
 fitsio
-photutils
+photutils=1.6.0
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
 git+https://github.com/desihub/specter.git@0.10.0#egg=specter

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ healpy
 speclite
 sqlalchemy
 fitsio
-photutils=1.6.0
+photutils==1.6.0
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
 git+https://github.com/desihub/specter.git@0.10.0#egg=specter


### PR DESCRIPTION
This PR fixes a bug introduced when incorporating the MTL "override" ledgers into reprocessing.

When an override ledger didn't exist, or was otherwise empty, the data types for some columns were updated to standard types for an empty numpy array. This could then conflict with the data types for an overall ledger. 

The fix is to never use standardized column updates for empty override ledgers.