### PR TITLE
Ensure io.read_targets_in_hp() always returns targets in a reproducible order

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 2.6.2 (unreleased)
 ------------------
 
-No changes yet.
+* Reproducible output from :func:`io.read_targets_in_hp()` [`PR #806`_].
+
+.. _`PR #806`: https://github.com/desihub/desitarget/pull/806
 
 2.6.1 (2023-08-23)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -3345,7 +3345,7 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None, header=False,
         filepixlist = filepixlist[isindict]
 
         # ADM make sure each file is only read once.
-        infiles = set([filedict[pix] for pix in filepixlist])
+        infiles = sorted(set([filedict[pix] for pix in filepixlist]))
 
         # ADM read in the files and concatenate the resulting targets.
         targets = []


### PR DESCRIPTION
Anand noticed that a small number of skies could have discrepant `TARGETID`s in different realizations of the sky location files produced by versions `1.1.0` and `1.1.1` of the `desitarget` code. This was caused by a somewhat convoluted bug:

- The discrepancies correspond to `BAD_SKY` sky locations that have been flagged by the masking routine because they are near a bright star (`NEAR_BRIGHT_OBJECT`).
- The masking routine, it turns out, assigns an `OBJID` (`BRICK_OBJID`) on the basis of the order in which a target is matched to a mask.
- This `OBJID` propagates into the `TARGETID` in the usual way.
- The _actual bug_ is that the masks are not always read in the exact-same order. If the masks are read in a different order, then the targets are matched in a different order, which produces a different `OBJID`, which produces a different `TARGETID`.
- The culprit that causes the masks to be read in a different order is [this line of code](https://github.com/desihub/desitarget/blob/2.6.0/py/desitarget/io.py#L3335) in `io.read_targets_in_hp()`.
- The `set` in `infiles = set([filedict[pix] for pix in filepixlist])` is unordered, potentially changing the order in which targets/masks are read in a non-reproducible fashion.

This PR resolves this bug by sorting the problematic set.

This PR is likely to be non-controversial. Sorting the set will potentially change the order of output targets/masks, but these were unordered anyway. I'll merge in a few days.

