### PR TITLE
Add check to run_mtl_loop that archived directories match the tiles-specstatus file

### DIFF
--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -41,7 +41,8 @@ if ns.obscon == "BACKUP" and ns.survey == "main":
     log.error(msg)
 
 if not ns.noarchivecheck:
-    check_archiving(zcatdir=ns.zcatdir, mtldir=ns.mtldir)
+    check_archiving(ns.obscon, survey=ns.survey, zcatdir=ns.zcatdir,
+                    mtldir=ns.mtldir)
 
 scndstates = [False]
 

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from desitarget.mtl import loop_ledger
+from desitarget.mtl import loop_ledger, check_archiving
 from desiutil.log import get_logger
 log = get_logger()
 
@@ -30,6 +30,8 @@ ap.add_argument("-nosec", "--nosecondary", action='store_true',
                 there are no secondaries to process")
 ap.add_argument("--reprocess", action='store_true',
                 help="Run reprocessed tiles (instead of the standard loop)")
+ap.add_argument("--noarchivecheck", action='store_true',
+                help="Do NOT check if tiles-specstatus and archived tiles match")
 
 ns = ap.parse_args()
 
@@ -37,6 +39,9 @@ if ns.obscon == "BACKUP" and ns.survey == "main":
     msg = "Updating BACKUP ledgers is not yet supported for the Main Survey!!!"
     raise RuntimeError(msg)
     log.error(msg)
+
+if not ns.noarchivecheck:
+    check_archiving(zcatdir=ns.zcatdir, mtldir=ns.mtldir)
 
 scndstates = [False]
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desitarget Change Log
 ------------------
 
 * Add check that archived tiles match tiles-specstatus file [`PR #808`_].
+* Reproducible output from :func:`io.read_targets_in_hp()` [`PR #806`_].
 * Option to read subset of columns from HEALPix-split MTLs [`PR #805`_].
     * Specifically in :func:`io.read_mtl_in_hp()`.
     * Addresses `issue #802`_.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 2.6.2 (unreleased)
 ------------------
 
-* Reproducible output from :func:`io.read_targets_in_hp()` [`PR #806`_].
+* Add check that archived tiles match tiles-specstatus file [`PR #808`_].
 * Option to read subset of columns from HEALPix-split MTLs [`PR #805`_].
     * Specifically in :func:`io.read_mtl_in_hp()`.
     * Addresses `issue #802`_.
@@ -16,6 +16,7 @@ desitarget Change Log
 .. _`issue #804`: https://github.com/desihub/desitarget/issues/804
 .. _`PR #805`: https://github.com/desihub/desitarget/pull/805
 .. _`PR #806`: https://github.com/desihub/desitarget/pull/806
+.. _`PR #808`: https://github.com/desihub/desitarget/pull/808
 
 2.6.1 (2023-08-23)
 ------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -483,7 +483,7 @@ def check_archiving(zcatdir=None, mtldir=None):
     ii = ~np.isin(arxiv["TA"], specs["TA"])
     mismatch1 = np.array(arxiv[ii]["TILEID"])
     msg1 = f"archived tiles not in specstatus file: {mismatch1}; "
-    
+
     # ADM tiles in tiles-specstatus file that are not archived.
     ii = ~np.isin(specs["TA"], arxiv["TA"])
     mismatch2 = np.array(specs[ii]["TILEID"])

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -433,6 +433,9 @@ def check_archiving(zcatdir=None, mtldir=None):
     - The check is limited to BRIGHT/DARK main survey tiles.
     - Based on work by Anand Raichoor.
     """
+    start = time()
+    log.info("Checking archived tiles match tiles-specstatus file...")
+
     # ADM grab tile files, use default environment variables, if needed.
     ztilefn = get_ztile_file_name(survey="main")
     mtldir = get_mtl_dir(mtldir)
@@ -490,6 +493,8 @@ def check_archiving(zcatdir=None, mtldir=None):
     if len(mismatch1) > 0 or len(mismatch2) > 0:
         log.error(msg1 + msg2)
         raise ValueError(msg1 + msg2)
+
+    log.info(f"Finished archiving check...t={time()-start:.1f}s")
 
     return
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -412,6 +412,42 @@ def get_mtl_ledger_format():
     return ff
 
 
+def check_archiving(zcatdir=None, mtldir=None):
+    """Check the previous archiving state of tiles.
+
+    Parameters
+    ----------
+    zcatdir : :class:`str`, optional
+        Full path to the directory that hosts redshift catalogs. Defaults
+        to the directory stored in the $ZCAT_DIR environment variable.
+    mtldir : :class:`str`, optional, defaults to ``None``
+        Full path to the directory that hosts the MTL ledgers and the MTL
+        tile file. If ``None``, then look up the MTL directory from the
+        $MTL_DIR environment variable.
+
+    Notes
+    -----
+    - The basic check is that the latest archive date for tiles in the
+      "archive" sub-directory of the redshift catalog directory matches
+      the `ARCHIVEDATE` recorded in the `tiles-specstatus.ecsv` file.
+    - The check is limited to BRIGHT/DARK main survey tiles.
+    """
+    # ADM use the default $ZCAT_DIR, if needed.
+    zcatdir = get_zcat_dir(zcatdir)
+    # ADM grab the tile-based sub-directories in the archive directory.
+    archivedir = os.path.join(zcatdir, "tiles", "archive")
+    fns = sorted(glob(os.path.join(archivedir, "*", "*")))
+
+    # ADM grab tile files, use default environment variables, if needed.
+    ztilefn = get_ztile_file_name(survey="main")
+    mtldir = get_mtl_dir(mtldir)
+    opsdir = os.path.join(os.path.dirname(mtldir), "ops")
+    ztilefn = os.path.join(opsdir, ztilefn)
+    # ADM need to check which specstatus tiles are Main Survey tiles.
+    maintilefn = ztilefn.replace("specstatus", "main")
+    
+
+
 def make_mtl(targets, obscon, zcat=None, scnd=None,
              trim=False, trimcols=False, trimtozcat=False):
     """Add zcat columns to a targets table, update priorities and NUMOBS.


### PR DESCRIPTION
This PR adds a `check_archiving()` function that is used in `run_mtl_loop` to test whether archived tile directories match the `ARCHIVEDATE` column in the `tiles-spectstatus.ecsv` file. The check is restricted to bright and dark tiles from the Main Survey.

See #807 and https://github.com/desihub/desisurveyops/issues/141 for more context.

`run_mtl_loop` now also includes a `--noarchivecheck` flag that can be used to bypass the archiving check (e.g., to speed up simulations or the alt-MTL process).

I tested this pretty extensively by:

- Creating a mock up of the `archive` directories in `/pscratch/sd/a/adamyers/arxivsandbox/tiles/archive/`.
- Copying the `tiles-specstatus.ecsv` file to `/pscratch/sd/a/adamyers/arxivsandbox/ops/`.
- Moving the archive directories for tiles `20994` and `25442` to `/pscratch/sd/a/adamyers/arxivsandbox/tiles/original/`.
- Removing tile `3333` from `/pscratch/sd/a/adamyers/arxivsandbox/ops/tiles-specstatus.ecsv` (the original file is retained at `/pscratch/sd/a/adamyers/arxivsandbox/ops/tiles-specstatus.ecsv.orig`).
- Then running, e.g., ` run_mtl_loop DARK --zcatdir /pscratch/sd/a/adamyers/arxivsandbox/ --mtldir /pscratch/sd/a/adamyers/arxivsandbox/mtl`

The resulting error message was:
```
ERROR:mtl.py:494:check_archiving: archived tiles not in specstatus file: [3333]; tiles in specstatus file that aren't archived: [20994 25442]
```

@araichoor: I'd appreciate a second pair of eyes on this PR before I tag `desitarget` and we make the check a standard part of daily ops. 

I don't think this is critical to resolve on the timescale of the long weekend, though!