### PR TITLE
Allow different astropy Table.read() reader options when accessing MTLs

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,15 @@ desitarget Change Log
 2.7.1 (unreleased)
 ------------------
 
+* Allow different Table reader options when reading MTLs [`PR #822`_].
+    * Addresses `issue #818`_.
 * Function to match RA/Dec positions to Main Survey targets [`PR #820`_].
 * Bump astropy from 5.0 to 5.3.3 (dependabot) [`PR #815`_].
 
 .. _`PR #815`: https://github.com/desihub/desitarget/pull/815
+.. _`issue #818`: https://github.com/desihub/desitarget/issues/818
 .. _`PR #820`: https://github.com/desihub/desitarget/pull/820
+.. _`PR #822`: https://github.com/desihub/desitarget/pull/822
 
 2.7.0 (2023-12-05)
 ------------------


### PR DESCRIPTION
This PR updates the desitarget I/O code for MTLs to allow different reader options to be passed to the core `Table.read()` reader function.

Context:
 - We originally fixed the reader for MTLs to `ascii.basic`, as this reader is ~3-4x faster than, e.g., `ascii.ecsv`. 
   * The `ascii.basic` option will remain the default after this PR.
 - The alt-MTL/mocks work is occasionally tripping on formatting errors that could be related to strict parsing using `ascii.ecsv` instead of `ascii.basic`.
   * This has never been a problem for the real MTLs, though.

This PR should address issue #818.