### PR TITLE
When resolving, only set bits for targets that pass northern (southern) cuts in northern (southern) imaging.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,11 +7,13 @@ desitarget Change Log
 
 * When resolving, only set bits for northern cuts/imaging [`PR #823`_].
     * And, similarly, for southern cuts in southern imaging.
+    * Addresses `issue #821`_.
 * Function to match RA/Dec positions to Main Survey targets [`PR #820`_].
 * Bump astropy from 5.0 to 5.3.3 (dependabot) [`PR #815`_].
 
 .. _`PR #815`: https://github.com/desihub/desitarget/pull/815
 .. _`PR #820`: https://github.com/desihub/desitarget/pull/820
+.. _`issue #821`: https://github.com/desihub/desitarget/issues/821
 .. _`PR #823`: https://github.com/desihub/desitarget/pull/823
 
 2.7.0 (2023-12-05)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,14 @@ desitarget Change Log
 2.7.1 (unreleased)
 ------------------
 
+* When resolving, only set bits for northern cuts/imaging [`PR #823`_].
+    * And, similarly, for southern cuts in southern imaging.
 * Function to match RA/Dec positions to Main Survey targets [`PR #820`_].
 * Bump astropy from 5.0 to 5.3.3 (dependabot) [`PR #815`_].
 
 .. _`PR #815`: https://github.com/desihub/desitarget/pull/815
 .. _`PR #820`: https://github.com/desihub/desitarget/pull/820
+.. _`PR #823`: https://github.com/desihub/desitarget/pull/823
 
 2.7.0 (2023-12-05)
 ------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2597,19 +2597,29 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     mws_faint_red = (mws_faint_red_n & photsys_north) | (mws_faint_red_s & photsys_south)
     mws_faint_blue = (mws_faint_blue_n & photsys_north) | (mws_faint_blue_s & photsys_south)
 
+    # ADM when resolving, strictly only set bits for targets that pass
+    # ADM the northern (southern) cuts in northern (southern) imaging.
+    res_north = np.ones_like(photsys_north)
+    res_south = np.ones_like(photsys_south)
+    if resolvetargs:
+        # ADM this construction guards against mutability but is far
+        # ADM quicker than making a copy.
+        res_north[:] = photsys_north[:]
+        res_south[:] = photsys_south[:]
+
     # Construct the targetflag bits for DECaLS (i.e. South).
-    desi_target = lrg_south * desi_mask.LRG_SOUTH
-    desi_target |= elg_south * desi_mask.ELG_SOUTH
-    desi_target |= elg_vlo_south * desi_mask.ELG_VLO_SOUTH
-    desi_target |= elg_lop_south * desi_mask.ELG_LOP_SOUTH
-    desi_target |= qso_south * desi_mask.QSO_SOUTH
+    desi_target = (lrg_south & res_south) * desi_mask.LRG_SOUTH
+    desi_target |= (elg_south & res_south) * desi_mask.ELG_SOUTH
+    desi_target |= (elg_vlo_south & res_south) * desi_mask.ELG_VLO_SOUTH
+    desi_target |= (elg_lop_south & res_south) * desi_mask.ELG_LOP_SOUTH
+    desi_target |= (qso_south & res_south) * desi_mask.QSO_SOUTH
 
     # Construct the targetflag bits for MzLS and BASS (i.e. North).
-    desi_target |= lrg_north * desi_mask.LRG_NORTH
-    desi_target |= elg_north * desi_mask.ELG_NORTH
-    desi_target |= elg_vlo_north * desi_mask.ELG_VLO_NORTH
-    desi_target |= elg_lop_north * desi_mask.ELG_LOP_NORTH
-    desi_target |= qso_north * desi_mask.QSO_NORTH
+    desi_target |= (lrg_north & res_north) * desi_mask.LRG_NORTH
+    desi_target |= (elg_north & res_north) * desi_mask.ELG_NORTH
+    desi_target |= (elg_vlo_north & res_north) * desi_mask.ELG_VLO_NORTH
+    desi_target |= (elg_lop_north & res_north) * desi_mask.ELG_LOP_NORTH
+    desi_target |= (qso_north & res_north) * desi_mask.QSO_NORTH
 
     # Construct the targetflag bits combining north and south.
     desi_target |= lrg * desi_mask.LRG
@@ -2627,14 +2637,14 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= std_wd * desi_mask.STD_WD
 
     # BGS targets, south.
-    bgs_target = bgs_bright_south * bgs_mask.BGS_BRIGHT_SOUTH
-    bgs_target |= bgs_faint_south * bgs_mask.BGS_FAINT_SOUTH
-    bgs_target |= bgs_wise_south * bgs_mask.BGS_WISE_SOUTH
+    bgs_target = (bgs_bright_south & res_south) * bgs_mask.BGS_BRIGHT_SOUTH
+    bgs_target |= (bgs_faint_south & res_south) * bgs_mask.BGS_FAINT_SOUTH
+    bgs_target |= (bgs_wise_south & res_south) * bgs_mask.BGS_WISE_SOUTH
 
     # BGS targets, north.
-    bgs_target |= bgs_bright_north * bgs_mask.BGS_BRIGHT_NORTH
-    bgs_target |= bgs_faint_north * bgs_mask.BGS_FAINT_NORTH
-    bgs_target |= bgs_wise_north * bgs_mask.BGS_WISE_NORTH
+    bgs_target |= (bgs_bright_north & res_north) * bgs_mask.BGS_BRIGHT_NORTH
+    bgs_target |= (bgs_faint_north & res_north) * bgs_mask.BGS_FAINT_NORTH
+    bgs_target |= (bgs_wise_north & res_north) * bgs_mask.BGS_WISE_NORTH
 
     # BGS targets, combined.
     bgs_target |= bgs_bright * bgs_mask.BGS_BRIGHT
@@ -2651,24 +2661,16 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     mws_target |= mws_bhb * mws_mask.MWS_BHB
 
     # ADM MWS main north/south split.
-    mws_target |= mws_broad_n * mws_mask.MWS_BROAD_NORTH
-    mws_target |= mws_broad_s * mws_mask.MWS_BROAD_SOUTH
+    mws_target |= (mws_broad_n & res_north) * mws_mask.MWS_BROAD_NORTH
+    mws_target |= (mws_broad_s & res_south) * mws_mask.MWS_BROAD_SOUTH
 
     # ADM MWS main blue/red split.
     mws_target |= mws_blue * mws_mask.MWS_MAIN_BLUE
-    mws_target |= mws_blue_n * mws_mask.MWS_MAIN_BLUE_NORTH
-    mws_target |= mws_blue_s * mws_mask.MWS_MAIN_BLUE_SOUTH
+    mws_target |= (mws_blue_n & res_north) * mws_mask.MWS_MAIN_BLUE_NORTH
+    mws_target |= (mws_blue_s & res_south) * mws_mask.MWS_MAIN_BLUE_SOUTH
     mws_target |= mws_red * mws_mask.MWS_MAIN_RED
-    mws_target |= mws_red_n * mws_mask.MWS_MAIN_RED_NORTH
-    mws_target |= mws_red_s * mws_mask.MWS_MAIN_RED_SOUTH
-
-    # Add MWS FAINT blue/red split. Only ever set in v1.1 of desitarget.
-#    mws_target |= mws_faint_blue * mws_mask.MWS_FAINT_BLUE
-#    mws_target |= mws_faint_blue_n * mws_mask.MWS_FAINT_BLUE_NORTH
-#    mws_target |= mws_faint_blue_s * mws_mask.MWS_FAINT_BLUE_SOUTH
-#    mws_target |= mws_faint_red * mws_mask.MWS_FAINT_RED
-#    mws_target |= mws_faint_red_n * mws_mask.MWS_FAINT_RED_NORTH
-#    mws_target |= mws_faint_red_s * mws_mask.MWS_FAINT_RED_SOUTH
+    mws_target |= (mws_red_n & res_north) * mws_mask.MWS_MAIN_RED_NORTH
+    mws_target |= (mws_red_s & res_south) * mws_mask.MWS_MAIN_RED_SOUTH
 
     # Are any BGS or MWS bit set?  Tell desi_target too.
     desi_target |= (bgs_target != 0) * desi_mask.BGS_ANY


### PR DESCRIPTION
This PR addresses #821 by only strictly setting bits for targets that pass the northern cuts in northern imaging, and vice versa, when resolving is turned on.

I tested this against the objects mentioned by @moustakas in #821, and the offending target bits are no longer set:

```
import fitsio
from desitarget.cuts import select_targets

targetids = [39627658597767428, 39627658601958684, 39627676696188831,
39627835563838694, 39627847626657859, 39627847664405076, 39627859714641687,
39633321159821042, 39633324632703364, 39633324645287048, 39633328084619301,
39633331507171632, 39633331536531297, 39633334904557083, 39633334908748247,
39633334942302972, 39633334954887818, 39633341665771821, 39633341665775786,
39633341674160813, 39633345012829156, 39633345025413416, 39633348355689677,
39633351639826525, 39633351648217151]

tractorfile = '/pscratch/sd/i/ioannis/Y3-templates/sample/tractor-iron-vi-main.fits'
alltargets = select_targets(tractorfile, backup=False, numproc=1)
for targetid in targetids:
    print(targetid, alltargets[alltargets['TARGETID'] == targetid])
    
39627658597767428 []
39627658601958684 []
39627676696188831 []
39627835563838694 []
39627847626657859 []
39627847664405076 []
...
...
...
```

I also checked the `main` branch against this `branch` for a couple of sweeps files (one from the north and one from the south), e.g.:

```
from desitarget.cuts import select_targets
import fitsio
swfile = "/global/cfs/cdirs/cosmo/data/legacysurvey/dr9/north/sweep/9.0/sweep-270p035-280p040.fits"
alltargets = select_targets(swfile, backup=False, numproc=1)
fitsio.write("/pscratch/sd/a/adamyers/ADM-photsys-branch-targets.fits", alltargets)
```

All resulting targets and columns are identical. Some example output files are here:

```
/pscratch/sd/a/adamyers/main-targets.fits
/pscratch/sd/a/adamyers/ADM-photsys-branch-targets.fits
```