### PR TITLE
Add a function to help secondary proposers check the format of their target files

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,13 @@ desitarget Change Log
 2.7.1 (unreleased)
 ------------------
 
+* Add function to check format of secondary target files [`PR #824`_].
 * Function to match RA/Dec positions to Main Survey targets [`PR #820`_].
 * Bump astropy from 5.0 to 5.3.3 (dependabot) [`PR #815`_].
 
 .. _`PR #815`: https://github.com/desihub/desitarget/pull/815
 .. _`PR #820`: https://github.com/desihub/desitarget/pull/820
+.. _`PR #824`: https://github.com/desihub/desitarget/pull/824
 
 2.7.0 (2023-12-05)
 ------------------


### PR DESCRIPTION
This PR adds a function to check the format of secondary target files for the new call for secondary targets.

As the PR only adds a small new function and doesn't change existing code, it's likely to be uncontroversial and I'll merge it later today.