### PR TITLE
Add different Table reader options to mtl.update_ledger()

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 2.7.1 (unreleased)
 ------------------
 
+* Add different Table reader options to mtl.update_ledger() [`PR #825`_].
+    * Augments `PR #822`_.
 * Add function to check format of secondary target files [`PR #824`_].
 * When resolving, only set bits for northern cuts/imaging [`PR #823`_].
     * And, similarly, for southern cuts in southern imaging.
@@ -27,6 +29,7 @@ desitarget Change Log
 .. _`PR #822`: https://github.com/desihub/desitarget/pull/822
 .. _`PR #823`: https://github.com/desihub/desitarget/pull/823
 .. _`PR #824`: https://github.com/desihub/desitarget/pull/824
+.. _`PR #825`: https://github.com/desihub/desitarget/pull/825
 
 2.7.0 (2023-12-05)
 ------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1643,7 +1643,7 @@ def standard_override_columns(mtl):
     return mtl
 
 
-def process_overrides(ledgerfn):
+def process_overrides(ledgerfn, tabform='ascii.basic'):
     """
     Recover MTL entries from override ledgers and update those ledgers.
 
@@ -1651,6 +1651,10 @@ def process_overrides(ledgerfn):
     ----------
     ledgerfn : :class:`str`
         Name of the override ledger to process.
+    tabform : :class:`str`, optional, defaults to 'ascii.basic'
+        Format to pass to the astropy Table.read() function. The default
+        ('ascii.basic') is standard for reading and writing MTL files.
+        But 'ascii.ecsv' is useful for some of the mock/alt-MTL work.
 
     Returns
     -------
@@ -1670,7 +1674,7 @@ def process_overrides(ledgerfn):
     log.info("Processing override ledgers")
 
     # ADM read in the relevant entries in the override ledger.
-    mtl = Table(io.read_mtl_ledger(ledgerfn))
+    mtl = Table(io.read_mtl_ledger(ledgerfn, tabform=tabform))
 
     # ADM limit to entries with NUMOVERRIDE > 0.
     ii = mtl["NUMOVERRIDE"] > 0
@@ -2228,7 +2232,7 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
 
 
 def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
-                  numobs_from_ledger=False):
+                  numobs_from_ledger=False, tabform='ascii.basic'):
     """
     Update relevant HEALPixel-split ledger files for some targets.
 
@@ -2255,6 +2259,10 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
         If ``True`` then inherit the number of observations so far from
         the ledger rather than expecting it to have a reasonable value
         in the `zcat.`
+    tabform : :class:`str`, optional, defaults to 'ascii.basic'
+        Format to pass to the astropy Table.read() function. The default
+        ('ascii.basic') is standard for reading and writing MTL files.
+        But 'ascii.ecsv' is useful for some of the mock/alt-MTL work.
 
     Returns
     -------
@@ -2282,7 +2290,8 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
         pixnum = list(set(pixnum))
         # ADM we'll read in too many targets, here, but that's OK as
         # ADM make_mtl(trimtozcat=True) only returns the updated targets.
-        targets = io.read_mtl_in_hp(hpdirname, nside, pixnum, unique=True)
+        targets = io.read_mtl_in_hp(hpdirname, nside, pixnum, unique=True,
+                                    tabform=tabform)
 
     # ADM if requested, use the previous values in the ledger to set
     # ADM NUMOBS in the zcat.
@@ -2319,7 +2328,7 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
         # ADM if an override ledger exists, update it and recover its
         # ADM relevant MTL entries.
         if os.path.exists(overfn):
-            overmtl = process_overrides(overfn)
+            overmtl = process_overrides(overfn, tabform=tabform)
             # ADM add any override entries TO THE END OF THE LEDGER.
             mtlpix = vstack([mtlpix, overmtl])
 


### PR DESCRIPTION
PR #822 added different astropy table reader options for MTL I/O. The alt-MTL mocks specifically use `desitarget.mtl.update_ledger()` as a worker function, though, and PR #822 neglected to also add the different table reader options to _that_ function.

This PR augments PR #822 by also adding the `tabform` kwarg to `desitarget.mtl.update_ledger()` to facilitate different astropy table reader arguments for the alt-MTL mocks.

This is a small PR, and I've carefully checked that I haven't broken anything about the MTL loop on the data side, so I'll merge in a few hours.