### PR TITLE
Add GAIA_ prefix to PHOT_*_MEAN_MAG column names

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 2.7.1 (unreleased)
 ------------------
 
+* Add `GAIA_` prefix to `PHOT_*_MEAN_MAG` column names [`PR #827`_].
+    * So GD1/streams files conform to downstream data model.
 * Add different Table reader options to mtl.update_ledger() [`PR #825`_].
     * Augments `PR #822`_.
 * Add function to check format of secondary target files [`PR #824`_].
@@ -30,6 +32,7 @@ desitarget Change Log
 .. _`PR #823`: https://github.com/desihub/desitarget/pull/823
 .. _`PR #824`: https://github.com/desihub/desitarget/pull/824
 .. _`PR #825`: https://github.com/desihub/desitarget/pull/825
+.. _`PR #827`: https://github.com/desihub/desitarget/pull/827
 
 2.7.0 (2023-12-05)
 ------------------

--- a/py/desitarget/streams/io.py
+++ b/py/desitarget/streams/io.py
@@ -378,7 +378,8 @@ def write_targets(dirname, targs, header, streamnames="", obscon=None,
     maglim = 15
     fluxlim = 10**((22.5-maglim)/2.5)
     toobright = np.zeros(len(targs), dtype="?")
-    for col in ["PHOT_G_MEAN_MAG", "PHOT_BP_MEAN_MAG", "PHOT_RP_MEAN_MAG"]:
+    for col in ["GAIA_PHOT_G_MEAN_MAG", "GAIA_PHOT_BP_MEAN_MAG",
+                "GAIA_PHOT_RP_MEAN_MAG"]:
         toobright |= (targs[col] != 0) & (targs[col] < maglim)
     for col in ["FIBERTOTFLUX_G", "FIBERTOTFLUX_R", "FIBERTOTFLUX_Z"]:
         toobright |= (targs[col] != 0) & (targs[col] > fluxlim)

--- a/py/desitarget/streams/targets.py
+++ b/py/desitarget/streams/targets.py
@@ -66,11 +66,15 @@ def finalize(targets, desi_target, bgs_target, mws_target, scnd_target):
     assert ntargets == len(mws_target)
     assert ntargets == len(scnd_target)
 
-    # - OBJID in tractor files is only unique within the brick; rename and
-    # - create a new unique TARGETID
+    # ADM rename some columns for downstream code.
     targets = rfn.rename_fields(targets,
-                                {'OBJID': 'BRICK_OBJID', 'TYPE': 'MORPHTYPE'})
+                                {'OBJID': 'BRICK_OBJID', 'TYPE': 'MORPHTYPE',
+                                 'PHOT_G_MEAN_MAG': 'GAIA_PHOT_G_MEAN_MAG',
+                                 'PHOT_BP_MEAN_MAG': 'GAIA_PHOT_BP_MEAN_MAG',
+                                 'PHOT_RP_MEAN_MAG': 'GAIA_PHOT_RP_MEAN_MAG'}
+                                )
 
+    # ADM create the unique TARGETID.
     targetid = encode_targetid(objid=targets['BRICK_OBJID'],
                                brickid=targets['BRICKID'],
                                release=targets['RELEASE'])
@@ -111,8 +115,8 @@ def finalize(targets, desi_target, bgs_target, mws_target, scnd_target):
     done["OBSCONDITIONS"] = set_obsconditions(done, scnd=True)
 
     # ADM replace any NaNs with zeros.
-    for col in ["PHOT_G_MEAN_MAG", "PHOT_BP_MEAN_MAG", "PHOT_RP_MEAN_MAG",
-                "PARALLAX", "PMRA", "PMDEC"]:
+    for col in ["GAIA_PHOT_G_MEAN_MAG", "GAIA_PHOT_BP_MEAN_MAG",
+                "GAIA_PHOT_RP_MEAN_MAG", "PARALLAX", "PMRA", "PMDEC"]:
         ii = np.isnan(done[col])
         done[col][ii] = 0.
 


### PR DESCRIPTION
This PR adds a `GAIA_` prefix to the `PHOT_*_MEAN_MAG` column names for the GD1/streams programs.

It's a minor update to PR #814.

An example output file with the new data model is available at:

`/pscratch/sd/a/adamyers/blatnew/dr9/2.7.0.dev5481/streamtargets/main/resolve/bright/streamtargets-gd1-bright.fits`