### PR TITLE
Update matching routines to check input arrays for duplicates

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desitarget Change Log
 ------------------
 
 * Change match routines to test input arrays for duplicates [`PR #828`_].
+  * Addresses `issue #811`_.
 * Add `GAIA_` prefix to `PHOT_*_MEAN_MAG` column names [`PR #827`_].
     * So GD1/streams files conform to downstream data model.
 * Module file removed vars that are now defined in desimodules:
@@ -25,6 +26,7 @@ desitarget Change Log
   * Addresses `issue #812`_.
   * General unit tests fixes, including one introduced in `PR #823`_
 
+.. _`issue #811`: https://github.com/desihub/desitarget/issues/811
 .. _`issue #812`: https://github.com/desihub/desitarget/issues/812
 .. _`PR #814`: https://github.com/desihub/desitarget/pull/814
 .. _`PR #815`: https://github.com/desihub/desitarget/pull/815

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desitarget Change Log
 ------------------
 
 * Change match routines to test input arrays for duplicates [`PR #828`_].
-  * Addresses `issue #811`_.
+    * Addresses `issue #811`_.
 * Add `GAIA_` prefix to `PHOT_*_MEAN_MAG` column names [`PR #827`_].
     * So GD1/streams files conform to downstream data model.
 * Module file removed vars that are now defined in desimodules:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 2.7.1 (unreleased)
 ------------------
 
+* Change match routines to test input arrays for duplicates [`PR #828`_].
 * Add `GAIA_` prefix to `PHOT_*_MEAN_MAG` column names [`PR #827`_].
     * So GD1/streams files conform to downstream data model.
 * Module file removed vars that are now defined in desimodules:
@@ -36,6 +37,7 @@ desitarget Change Log
 .. _`PR #825`: https://github.com/desihub/desitarget/pull/825
 .. _`PR #826`: https://github.com/desihub/desitarget/pull/826
 .. _`PR #827`: https://github.com/desihub/desitarget/pull/827
+.. _`PR #828`: https://github.com/desihub/desitarget/pull/828
 
 2.7.0 (2023-12-05)
 ------------------

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -33,7 +33,7 @@ from desiutil.log import get_logger
 log = get_logger()
 
 
-def match_to(A, B):
+def match_to(A, B, check_for_dups=True):
     """Return indexes where B matches A, holding A in place.
 
     Parameters
@@ -42,6 +42,11 @@ def match_to(A, B):
         Array of integers to match TO.
     B : :class:`~numpy.ndarray` or `list`
         Array of integers matched to `A`
+    check_for_dups : :class:`bool`, optional, defaults to ``True``
+        If ``True`` trigger an exception if there are duplicates in
+        either of the `A` or `B` arrays. Passing ``False`` for
+        `check_for_dups` isn't recommended, but is retained to facilitate
+        comparisons against earlier versions of the function.
 
     Returns
     -------
@@ -57,13 +62,13 @@ def match_to(A, B):
       unique) but A cannot be a shorter array than B.
     """
     # ADM grab the integer matchers.
-    Aii, Bii = match(A, B)
+    Aii, Bii = match(A, B, check_for_dups=check_for_dups)
 
     # ADM return, restoring the original order.
     return Aii[np.argsort(Bii)]
 
 
-def match(A, B):
+def match(A, B, check_for_dups=True):
     """Return matching indexes for two arrays on a unique key.
 
     Parameters
@@ -72,27 +77,47 @@ def match(A, B):
         An array of integers.
     B : :class:`~numpy.ndarray` or `list`
         An array of integers.
+    check_for_dups : :class:`bool`, optional, defaults to ``True``
+        If ``True`` trigger an exception if there are duplicates in
+        either of the `A` or `B` arrays. Passing ``False`` for
+        `check_for_dups` isn't recommended, but is retained to facilitate
+        comparisons against earlier versions of the function.
 
     Returns
     -------
     :class:`~numpy.ndarray`
-        The integer indexes in A to match to B.
+        The integer indexes in A that match to B.
     :class:`~numpy.ndarray`
-        The integer indexes in B to match to A.
+        The integer indexes in B that match to A.
 
     Notes
     -----
     - Result should be such that for Aii, Bii = match(A, B)
       np.all(A[Aii] == B[Bii]) is True.
     - Only works if there is a unique mapping from A->B, i.e
-      if A and B do NOT contain duplicates.
+      if A and B do NOT contain duplicates. This is explicitly checked if
+      `check_for_dups` is ``True``
     - h/t Anand Raichoor `by way of Stack Overflow`_.
     """
     # AR sorting A,B
     tmpA = np.sort(A)
     tmpB = np.sort(B)
 
-    # AR create mask equivalent to np.in1d(A,B) and np.in1d(B,A) for unique elements
+    # ADM via AR rapid check for duplicates in either array.
+    if check_for_dups:
+        n_Adups = np.count_nonzero(tmpA[1:] == tmpA[:-1])
+        n_Bdups = np.count_nonzero(tmpB[1:] == tmpB[:-1])
+        msg = []
+        if n_Adups > 0:
+            msg.append("Array A has {} duplicates".format(n_Adups))
+        if n_Bdups > 0:
+            msg.append("Array B has {} duplicates".format(n_Bdups))
+        if len(msg) > 0:
+            msg = "; ".join(msg)
+            log.error(msg)
+            raise ValueError(msg)
+
+    # AR mask equivalent to np.in1d(A, B) for unique elements.
     maskA = (
         np.searchsorted(tmpB, tmpA, "right") - np.searchsorted(tmpB, tmpA, "left")
     ) == 1


### PR DESCRIPTION
This PR addresses issue #811.

@araichoor: In the end I used your suggested approach, utilizing `np.count_nonzero()`, in full. I tested a bunch of corner cases and I think your approach always returns the desired result. And it is _very_ fast!

I also agree with @araichoor that it's actually _desirable_ to break backwards compatibility in this case, as the results without checking for duplicates are essentially garbage.