### PR TITLE
fix pkg_resources, scipy.ndimage, and pytest deprecation warnings

### DIFF
--- a/bin/make_new_sv
+++ b/bin/make_new_sv
@@ -6,7 +6,7 @@ import numpy as np
 #import warnings
 #warnings.simplefilter('error')
 
-from pkg_resources import resource_filename
+from importlib import resources
 from glob import glob
 from time import time
 start = time()
@@ -19,7 +19,7 @@ ap = ArgumentParser("Make a new sv directory, based on the highest existing sv d
 _ = ap.parse_args()
 
 # ADM the standard root name for a desitarget SV directory.
-svroot = resource_filename('desitarget', 'sv')
+svroot = str(resources.files('desitarget').joinpath('sv'))
 
 # ADM retrieve the highest current sv directory.
 fns = sorted(glob(svroot+'*'))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desitarget Change Log
 2.7.1 (unreleased)
 ------------------
 
+* Fix `pkg_resources`, `scipy.ndimage`, and `pytest` deprecation warnings [`PR #829`_].
 * Add `GAIA_` prefix to `PHOT_*_MEAN_MAG` column names [`PR #827`_].
     * So GD1/streams files conform to downstream data model.
 * Module file removed vars that are now defined in desimodules:
@@ -36,6 +37,7 @@ desitarget Change Log
 .. _`PR #825`: https://github.com/desihub/desitarget/pull/825
 .. _`PR #826`: https://github.com/desihub/desitarget/pull/826
 .. _`PR #827`: https://github.com/desihub/desitarget/pull/827
+.. _`PR #829`: https://github.com/desihub/desitarget/pull/829
 
 2.7.0 (2023-12-05)
 ------------------

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -23,7 +23,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, Row
 
-from pkg_resources import resource_filename
+from importlib import resources
 
 from desitarget import io
 from desitarget.cuts import _psflike, _is_row, _get_colnames, _prepare_gaia
@@ -1008,7 +1008,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None,
         colorsReducedIndex = colorsIndex[preSelection]
 
         # Path to random forest files
-        pathToRF = resource_filename('desitarget', 'data')
+        pathToRF = str(resources.files('desitarget').joinpath('data'))
         # ADM Use RF trained over DR7
         rf_fileName = pathToRF + '/rf_model_dr7.npz'
         rf_HighZ_fileName = pathToRF + '/rf_model_dr7_HighZ.npz'

--- a/py/desitarget/cmx/ms_cuts.py
+++ b/py/desitarget/cmx/ms_cuts.py
@@ -11,7 +11,7 @@ An old copy of the Main Survey cuts (../cuts.py) that were used for commissionin
 """
 
 import numpy as np
-from pkg_resources import resource_filename
+from importlib import resources
 from desitarget.geomask import imaging_mask
 
 # ADM set up the DESI default logger
@@ -545,7 +545,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
         colorsReducedIndex = colorsIndex[preSelection]
 
         # Path to random forest files
-        pathToRF = resource_filename('desitarget', 'data')
+        pathToRF = str(resources.files('desitarget').joinpath('data'))
         # rf filenames
         rf_DR3_fileName = pathToRF + '/rf_model_dr3.npz'
         rf_DR7_fileName = pathToRF + '/rf_model_dr7.npz'

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -23,7 +23,7 @@ import sys
 import fitsio
 import numpy as np
 import healpy as hp
-from pkg_resources import resource_filename
+from importlib import resources
 import numpy.lib.recfunctions as rfn
 from importlib import import_module
 
@@ -1904,7 +1904,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
         colorsReducedIndex = colorsIndex[preSelection]
 
         # Path to random forest files.
-        pathToRF = resource_filename('desitarget', 'data')
+        pathToRF = str(resources.files('desitarget').joinpath('data'))
         # rf filename.
         rf_DR9_fileName = pathToRF + '/rf_model_dr9_final.npz'
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -22,7 +22,7 @@ import numpy.lib.recfunctions as rfn
 import healpy as hp
 from glob import glob, iglob
 from time import time
-from pkg_resources import resource_filename
+from importlib import resources
 import yaml
 import hashlib
 
@@ -435,7 +435,7 @@ def write_with_units(filename, data, extname=None, header=None, ecsv=False):
           conversion is applied to `data`.
     """
     # ADM read the desitarget units yaml file.
-    fn = resource_filename('desitarget', os.path.join('data', 'units.yaml'))
+    fn = resources.files('desitarget').joinpath('data/units.yaml')
     with open(fn) as f:
         unitdict = yaml.safe_load(f)
 

--- a/py/desitarget/mock/mockmaker.py
+++ b/py/desitarget/mock/mockmaker.py
@@ -10,7 +10,7 @@ Read mock catalogs and assign spectra.
 import os
 import numpy as np
 from glob import glob
-from pkg_resources import resource_filename
+from importlib import resources
 
 import fitsio
 import healpy as hp
@@ -514,11 +514,11 @@ class SelectTargets(object):
                 pass
                 #return
 
-            gmmdir = resource_filename('desitarget', 'mock/data/dr9')
+            gmmdir = resources.files('desitarget').joinpath('mock/data/dr9')
             if not os.path.isdir:
                 log.warning('DR9 GMM directory {} not found!'.format(gmmdir))
                 raise IOError
-            
+
             fracfile = os.path.join(gmmdir, 'fractype_{}.fits'.format(target.lower()))
             fractype = Table.read(fracfile)
 

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -15,9 +15,9 @@ from time import time
 import photutils
 import healpy as hp
 from glob import glob
-from scipy.ndimage.morphology import binary_dilation, binary_erosion
-from scipy.ndimage.measurements import label, find_objects, center_of_mass
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import binary_dilation, binary_erosion
+from scipy.ndimage import label, find_objects, center_of_mass
+from scipy.ndimage import gaussian_filter
 
 # ADM some utility code taken from legacypipe and astrometry.net.
 from desitarget.skyutilities.astrometry.fits import fits_table

--- a/py/desitarget/streams/utilities.py
+++ b/py/desitarget/streams/utilities.py
@@ -13,7 +13,7 @@ import os
 import numpy as np
 import astropy.coordinates as acoo
 import astropy.units as auni
-from pkg_resources import resource_filename
+from importlib import resources
 from scipy.interpolate import UnivariateSpline
 from time import time
 import desitarget.streams.gaia_dr3_parallax_zero_point.zpt as gaia_zpt
@@ -396,7 +396,7 @@ def get_stream_parameters(stream_name):
     stream_name = stream_name.upper()
 
     # ADM open and load the parameter yaml file.
-    fn = resource_filename('desitarget', os.path.join('data', 'streams.yaml'))
+    fn = resources.files('desitarget').joinpath('data/streams.yaml')
     with open(fn) as f:
         stream = yaml.safe_load(f)
 

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -16,7 +16,7 @@ import numpy as np
 import warnings
 
 from time import time
-from pkg_resources import resource_filename
+from importlib import resources
 import healpy as hp
 import fitsio
 
@@ -780,7 +780,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, w1flux=None,
         colorsReducedIndex = colorsIndex[preSelection]
 
         # Path to random forest files
-        pathToRF = resource_filename('desitarget', 'data')
+        pathToRF = str(resources.files('desitarget').joinpath('data'))
         # Use RF trained over DR9
         rf_fileName = pathToRF + '/rf_model_dr9.npz'
         rf_HighZ_fileName = pathToRF + '/rf_model_dr9_HighZ.npz'
@@ -911,7 +911,7 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None,
         colorsReducedIndex = colorsIndex[preSelection]
 
         # Path to random forest files.
-        pathToRF = resource_filename('desitarget', 'data')
+        pathToRF = str(resources.files('desitarget').joinpath('data'))
         # Use RF trained over DR9.
         rf_fileName = pathToRF + '/rf_model_dr9.npz'
 

--- a/py/desitarget/sv2/sv2_cuts.py
+++ b/py/desitarget/sv2/sv2_cuts.py
@@ -20,7 +20,7 @@ import sys
 import fitsio
 import numpy as np
 import healpy as hp
-from pkg_resources import resource_filename
+from importlib import resources
 import numpy.lib.recfunctions as rfn
 from importlib import import_module
 
@@ -1516,7 +1516,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
         colorsReducedIndex = colorsIndex[preSelection]
 
         # Path to random forest files
-        pathToRF = resource_filename('desitarget', 'data')
+        pathToRF = str(resources.files('desitarget').joinpath('data'))
         # rf filenames
         rf_DR3_fileName = pathToRF + '/rf_model_dr3.npz'
         rf_DR7_fileName = pathToRF + '/rf_model_dr7.npz'

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -20,7 +20,7 @@ import sys
 import fitsio
 import numpy as np
 import healpy as hp
-from pkg_resources import resource_filename
+from importlib import resources
 import numpy.lib.recfunctions as rfn
 from importlib import import_module
 
@@ -1721,7 +1721,7 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
         colorsReducedIndex = colorsIndex[preSelection]
 
         # Path to random forest files
-        pathToRF = resource_filename('desitarget', 'data')
+        pathToRF = str(resources.files('desitarget').joinpath('data'))
         # rf filenames
         rf_DR3_fileName = pathToRF + '/rf_model_dr3.npz'
         rf_DR7_fileName = pathToRF + '/rf_model_dr7.npz'

--- a/py/desitarget/targetmask.py
+++ b/py/desitarget/targetmask.py
@@ -7,7 +7,7 @@ This looks more like a script than an actual module.
 import os.path
 from desiutil.bitmask import BitMask
 import yaml
-from pkg_resources import resource_filename
+from importlib import resources
 
 
 def load_mask_bits(prefix=""):
@@ -18,7 +18,7 @@ def load_mask_bits(prefix=""):
         us = '_'
     prename = prefix+us
     fn = os.path.join(prefix, "data", "{}targetmask.yaml".format(prename))
-    _filepath = resource_filename('desitarget', fn)
+    _filepath = resources.files('desitarget').joinpath(fn)
     with open(_filepath) as fx:
         bitdefs = yaml.safe_load(fx)
         try:

--- a/py/desitarget/test/__init__.py
+++ b/py/desitarget/test/__init__.py
@@ -1,8 +1,5 @@
-def test_suite():
-    """Returns unittest.TestSuite for this package"""
-    import unittest
-    from os.path import dirname
-    basedir = dirname(dirname(__file__))
-    # print(desispec_dir)
-    return unittest.defaultTestLoader.discover(basedir,
-                                               top_level_dir=dirname(basedir))
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from .desitarget_test_suite import runtests

--- a/py/desitarget/test/make_testgaia.py
+++ b/py/desitarget/test/make_testgaia.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     import fitsio
     import numpy as np
     from time import time
-    from pkg_resources import resource_filename
+    from importlib import resources
     from desitarget.gaiamatch import find_gaia_files
     from desitarget.tychomatch import find_tycho_files
     from desitarget.uratmatch import find_urat_files
@@ -17,7 +17,7 @@ if __name__ == "__main__":
 
     # ADM choose the Gaia files to cover the same object
     # ADM locations as the sweeps/tractor files.
-    datadir = resource_filename('desitarget.test', 't')
+    datadir = resources.files('desitarget').joinpath('test/t')
     tractorfiles = sorted(io.list_tractorfiles(datadir))
     sweepfiles = sorted(io.list_sweepfiles(datadir))
 

--- a/py/desitarget/test/test_brick_fluctuation.py
+++ b/py/desitarget/test/test_brick_fluctuation.py
@@ -57,15 +57,3 @@ class TestBrickFluctuation(unittest.TestCase):
             self.assertTrue(isinstance(self.depth[k], np.ndarray))
             self.assertEqual(len(self.depth[k]), len(self.b['RA']))
             self.assertEqual(len(self.depth[k]), len(self.b['DEC']))
-
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_brick_fluctuation
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_brightmask.py
+++ b/py/desitarget/test/test_brightmask.py
@@ -262,15 +262,3 @@ class TestBRIGHTMASK(unittest.TestCase):
         brickidset = np.array(
             [int(bintargid[-lmostbit:-rmostbit], 2) for bintargid in bintargids])
         self.assertTrue(np.all(brickidset == bid))
-
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_brightmask
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_brightmask.py
+++ b/py/desitarget/test/test_brightmask.py
@@ -3,7 +3,7 @@
 """Test desitarget.brightmask.
 """
 import unittest
-from pkg_resources import resource_filename
+from importlib import resources
 import os
 import sys
 import fitsio
@@ -28,12 +28,12 @@ class TestBRIGHTMASK(unittest.TestCase):
     def setUpClass(cls):
         # ADM set up the necessary environment variables.
         cls.gaiadir_orig = os.getenv("GAIA_DIR")
-        testdir = 'desitarget.test'
-        os.environ["GAIA_DIR"] = resource_filename(testdir, 't4')
+        testdir = resources.files('desitarget').joinpath('test')
+        os.environ["GAIA_DIR"] = os.path.join(testdir, 't4')
         cls.tychodir_orig = os.getenv("TYCHO_DIR")
-        os.environ["TYCHO_DIR"] = resource_filename(testdir, 't4/tycho')
+        os.environ["TYCHO_DIR"] = os.path.join(testdir, 't4', 'tycho')
         cls.uratdir_orig = os.getenv("URAT_DIR")
-        os.environ["URAT_DIR"] = resource_filename(testdir, 't4/urat')
+        os.environ["URAT_DIR"] = os.path.join(testdir, 't4', 'urat')
 
         # ADM a temporary output directory to test writing masks.
         cls.maskdir = tempfile.mkdtemp()
@@ -60,7 +60,7 @@ class TestBRIGHTMASK(unittest.TestCase):
             maglim=cls.maglim, maskepoch=cls.maskepoch)
 
         # ADM read in some targets.
-        targdir = resource_filename(testdir, 't')
+        targdir = os.path.join(testdir, 't')
         fn = os.path.join(targdir, 'sweep-320m005-330p000.fits')
         ts = fitsio.read(fn)
         # ADM targets are really sweeps objects, so add target fields.

--- a/py/desitarget/test/test_cmx.py
+++ b/py/desitarget/test/test_cmx.py
@@ -157,14 +157,3 @@ class TestCMX(unittest.TestCase):
                 self.assertTrue('CMX_TARGET' in targets.dtype.names)
                 self.assertEqual(len(targets), np.count_nonzero(targets['CMX_TARGET']))
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_cmx
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_cmx.py
+++ b/py/desitarget/test/test_cmx.py
@@ -4,7 +4,7 @@
 """
 import unittest
 import sys
-from pkg_resources import resource_filename
+from importlib import resources
 import os.path
 from uuid import uuid4
 import numbers
@@ -26,10 +26,10 @@ class TestCMX(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.datadir = resource_filename('desitarget.test', 't')
+        cls.datadir = resources.files('desitarget').joinpath('test/t')
         cls.tractorfiles = sorted(io.list_tractorfiles(cls.datadir))
         cls.sweepfiles = sorted(io.list_sweepfiles(cls.datadir))
-        cls.cmxdir = resource_filename('desitarget.test', 't3')
+        cls.cmxdir = resources.files('desitarget').joinpath('test/t3')
 
         # ADM find which HEALPixels are covered by test sweeps files.
         cls.nside = 32
@@ -43,7 +43,7 @@ class TestCMX(unittest.TestCase):
 
         # ADM set up the GAIA_DIR environment variable.
         cls.gaiadir_orig = os.getenv("GAIA_DIR")
-        os.environ["GAIA_DIR"] = resource_filename('desitarget.test', 't4')
+        os.environ["GAIA_DIR"] = str(resources.files('desitarget').joinpath('test/t4'))
 
     @classmethod
     def tearDownClass(cls):

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -4,7 +4,7 @@
 """
 import unittest
 import sys
-from pkg_resources import resource_filename
+from importlib import resources
 import os.path
 from uuid import uuid4
 import numbers
@@ -27,7 +27,7 @@ class TestCuts(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.datadir = resource_filename('desitarget.test', 't')
+        cls.datadir = resources.files('desitarget').joinpath('test/t')
         cls.tractorfiles = sorted(io.list_tractorfiles(cls.datadir))
         cls.sweepfiles = sorted(io.list_sweepfiles(cls.datadir))
 
@@ -43,7 +43,7 @@ class TestCuts(unittest.TestCase):
 
         # ADM set up the GAIA_DIR environment variable.
         cls.gaiadir_orig = os.getenv("GAIA_DIR")
-        os.environ["GAIA_DIR"] = resource_filename('desitarget.test', 't4')
+        os.environ["GAIA_DIR"] = str(resources.files('desitarget').joinpath('test/t4'))
 
     @classmethod
     def tearDownClass(cls):

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -445,14 +445,3 @@ class TestCuts(unittest.TestCase):
 
         self.assertEqual(timesthrown, 3)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_cuts
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_geomask.py
+++ b/py/desitarget/test/test_geomask.py
@@ -3,7 +3,6 @@
 """Test desitarget.geomask.
 """
 import unittest
-from pkg_resources import resource_filename
 import numpy as np
 import os
 

--- a/py/desitarget/test/test_geomask.py
+++ b/py/desitarget/test/test_geomask.py
@@ -56,14 +56,3 @@ class TestGEOMASK(unittest.TestCase):
         self.assertTrue(np.all(a[iia] == b[iib]))
         self.assertTrue(len(iia), len(a))
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_geomask
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -20,7 +20,7 @@ class TestIO(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.datadir = resources.files('desitarget').joinpath('test/t')
+        cls.datadir = str(resources.files('desitarget').joinpath('test/t'))
 
     def setUp(self):
         self.testdir = 'test-{}'.format(uuid4().hex)

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -3,7 +3,7 @@
 """Test desitarget.io.
 """
 import unittest
-from pkg_resources import resource_filename
+from importlib import resources
 import shutil
 import os.path
 from uuid import uuid4
@@ -20,7 +20,7 @@ class TestIO(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.datadir = resource_filename('desitarget.test', 't')
+        cls.datadir = resources.files('desitarget').joinpath('test/t')
 
     def setUp(self):
         self.testdir = 'test-{}'.format(uuid4().hex)

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -185,14 +185,3 @@ class TestIO(unittest.TestCase):
         self.assertEqual(bt['SUBPRIORITY'][0], 2.0)
         self.assertNotEqual(bt['SUBPRIORITY'][1], 0.0)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_io
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_mock_build.py
+++ b/py/desitarget/test/test_mock_build.py
@@ -106,12 +106,3 @@ class TestMockBuild(unittest.TestCase):
         skypix = hp.ang2pix(nside, theta, phi, nest=True)
         self.assertEqual(set(surveypix), set(skypix))
 
-if __name__ == '__main__':
-    unittest.main()
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_mock_build
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_mock_build.py
+++ b/py/desitarget/test/test_mock_build.py
@@ -6,7 +6,7 @@ import unittest
 import tempfile
 import os
 import shutil
-from pkg_resources import resource_filename
+from importlib import resources
 import numpy as np
 from astropy.table import Table
 import healpy as hp
@@ -19,7 +19,7 @@ from desitarget.mock.build import targets_truth
 from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
 
 class TestMockBuild(unittest.TestCase):
-    
+
     def setUp(self):
         self.outdir = tempfile.mkdtemp()
 
@@ -29,7 +29,7 @@ class TestMockBuild(unittest.TestCase):
 
     @unittest.skipUnless('DESITARGET_RUN_MOCK_UNITTEST' in os.environ, '$DESITARGET_RUN_MOCK_UNITTEST not set; skipping expensive mock tests')
     def test_targets_truth(self):
-        configfile = resource_filename('desitarget.mock', 'data/select-mock-targets.yaml')
+        configfile = resources.files('desitarget').joinpath('mock/data/select-mock-targets.yaml')
 
         import yaml
         with open(configfile) as fx:

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -406,14 +406,3 @@ class TestMTL(unittest.TestCase):
                                 "ZWARN bit value mismatch for {}".format(
                                     bitname))
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_mtl
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_mtl_multiple.py
+++ b/py/desitarget/test/test_mtl_multiple.py
@@ -128,14 +128,3 @@ class TestMTL(unittest.TestCase):
             toohigh |= more_zwarn > done
             self.assertFalse(toomany & toohigh, msg.format(bitname))
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_mtl
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_mtl_streams.py
+++ b/py/desitarget/test/test_mtl_streams.py
@@ -123,14 +123,3 @@ class TestMTLStreams(unittest.TestCase):
             self.assertTrue(np.all(mtl['PRIORITY'] == self.post_prio[numobs]))
             self.assertTrue(np.all(mtl['NUMOBS_MORE'] == self.post_nom[numobs]))
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_mtl_streams
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -347,14 +347,3 @@ class TestPriorities(unittest.TestCase):
 
         self.assertLess(lowest_bgs_priority_zgood, lowest_mws_priority)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_priorities
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_qa.py
+++ b/py/desitarget/test/test_qa.py
@@ -10,7 +10,7 @@ import tempfile
 import warnings
 import numpy as np
 import healpy as hp
-from pkg_resources import resource_filename
+from importlib import resources
 from glob import glob
 from desitarget.QA import make_qa_page, _load_systematics
 from desitarget.QA import _parse_tcnames, _in_desi_footprint
@@ -24,7 +24,7 @@ class TestQA(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.datadir = resource_filename('desitarget.test', 't/')
+        cls.datadir = resources.files('desitarget').joinpath('test/t')
         cls.targfile = os.path.join(cls.datadir, 'targets.fits')
         cls.mocktargfile = os.path.join(cls.datadir, 'targets-mocks.fits')
         cls.cmxfile = os.path.join(cls.datadir, 'cmx-targets.fits')

--- a/py/desitarget/test/test_qa.py
+++ b/py/desitarget/test/test_qa.py
@@ -148,14 +148,3 @@ class TestQA(unittest.TestCase):
         self.assertEqual(len(tin[0]), 1)
         self.assertEqual(len(tout[0]), 0)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_qa
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_secondary.py
+++ b/py/desitarget/test/test_secondary.py
@@ -7,7 +7,7 @@ import numpy as np
 import unittest
 from importlib import import_module
 from glob import glob
-from pkg_resources import resource_filename
+from importlib import resources
 
 
 class TestSECONDARY(unittest.TestCase):
@@ -16,7 +16,7 @@ class TestSECONDARY(unittest.TestCase):
         # ADM these are the allowed types of observations of secondaries.
         self.flavors = {"SPARE", "DEDICATED", "SSV", "QSO", "TOO"}
         # ADM this is the list of defined directories for SV.
-        fns = sorted(glob(resource_filename('desitarget', 'sv*')))
+        fns = sorted(glob(str(resources.files('desitarget').joinpath('sv*'))))
         svlist = [os.path.basename(fn) for fn in fns if os.path.isdir(fn)]
         # ADM loop over all SV flavors and main survey to get all masks.
         from desitarget.targetmask import scnd_mask as Mx

--- a/py/desitarget/test/test_secondary.py
+++ b/py/desitarget/test/test_secondary.py
@@ -67,14 +67,3 @@ class TestSECONDARY(unittest.TestCase):
         # ADM check downsample is always less than 1 (< 100%).
         self.assertTrue(np.all(np.array(ds) <= 1))
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_mtl
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_skyfibers.py
+++ b/py/desitarget/test/test_skyfibers.py
@@ -3,7 +3,7 @@
 """Test desitarget.skyfibers.
 """
 import unittest
-from pkg_resources import resource_filename
+from importlib import resources
 import numpy as np
 
 from glob import glob
@@ -23,7 +23,7 @@ class TestSKYFIBERS(unittest.TestCase):
     @classmethod
     def setUp(self):
         # ADM location of input test survey directory structure.
-        self.sd = resource_filename('desitarget.test', 'dr6')
+        self.sd = str(resources.files('desitarget').joinpath('test/dr6'))
 
         # ADM create the survey object.
         self.survey = LegacySurveyData(self.sd)

--- a/py/desitarget/test/test_skyfibers.py
+++ b/py/desitarget/test/test_skyfibers.py
@@ -183,14 +183,3 @@ class TestSKYFIBERS(unittest.TestCase):
         # ADM check the wrapper generates a single brick correctly.
         self.assertTrue(np.all(ss == skies))
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_skyfibers
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_subpriority.py
+++ b/py/desitarget/test/test_subpriority.py
@@ -3,7 +3,6 @@
 """Test desitarget.subpriority
 """
 import unittest
-from pkg_resources import resource_filename
 import numpy as np
 import os
 from astropy.table import Table

--- a/py/desitarget/test/test_subpriority.py
+++ b/py/desitarget/test/test_subpriority.py
@@ -65,14 +65,3 @@ class TestSubpriority(unittest.TestCase):
             else:
                 self.assertEqual(targets['SUBPRIORITY'][i], orig_subpriority[i])
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_geomask
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_sv.py
+++ b/py/desitarget/test/test_sv.py
@@ -90,14 +90,3 @@ class TestSV(unittest.TestCase):
 
             self.assertEqual(number_of_calls, 3)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_sv
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_sv.py
+++ b/py/desitarget/test/test_sv.py
@@ -10,7 +10,7 @@ import numpy as np
 import healpy as hp
 from glob import glob
 
-from pkg_resources import resource_filename
+from importlib import resources
 from desitarget import io, cuts
 from desitarget.targetmask import desi_mask
 
@@ -21,7 +21,7 @@ class TestSV(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.datadir = resource_filename('desitarget.test', 't')
+        cls.datadir = resources.files('desitarget').joinpath('test/t')
         cls.tractorfiles = sorted(io.list_tractorfiles(cls.datadir))
         cls.sweepfiles = sorted(io.list_sweepfiles(cls.datadir))
 
@@ -37,7 +37,7 @@ class TestSV(unittest.TestCase):
 
         # ADM set up the GAIA_DIR environment variable.
         cls.gaiadir_orig = os.getenv("GAIA_DIR")
-        os.environ["GAIA_DIR"] = resource_filename('desitarget.test', 't4')
+        os.environ["GAIA_DIR"] = str(resources.files('desitarget').joinpath('test/t4'))
 
     @classmethod
     def tearDownClass(cls):
@@ -50,7 +50,7 @@ class TestSV(unittest.TestCase):
         """Test SV cuts work.
         """
         # ADM find all svX sub-directories in the desitarget directory.
-        fns = sorted(glob(resource_filename('desitarget', 'sv*')))
+        fns = sorted(glob(str(resources.files('desitarget').joinpath('sv*'))))
         svlist = [os.path.basename(fn) for fn in fns if os.path.isdir(fn)]
         self.assertEqual(len(svlist), 3)
 

--- a/py/desitarget/test/test_targetids.py
+++ b/py/desitarget/test/test_targetids.py
@@ -99,14 +99,3 @@ class TestTargetID(unittest.TestCase):
             self.assertLess(np.abs(ra1-ra), delta)
             self.assertLess(np.abs(dec1-dec), delta)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_geomask
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_top_level.py
+++ b/py/desitarget/test/test_top_level.py
@@ -38,14 +38,3 @@ class TestTopLevel(unittest.TestCase):
         else:
             self.assertRegexpMatches(theVersion, self.versionre)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_top_level
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/test/test_units.py
+++ b/py/desitarget/test/test_units.py
@@ -9,7 +9,7 @@ import astropy.version as astropyversion
 import astropy.units as u
 import numpy as np
 from astropy.table import Table
-from pkg_resources import resource_filename
+from importlib import resources
 from desitarget.brightmask import maskdatamodel as dma
 from desitarget.gaiamatch import gaiadatamodel as dmb
 from desitarget.gfa import gfadatamodel as dmc
@@ -25,7 +25,7 @@ class TestUNITS(unittest.TestCase):
     def setUp(self):
         # ADM load the units yaml file.
         basefn = os.path.join('data', 'units.yaml')
-        self.fn = resource_filename('desitarget', basefn)
+        self.fn = resources.files('desitarget').joinpath(basefn)
         with open(self.fn) as f:
             self.units = yaml.safe_load(f)
 

--- a/py/desitarget/test/test_units.py
+++ b/py/desitarget/test/test_units.py
@@ -88,14 +88,3 @@ class TestUNITS(unittest.TestCase):
             unitlist, tabunits)
         self.assertTrue(np.all(unitlist[tabunits != unitlist] == ""), msg=msg)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
-
-def test_suite():
-    """Allows testing of only this module with the command:
-
-        python setup.py test -m desitarget.test.test_mtl
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desitarget/train/train_test_RF/Convert_to_DESI_RF.py
+++ b/py/desitarget/train/train_test_RF/Convert_to_DESI_RF.py
@@ -17,7 +17,6 @@ import numpy as np
 import time
 
 from desitarget.myRF import myRF
-from pkg_resources import resource_filename
 
 import joblib
 from sklearn.ensemble import RandomForestClassifier

--- a/py/desitarget/train/train_test_RF/Some_tests.py
+++ b/py/desitarget/train/train_test_RF/Some_tests.py
@@ -4,7 +4,7 @@ import numpy as np
 import joblib
 
 from desitarget.myRF import myRF
-from pkg_resources import resource_filename
+from importlib import resources
 
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
@@ -59,7 +59,7 @@ def compute_proba_desitarget(sample):
     attributes = build_attributes(len(sample), nfeatures, sample)
 
     print("NOT FINAL VERSION 888")
-    pathToRF = resource_filename('desitarget', 'data')
+    pathToRF = str(resources.files('desitarget').joinpath('data'))
     rf_fileName = pathToRF + f'/rf_model_dr9.npz'
     rf_Highz_fileName = pathToRF + f'/rf_model_dr9_HighZ.npz'
 

--- a/py/desitarget/tychomatch.py
+++ b/py/desitarget/tychomatch.py
@@ -13,7 +13,6 @@ import requests
 import pickle
 from datetime import datetime
 
-from pkg_resources import resource_filename
 from time import time
 from astropy.io import ascii
 from glob import glob

--- a/py/desitarget/uratmatch.py
+++ b/py/desitarget/uratmatch.py
@@ -14,7 +14,7 @@ import fitsio
 import requests
 import pickle
 
-from pkg_resources import resource_filename
+from importlib import resources
 from time import time
 from astropy.io import ascii
 from glob import glob
@@ -177,8 +177,8 @@ def urat_binary_to_csv():
              .format(time()-start))
 
     # ADM check the v1dump executable has been compiled.
-    readme = resource_filename('desitarget', 'urat/fortran/README')
-    cmd = resource_filename('desitarget', 'urat/fortran/v1dump')
+    readme = resources.files('desitarget').joinpath('urat/fortran/README')
+    cmd = resources.files('desitarget').joinpath('urat/fortran/v1dump')
     if not (os.path.exists(cmd) and os.access(cmd, os.X_OK)):
         msg = "{} must have been compiled (see {})".format(cmd, readme)
         log.critical(msg)


### PR DESCRIPTION
This PR cleans up a number of deprecation warnings seen in the unit tests due to:
* `pkg_resources.resource_filename` (deprecated in favor of `importlib.resources.files`; see also https://github.com/desihub/desispec/pull/2157))
* `scipy.ndimage`; and
* `pytest` (deprecated `test_suite` functions).

The `pkg_resources` warnings aren't seen in the `desitarget` tests because tests are only done against `python/3.9`, but they are seen in other packages like `fastspecfit`, which are testing against `python/3.10` and `3.11`.
