### PR TITLE
fix install with latest desiutil without DesiTest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
                 python-version: ['3.10']
                 astropy-version: ['==5.0', '<6.1']
                 fitsio-version: ['==1.2.1']
-                numpy-version: ['<2']
+                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
                 scipy-version: ['<1.9']
                 matplotlib-version: ['<3.7']
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-22.04]
-                python-version: [3.10]
+                python-version: ['3.10']
                 astropy-version: ['==5.0', '<6.1']
                 fitsio-version: ['==1.2.1']
                 numpy-version: ['<2']

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,8 @@ jobs:
             DESIMODEL_DATA: branches/test-0.17
 
         steps:
+            - name: Install System Packages
+              run: sudo apt install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v2
               with:
@@ -66,6 +68,8 @@ jobs:
             DESIMODEL_DATA: branches/test-0.17
 
         steps:
+            - name: Install System Packages
+              run: sudo apt install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v2
               with:
@@ -80,8 +84,7 @@ jobs:
                 python -m pip install pytest\<7 pytest-cov\<4 coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'matplotlib${{ matrix.matplotlib-version }}' 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-latest]
+                os: [ubuntu-22.04]
                 python-version: [3.9]
                 astropy-version: ['==5.0', '<6']  # fuji version
                 fitsio-version: ['==1.1.6']  # fuji version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,10 +17,10 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-22.04]
-                python-version: [3.11]
+                python-version: [3.9]
                 astropy-version: ['==5.0', '<6']  # fuji version
                 fitsio-version: ['==1.1.6']  # fuji version
-                numpy-version: ['<2']  # 2 not yet supported by desi
+                numpy-version: ['<1.23']  # 2 not yet supported by desi
                 matplotlib-version: ['<3.6.3']
 
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,11 +17,12 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-22.04]
-                python-version: [3.9]
-                astropy-version: ['==5.0', '<6']  # fuji version
-                fitsio-version: ['==1.1.6']  # fuji version
-                numpy-version: ['<1.23']  # 2 not yet supported by desi
-                matplotlib-version: ['<3.6.3']
+                python-version: [3.10]
+                astropy-version: ['==5.0', '<6.1']
+                fitsio-version: ['==1.2.1']
+                numpy-version: ['<2']
+                scipy-version: ['<1.9']
+                matplotlib-version: ['<3.7']
 
         env:
             DESIUTIL_VERSION: 3.2.5
@@ -42,10 +43,7 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
-                python -m pip install PIL
-                python -m pip install --no-deps -U 'matplotlib${{ matrix.matplotlib-version }}'
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'matplotlib${{ matrix.matplotlib-version }}' 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
                 astropy-version: ['==5.0', '<6']  # fuji version
                 fitsio-version: ['==1.1.6']  # fuji version
                 numpy-version: ['<2']  # 2 not yet supported by desi
-                matplotlib-version: ['3.10.0']
+                matplotlib-version: ['<3.6.3']
 
         env:
             DESIUTIL_VERSION: 3.2.5
@@ -44,7 +44,7 @@ jobs:
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
-                python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
+                python -m pip install --no-deps -U 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,6 +44,7 @@ jobs:
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install PIL
                 python -m pip install --no-deps -U 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,7 @@ jobs:
                 astropy-version: ['==5.0', '<6.1']
                 fitsio-version: ['==1.2.1']
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                numba-version: ['<0.61.0'] # for compatibility with old numpy
                 scipy-version: ['<1.9']
                 matplotlib-version: ['<3.7']
 
@@ -45,7 +46,7 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'matplotlib${{ matrix.matplotlib-version }}' 'astropy${{ matrix.astropy-version }}'
+                python -m pip install 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'matplotlib${{ matrix.matplotlib-version }}' 'astropy${{ matrix.astropy-version }}' 'numba${{ matrix.numba-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-22.04]
-                python-version: [3.9]
+                python-version: [3.11]
                 astropy-version: ['==5.0', '<6']  # fuji version
                 fitsio-version: ['==1.1.6']  # fuji version
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,8 +20,8 @@ jobs:
                 python-version: [3.11]
                 astropy-version: ['==5.0', '<6']  # fuji version
                 fitsio-version: ['==1.1.6']  # fuji version
-                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
-                matplotlib-version: ['<3.6.3'] # later versions of matplotlib require later versions of numpy.
+                numpy-version: ['<2']  # 2 not yet supported by desi
+                matplotlib-version: ['3.10.0']
 
         env:
             DESIUTIL_VERSION: 3.2.5

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -15,7 +15,7 @@ from astropy.wcs import WCS
 from time import time
 import healpy as hp
 import fitsio
-import photutils
+import photutils.aperture
 from glob import glob, iglob
 
 from desitarget.gaiamatch import get_gaia_dir

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 #
 # DESI support code.
 #
-from desiutil.setup import DesiTest, DesiVersion, get_version
+from desiutil.setup import DesiVersion, get_version
 #
 # Begin setup
 #
@@ -52,7 +52,7 @@ setup_keywords['zip_safe'] = False
 setup_keywords['use_2to3'] = False
 setup_keywords['packages'] = find_packages('py')
 setup_keywords['package_dir'] = {'':'py'}
-setup_keywords['cmdclass'] = {'version': DesiVersion,'test': DesiTest}
+setup_keywords['cmdclass'] = {'version': DesiVersion}
 setup_keywords['test_suite']='{name}.test.{name}_test_suite.{name}_test_suite'.format(**setup_keywords)
 #
 # Autogenerate command-line scripts.
@@ -70,6 +70,13 @@ setup_keywords['package_data'] = {'desitarget': ['data/*',],
                                   'desitarget.mock': [os.path.relpath(_,'py/desitarget/mock') for _ in [os.path.join(_[0],'*') for _ in os.walk('py/desitarget/mock/data')]],
                                   'desitarget.streams.gaia_dr3_parallax_zero_point': ['coefficients/*',],
                                   }
+
+#
+# Print informative message if user tried "python setup.py test"
+if "test" in sys.argv:
+    print("Please run pytest instead")
+    sys.exit(1)
+
 #
 # Run setup command.
 #


### PR DESCRIPTION
desihub/desiutil#212 removed `desiutil.setup.DesiTest`, which broke the ability to install desitarget when using the latest desiutil.  This PR fixes that by removing the DesiTest import from setup.py.  Now to run desitarget tests you have to use `pytest` and not `python setup.py test`.  That has been our recommendation for awhile (and how github actions and NERSC tests have been performed), but this PR removes support for the old `python setup.py test` option.

With current main this fails with "ImportError: cannot import name 'DesiTest' from 'desiutil.setup'":
```
conda create --yes --name desitest 'numpy<2' 'astropy<7'
conda activate desitest

pip install git+https://github.com/desihub/desiutil.git@main
pip install git+https://github.com/desihub/desitarget.git@main
```

Replacing that last line with this branch works
```
pip install git+https://github.com/desihub/desitarget.git@fix-install
```

After merging this branch, it should be possible to install desitarget/main when using desiutil/main.