### PR TITLE
Implement multi-MTL procedure for the DESI extension

### DIFF
--- a/bin/make_initial_mtl_ledger
+++ b/bin/make_initial_mtl_ledger
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from desitarget.mtl import make_ledger, get_mtl_dir, _get_mtl_nside
+from desitarget.QA import _parse_tcnames
 
 # ADM this is the upper-limit for memory for mtl._get_mtl_nside()=32.
 nproc = 12
@@ -44,6 +45,9 @@ ap.add_argument('--timestamp',
 ap.add_argument('--append', action='store_true',
                 help="Append to existing ledgers, instead of writing new ones.  \
                 Particularly useful when adding new secondary targets")
+ap.add_argument('--tcnames', default=None,
+                help="Comma-separated names of target classes to run (e.g. QSO,LGE).")
+
 
 ns = ap.parse_args()
 
@@ -52,5 +56,12 @@ pixlist = ns.healpixels
 if pixlist is not None:
     pixlist = [int(pix) for pix in pixlist.split(',')]
 
+# ADM parse and check the list of target classes to run.
+if ns.tcnames is None:
+    tcnames = None
+else:
+    tcnames = _parse_tcnames(tcstring=ns.tcnames, add_all=False)
+
 make_ledger(ns.targdir, ns.dest, pixlist=pixlist, obscon=ns.obscon,
-            numproc=ns.numproc, timestamp=ns.timestamp, append=ns.append)
+            numproc=ns.numproc, timestamp=ns.timestamp, append=ns.append,
+            tcnames=tcnames)

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -11,8 +11,9 @@ from argparse import ArgumentParser
 ap = ArgumentParser(description='Update ledgers for the Merged Target based on new spectroscopic observations')
 ap.add_argument("obscon",
                 help="String matching ONE obscondition in the bitmask yaml file \
-                (e.g. 'BRIGHT'). Controls priorities when merging targets,      \
-                which tiles to process, etc.", choices=["DARK", "BRIGHT", "BACKUP"])
+                (e.g. 'BRIGHT'). Controls priorities when merging targets, which\
+                tiles to process, etc.", choices=["DARK", "BRIGHT", "BACKUP",
+                                                  "DARK1B", "BRIGHT1B"])
 ap.add_argument("-s", "--survey",
                 help="Flavor of survey to run. Defaults to [{}]".format(survey),
                 default=survey, choices=["main", "sv3", "sv2"])
@@ -48,11 +49,19 @@ scndstates = [False]
 
 # ADM if nosecondary wasn't passed, also process the secondary ledger
 # ADM for programs that actually have secondary ledgers (BRIGHT/DARK).
-if ns.obscon in ["BRIGHT", "DARK"]:
+if ns.obscon in ["BRIGHT", "DARK", "BRIGHT1B", "DARK1B"]:
     if not(ns.nosecondary):
         scndstates = [True, False]
 
 premsg = ["Processed", "REprocessed"][ns.reprocess]
+
+# ADM for the DESI extension (1B) first use the redshifts on the 1B tiles
+# ADM to update the Main Survey ledgers.
+if "1B" in ns.obscon:
+    obscon = ns.obscon.split("1B")[0]
+    loop_ledger(
+        obscon, survey='main', zcatdir=ns.zcatdir, mtldir=ns.mtldir,
+        secondary=False, reprocess=ns.reprocess, ext=True)
 
 for secondary in scndstates:
     # ADM run through the regular loop once.

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -215,12 +215,13 @@ if ns.bundlefiles is None:
     _, _, _, _, _, gaiadr = decode_targetid(targets["TARGETID"])
     isgaia = gaiadr > 0
     # ADM write out bright-time and dark-time targets separately,
-    # ADM together with the Gaia-only back-up objects.
+    # ADM together with the Gaia-only back-up objects
+    # ADM and the extension targets.
     # ADM can use DARK for the back-up/supp objects as they never
     # ADM need merged with another target.
-    obscons = ["BRIGHT", "DARK", "BACKUP"]
-    iis = [~isgaia, ~isgaia, isgaia]
-    supps = [False, False, True]
+    obscons = ["BRIGHT", "DARK", "BACKUP", "BRIGHT1B", "DARK1B"]
+    iis = [~isgaia, ~isgaia, isgaia, ~isgaia, ~isgaia]
+    supps = [False, False, True, False, False]
     if ns.writeall:
         obscons.append(None)
         iis.append(~isgaia)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,13 @@ desitarget Change Log
 2.8.0 (2024-08-23)
 ------------------
 
+* Implement multi-MTL procedure for the DESI extension [`PR #833`_].
+    * New dark-time targets for the DESI extension.
+    * New ledger types for DARK1B and BRIGHT1B.
+    * Update :func:`io.read_mtl_ledger()` to handle two sets of ledgers.
+    * Upate readers that wrap :func:`io.read_mtl_ledger()`.
+    * Add `HIGHEST`/`WANTED`/`CONTAINS` columns in multi-MTL mode.
+    * MTL loop updates Main Survey *and* 1B ledgers for extension tiles.
 * Attempt to fix coverage tests [`PR #831`_]
     * Didn't appear to fully work, but partial progress so merged.
 * Fix `pkg_resources`/`scipy.ndimage`/`pytest` deprecations [`PR #829`_].
@@ -50,6 +57,7 @@ desitarget Change Log
 .. _`PR #828`: https://github.com/desihub/desitarget/pull/828
 .. _`PR #829`: https://github.com/desihub/desitarget/pull/829
 .. _`PR #831`: https://github.com/desihub/desitarget/pull/831
+.. _`PR #833`: https://github.com/desihub/desitarget/pull/833
 
 2.7.0 (2023-12-05)
 ------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -51,9 +51,9 @@ def _parse_tcnames(tcstring=None, add_all=True):
 
     Parameters
     ----------
-    tcstring : :class:`str`, optional, defaults to `"ELG,QSO,LRG,MWS,BGS,STD,(ALL)"`
+    tcstring : :class:`str`, optional, defaults to `"ELG,QSO,LRG,MWS,BGS,STD,LGE(ALL)"`
         Comma-separated names of target classes e.g. QSO,LRG.
-        Options are `ELG`, `QSO`, `LRG`, `MWS`, `BGS`, `STD`.
+        Options are `ELG`, `QSO`, `LRG`, `MWS`, `BGS`, `STD`, "LGE".
     add_all : :class:`boolean`, optional, defaults to ``True``
         If ``True``, then include `ALL` in the default names.
 
@@ -67,9 +67,9 @@ def _parse_tcnames(tcstring=None, add_all=True):
         - One use of this function is to check for valid target class
           strings. An IOError is raised if a string is invalid.
     """
-    tcdefault = ["ELG", "QSO", "LRG", "MWS", "BGS", "STD"]
+    tcdefault = ["ELG", "QSO", "LRG", "MWS", "BGS", "STD", "LGE"]
     if add_all:
-        tcdefault = ["ELG", "QSO", "LRG", "MWS", "BGS", "STD", "ALL"]
+        tcdefault = ["ELG", "QSO", "LRG", "MWS", "BGS", "STD", "LGE", "ALL"]
 
     if tcstring is None:
         tcnames = tcdefault

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -479,7 +479,7 @@ def isBACKUP(ra=None, dec=None,
 def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
           zfiberflux=None, rfluxivar=None, zfluxivar=None, w1fluxivar=None,
           gaiagmag=None, gnobs=None, rnobs=None, znobs=None, maskbits=None,
-          zfibertotflux=None, primary=None, south=True, ext=None):
+          zfibertotflux=None, primary=None, south=True, ext=False):
     """
     Parameters
     ----------
@@ -487,9 +487,9 @@ def isLRG(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         Use cuts appropriate to the Northern imaging surveys (BASS/MzLS)
         if ``south=False``, otherwise use cuts appropriate to the
         Southern imaging survey (DECaLS).
-    ext: int, defaults to ``None``
-        Use a possible DESI extension selection. Pass ``None`` to ignore,
-        or 1 or 2 for DESI extension selection 1 or 2.
+    ext: int, defaults to ``False``
+        If ``True``, then apply the DESI extension selection instead of
+        the standard Main Survey selection.
 
     Returns
     -------
@@ -561,7 +561,7 @@ def notinLRG_mask(primary=None, rflux=None, zflux=None, w1flux=None,
 def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
                  gfiberflux=None, rfiberflux=None, zfiberflux=None,
                  ggood=None, w2flux=None, primary=None, south=True,
-                 ext=None):
+                 ext=False):
     """(see, e.g., :func:`~desitarget.cuts.isLRG`).
 
     Notes:
@@ -583,26 +583,18 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
         lrg &= zmag - w1mag > 0.8 * (rmag - zmag) - 0.6  # non-stellar cut
         lrg &= zfibermag < 21.6                   # faint limit
         lrg &= (gmag - w1mag > 2.9) | (rmag - w1mag > 1.8)  # low-z cuts
-        if ext is None:
+        if not ext:
             lrg &= (
                 ((rmag - w1mag > (w1mag - 17.14) * 1.8)
                  & (rmag - w1mag > (w1mag - 16.33) * 1.))
                 | (rmag - w1mag > 3.3)
             )  # double sliding cuts and high-z extension.
-        elif ext == 1:
+        else:
             lrg &= (
                 ((rmag - w1mag > (w1mag - 17.14 - 0.275) * 1.8)
                  & (rmag - w1mag > (w1mag - 16.33 - 0.275) * 1.))
                 | (rmag - w1mag > 3.3 - 0.1)
             )  # double sliding cuts and high-z extension.
-        elif ext == 2:
-            lrgmain = (
-                ((rmag - w1mag > (w1mag - 17.14 - 0.19) * 1.8)
-                 & (rmag - w1mag > (w1mag - 16.33 - 0.19) * 1.))
-                | (rmag - w1mag > 3.3 - 0.1)
-            )  # double sliding cuts and high-z extension.
-            lrgext = (((rmag - zmag -(-0.1))**2 + (gmag - rmag -(2.3))**2) > 2**2) & (rmag - zmag > 0.4)
-            lrg &= lrgmain | lrgext
     else:
         lrg &= zmag - w1mag > 0.8 * (rmag - zmag) - 0.6  # non-stellar cut
         lrg &= zfibermag < 21.61                   # faint limit
@@ -2435,7 +2427,8 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # ADM combine LRG target bits for an LRG target based on any imaging.
     lrg = (lrg_north & photsys_north) | (lrg_south & photsys_south)
 
-    # ADM initially set everything to arrays of False for LRG ext-1 selection.
+    # ADM add the LRG extension selection.
+    # ADM initially set to arrays of False for LRG extension selection.
     # ADM zeroth element stores the northern targets bits (south=False).
     lrg_classes = [tcfalse, tcfalse]
     if "LRG" in tcnames:
@@ -2446,30 +2439,12 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
                 zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
                 rfluxivar=rfluxivar, zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
                 gaiagmag=gaiagmag, zfibertotflux=zfibertotflux,
-                maskbits=maskbits, south=south, ext=1
+                maskbits=maskbits, south=south, ext=True
             )
-    lrg_north_ext1, lrg_south_ext1 = lrg_classes
+    lrg_north_ext, lrg_south_ext = lrg_classes
 
     # ADM combine LRG target bits for an LRG target based on any imaging.
-    lrg_ext1 = (lrg_north_ext1 & photsys_north) | (lrg_south_ext1 & photsys_south)
-
-    # ADM initially set everything to arrays of False for LRG selection.
-    # ADM zeroth element stores the northern targets bits (south=False).
-    lrg_classes = [tcfalse, tcfalse]
-    if "LRG" in tcnames:
-        for south in south_cuts:
-            lrg_classes[int(south)] = isLRG(
-                primary=primary,
-                gflux=gflux, rflux=rflux, zflux=zflux, w1flux=w1flux,
-                zfiberflux=zfiberflux, gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                rfluxivar=rfluxivar, zfluxivar=zfluxivar, w1fluxivar=w1fluxivar,
-                gaiagmag=gaiagmag, zfibertotflux=zfibertotflux,
-                maskbits=maskbits, south=south, ext=2
-            )
-    lrg_north_ext2, lrg_south_ext2 = lrg_classes
-
-    # ADM combine LRG target bits for an LRG target based on any imaging.
-    lrg_ext2 = (lrg_north_ext2 & photsys_north) | (lrg_south_ext2 & photsys_south)
+    lrg_ext = (lrg_north_ext & photsys_north) | (lrg_south_ext & photsys_south)
 
     # ADM initially set everything to arrays of False for ELG selection.
     # ADM zeroth element stores the northern targets bits (south=False).
@@ -2676,6 +2651,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= (elg_vlo_south & res_south) * desi_mask.ELG_VLO_SOUTH
     desi_target |= (elg_lop_south & res_south) * desi_mask.ELG_LOP_SOUTH
     desi_target |= (qso_south & res_south) * desi_mask.QSO_SOUTH
+    desi_target |= (lrg_south_ext & res_south) * desi_mask.LGE_SOUTH
 
     # Construct the targetflag bits for MzLS and BASS (i.e. North).
     desi_target |= (lrg_north & res_north) * desi_mask.LRG_NORTH
@@ -2683,6 +2659,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= (elg_vlo_north & res_north) * desi_mask.ELG_VLO_NORTH
     desi_target |= (elg_lop_north & res_north) * desi_mask.ELG_LOP_NORTH
     desi_target |= (qso_north & res_north) * desi_mask.QSO_NORTH
+    desi_target |= (lrg_north_ext & res_north) * desi_mask.LGE_NORTH
 
     # Construct the target flag bits combining north and south.
     desi_target |= lrg * desi_mask.LRG
@@ -2690,8 +2667,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     desi_target |= elg_vlo * desi_mask.ELG_VLO
     desi_target |= elg_lop * desi_mask.ELG_LOP
     desi_target |= qso * desi_mask.QSO
-    desi_target |= lrg_ext1 * desi_mask.LRG_EXT1
-    desi_target |= lrg_ext2 * desi_mask.LRG_EXT2
+    desi_target |= lrg_ext * desi_mask.LGE
 
     # ADM set fraction of the ELG_LOP/ELG_VLO targets to ELG_HIP.
     desi_target |= elg_hip * desi_mask.ELG_HIP

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2362,7 +2362,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     tcnames : :class:`list`, defaults to running all target classes
         A list of strings, e.g. ['QSO','LRG']. If passed, process only
         only those specific target classes. A useful speed-up for tests.
-        Options include ["ELG", "QSO", "LRG", "MWS", "BGS", "STD"].
+        Options are ["ELG", "QSO", "LRG", "MWS", "BGS", "STD", "LGE"].
     qso_optical_cuts : :class:`boolean` defaults to ``False``
         Apply just optical color-cuts when selecting QSOs with
         ``qso_selection="colorcuts"``.
@@ -2431,7 +2431,7 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
     # ADM initially set to arrays of False for LRG extension selection.
     # ADM zeroth element stores the northern targets bits (south=False).
     lrg_classes = [tcfalse, tcfalse]
-    if "LRG" in tcnames:
+    if "LGE" in tcnames:
         for south in south_cuts:
             lrg_classes[int(south)] = isLRG(
                 primary=primary,
@@ -2850,7 +2850,7 @@ def apply_cuts_gaia(numproc=4, survey='main', nside=None, pixlist=None,
 
 
 def apply_cuts(objects, qso_selection='randomforest',
-               tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD"],
+               tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD", "LGE"],
                qso_optical_cuts=False, survey='main', resolvetargs=True,
                mask=True):
     """Perform target selection on objects, returning target mask arrays.
@@ -2866,7 +2866,7 @@ def apply_cuts(objects, qso_selection='randomforest',
     tcnames : :class:`list`, defaults to running all target classes
         A list of strings, e.g. ['QSO','LRG']. If passed, process targets
         only for those specific classes. A useful speed-up when testing.
-        Options include ["ELG", "QSO", "LRG", "MWS", "BGS", "STD"].
+        Options are ["ELG", "QSO", "LRG", "MWS", "BGS", "STD", "LGE"].
     qso_optical_cuts : :class:`boolean` defaults to ``False``
         Apply just optical color-cuts when selecting QSOs with
         ``qso_selection="colorcuts"``.
@@ -2970,7 +2970,7 @@ qso_selection_options = ['colorcuts', 'randomforest']
 def select_targets(infiles, numproc=4, qso_selection='randomforest',
                    gaiasub=False, nside=None, pixlist=None, bundlefiles=None,
                    extra=None, radecbox=None, radecrad=None, mask=True,
-                   tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD"],
+                   tcnames=["ELG", "QSO", "LRG", "MWS", "BGS", "STD", "LGE"],
                    survey='main', resolvetargs=True, backup=True,
                    return_infiles=False, test=False):
     """Process input files in parallel to select targets.
@@ -3015,7 +3015,7 @@ def select_targets(infiles, numproc=4, qso_selection='randomforest',
     tcnames : :class:`list`, defaults to running all target classes
         List of strings, e.g. ['QSO','LRG']. If passed, process targets
         only for those specific classes. A useful speed-up when testing.
-        Options include ["ELG", "QSO", "LRG", "MWS", "BGS", "STD"].
+        Options are ["ELG", "QSO", "LRG", "MWS", "BGS", "STD", "LGE"].
     survey : :class:`str`, defaults to ``'main'``
         Which target masks yaml file and target selection cuts to use.
         Options are ``'main'`` and ``'svX``' (where X is 1, 2, 3 etc.)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -601,7 +601,7 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
                  & (rmag - w1mag > (w1mag - 16.33 - 0.19) * 1.))
                 | (rmag - w1mag > 3.3 - 0.1)
             )  # double sliding cuts and high-z extension.
-            lrgext = (((r-z-(-0.1))**2 + (g-r-(2.3))**2) > 2**2) & (r-z > 0.4)
+            lrgext = (((rmag - zmag -(-0.1))**2 + (gmag - rmag -(2.3))**2) > 2**2) & (rmag - zmag > 0.4)
             lrg &= lrgmain | lrgext
     else:
         lrg &= zmag - w1mag > 0.8 * (rmag - zmag) - 0.6  # non-stellar cut

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -599,7 +599,7 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
                  & (rmag - w1mag > (w1mag - 16.33 - 0.275) * 1.))
                 | (rmag - w1mag > 3.3 - 0.1)
             )  # double sliding cuts and high-z extension.
-            lrg &= ~lrgmaindsc # exclude DESI-1 LRGs.
+            lrg &= ~lrgmaindsc  # exclude DESI-1 LRGs.
     else:
         lrg &= zmag - w1mag > 0.8 * (rmag - zmag) - 0.6  # non-stellar cut.
         lrg &= zfibermag < 21.61                   # faint limit.

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -25,6 +25,10 @@ desi_mask:
     - [ELG_LOP_SOUTH,     19, "ELG at standard (ELG) priority tuned for DECam data",                       {obsconditions: DARK}]
     - [ELG_VLO_SOUTH,     20, "Very-low priority ELG (filler) tuned for DECam data",                       {obsconditions: DARK}]
 
+    # ADM LRG sub-classes
+    - [LRG_EXT1,     21, "LRG for DESI extension possible selection 1",              {obsconditions: DARK}]
+    - [LRG_EXT2,     22, "LRG for DESI extension possible selection 2",              {obsconditions: DARK}]
+
     #- Calibration targets
     - [SKY,         32, "Blank sky locations",                                       {obsconditions: DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18}]
     - [STD_FAINT,   33, "Standard stars for dark/gray conditions",                   {obsconditions: DARK}]
@@ -294,6 +298,10 @@ priorities:
         ELG_LOP_SOUTH: SAME_AS_LRG_NORTH
         ELG_VLO_SOUTH: SAME_AS_LRG_NORTH
 
+# ADM DESI extension targets same as LRGs.
+        LRG_EXT1: SAME_AS_LRG
+        LRG_EXT2: SAME_AS_LRG
+
 # ADM calibration and other non-standard targets.
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, MORE_MIDZQSO: 0}
         #- Standards and sky are treated specially; priorities don't apply
@@ -449,6 +457,10 @@ numobs:
         ELG_LOP_SOUTH: 0
         ELG_VLO_SOUTH: 0
         BAD_SKY:       0
+
+# ADM LRG extension targets.
+        LRG_EXT1: 2
+        LRG_EXT2: 2
 
 #- Standards and sky are treated specially; NUMOBS doesn't apply.
         STD_FAINT:         -1

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -1,8 +1,9 @@
 #- DESI primary survey target bit mask: dark survey + calib +
 desi_mask:
-    - [LRG,         0, "LRG", {obsconditions: DARK}]
-    - [ELG,         1, "ELG", {obsconditions: DARK}]
-    - [QSO,         2, "QSO", {obsconditions: DARK}]
+    - [LRG,         0, "LRG",                    {obsconditions: DARK}]
+    - [ELG,         1, "ELG",                    {obsconditions: DARK}]
+    - [QSO,         2, "QSO",                    {obsconditions: DARK}]
+    - [LGE,         3, "LRG for DESI extension", {obsconditions: DARK}]
 
     #- ADM QSO sub-classes. Used in SV but ultimately deprecated for the Main Survey.
     - [QSO_HIZ,     4, "QSO selected using high-redshift Random Forest (informational bit)", {obsconditions: DARK}]
@@ -18,16 +19,14 @@ desi_mask:
     - [QSO_NORTH,         10, "QSO cuts tuned for Bok/Mosaic data",                                        {obsconditions: DARK}]
     - [ELG_LOP_NORTH,     11, "ELG at standard (ELG) priority tuned for Bok/Mosaic data",                  {obsconditions: DARK}]
     - [ELG_VLO_NORTH,     12, "Very-low priority ELG (filler) tuned for Bok/Mosaic data",                  {obsconditions: DARK}]
+    - [LGE_NORTH,         13, "LRG extension cuts tuned for Bok/Mosaic data",                              {obsconditions: DARK}]
 
     - [LRG_SOUTH,         16, "LRG cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [ELG_SOUTH,         17, "ELG cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [QSO_SOUTH,         18, "QSO cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [ELG_LOP_SOUTH,     19, "ELG at standard (ELG) priority tuned for DECam data",                       {obsconditions: DARK}]
     - [ELG_VLO_SOUTH,     20, "Very-low priority ELG (filler) tuned for DECam data",                       {obsconditions: DARK}]
-
-    # ADM LRG sub-classes
-    - [LRG_EXT1,     21, "LRG for DESI extension possible selection 1",              {obsconditions: DARK}]
-    - [LRG_EXT2,     22, "LRG for DESI extension possible selection 2",              {obsconditions: DARK}]
+    - [LGE_SOUTH,         21, "LRG extension cuts tuned for DECam data",                                   {obsconditions: DARK}]
 
     #- Calibration targets
     - [SKY,         32, "Blank sky locations",                                       {obsconditions: DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18}]
@@ -277,6 +276,9 @@ priorities:
 # ADM of 100 should only be higher than DONE (and secondary filler) targets.
         QSO: {UNOBS: 3400, MORE_ZGOOD: 3350, MORE_ZWARN: 3300, MORE_MIDZQSO: 100, DONE: 2, OBS: 1, DONOTOBSERVE: 0}
 
+# ADM DESI extension LRGs. Cancun meeting conclusion was to have these a little higher than the Main Survey LRGs.
+        LGE: {UNOBS: 3210, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+
 # ADM different priority ELGs.
         ELG_LOP: {UNOBS: 3100, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         ELG_HIP: SAME_AS_LRG
@@ -291,16 +293,14 @@ priorities:
         QSO_NORTH: SAME_AS_LRG_NORTH
         ELG_LOP_NORTH: SAME_AS_LRG_NORTH
         ELG_VLO_NORTH: SAME_AS_LRG_NORTH
+        LGE_NORTH: SAME_AS_LRG_NORTH
 
         LRG_SOUTH: SAME_AS_LRG_NORTH
         ELG_SOUTH: SAME_AS_LRG_NORTH
         QSO_SOUTH: SAME_AS_LRG_NORTH
         ELG_LOP_SOUTH: SAME_AS_LRG_NORTH
         ELG_VLO_SOUTH: SAME_AS_LRG_NORTH
-
-# ADM DESI extension targets same as LRGs.
-        LRG_EXT1: SAME_AS_LRG
-        LRG_EXT2: SAME_AS_LRG
+        LGE_SOUTH: SAME_AS_LRG_NORTH
 
 # ADM calibration and other non-standard targets.
         BAD_SKY: {UNOBS: 0, OBS: 0, DONE: 0, MORE_ZWARN: 0, MORE_ZGOOD: 0, MORE_MIDZQSO: 0}
@@ -440,6 +440,9 @@ numobs:
         LRG: 2
         QSO: 4
 
+# ADM LRG targets for the DESI extension.
+        LGE: 2
+
 # ADM different flavors of ELGs.
         ELG_LOP: 2
         ELG_HIP: 2
@@ -457,10 +460,8 @@ numobs:
         ELG_LOP_SOUTH: 0
         ELG_VLO_SOUTH: 0
         BAD_SKY:       0
-
-# ADM LRG extension targets.
-        LRG_EXT1: 2
-        LRG_EXT2: 2
+        LGE_NORTH:     0
+        LGE_SOUTH:     0
 
 #- Standards and sky are treated specially; NUMOBS doesn't apply.
         STD_FAINT:         -1

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -3,7 +3,7 @@ desi_mask:
     - [LRG,         0, "LRG",                    {obsconditions: DARK}]
     - [ELG,         1, "ELG",                    {obsconditions: DARK}]
     - [QSO,         2, "QSO",                    {obsconditions: DARK}]
-    - [LGE,         3, "LRG for DESI extension", {obsconditions: DARK}]
+    - [LGE,         3, "LRG for DESI extension", {obsconditions: DARK1B}]
 
     #- ADM QSO sub-classes. Used in SV but ultimately deprecated for the Main Survey.
     - [QSO_HIZ,     4, "QSO selected using high-redshift Random Forest (informational bit)", {obsconditions: DARK}]
@@ -19,14 +19,14 @@ desi_mask:
     - [QSO_NORTH,         10, "QSO cuts tuned for Bok/Mosaic data",                                        {obsconditions: DARK}]
     - [ELG_LOP_NORTH,     11, "ELG at standard (ELG) priority tuned for Bok/Mosaic data",                  {obsconditions: DARK}]
     - [ELG_VLO_NORTH,     12, "Very-low priority ELG (filler) tuned for Bok/Mosaic data",                  {obsconditions: DARK}]
-    - [LGE_NORTH,         13, "LRG extension cuts tuned for Bok/Mosaic data",                              {obsconditions: DARK}]
+    - [LGE_NORTH,         13, "LRG extension cuts tuned for Bok/Mosaic data",                              {obsconditions: DARK1B}]
 
     - [LRG_SOUTH,         16, "LRG cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [ELG_SOUTH,         17, "ELG cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [QSO_SOUTH,         18, "QSO cuts tuned for DECam data",                                             {obsconditions: DARK}]
     - [ELG_LOP_SOUTH,     19, "ELG at standard (ELG) priority tuned for DECam data",                       {obsconditions: DARK}]
     - [ELG_VLO_SOUTH,     20, "Very-low priority ELG (filler) tuned for DECam data",                       {obsconditions: DARK}]
-    - [LGE_SOUTH,         21, "LRG extension cuts tuned for DECam data",                                   {obsconditions: DARK}]
+    - [LGE_SOUTH,         21, "LRG extension cuts tuned for DECam data",                                   {obsconditions: DARK1B}]
 
     #- Calibration targets
     - [SKY,         32, "Blank sky locations",                                       {obsconditions: DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18}]
@@ -203,6 +203,8 @@ obsconditions:
     - [CLOSED,      7, "Nighttime but dome is closed due to rain, wind, dew..."]
     - [APOCALYPSE,  8, "Conditions are so bad that the world is ending anyway"]
     - [IGNORE,      9, "Used to indicate that obsconditions are set by a sub-bit rather than this bit"]
+    - [DARK1B,     10, "Moon is down, DESI extension survey"]
+    - [BRIGHT1B,   11, "Moon up and bright, DESI extension survey"]
 
 #- Observation State
 #- if a target passes more than one target bit, it is possible that one bit

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1004,7 +1004,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             pixtracker.append(strgoodpix)
             if extra is not None:
                 strgoodpix += extra
-            print("srun -N 1 {}_{} {} $CSCRATCH {} --nside {} --healpixels {} &"
+            print("srun -N 1 {}_{} {} $SCRATCH {} --nside {} --healpixels {} &"
                   .format(cmd, prefix2, surveydir, s2, nside, strgoodpix))
     print("wait")
     print("")
@@ -1016,11 +1016,11 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             outfiles = []
             for pix in pixtracker:
                 outfn = find_target_files(
-                    "$CSCRATCH", dr=ddrr, flavor=prefix, seed=seed, hp=pix,
+                    "$SCRATCH", dr=ddrr, flavor=prefix, seed=seed, hp=pix,
                     resolve=resolve, region=region)
                 outfiles.append(outfn)
             outfn = find_target_files(
-                "$CSCRATCH", dr=ddrr, flavor=prefix, seed=seed, nohp=True,
+                "$SCRATCH", dr=ddrr, flavor=prefix, seed=seed, nohp=True,
                 resolve=resolve, region=region)
             print("")
             # ADM split each pixel-file into 10 smaller catalogs.

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -3469,10 +3469,14 @@ def read_mtl_in_hp(hpdirname, nside, pixlist, unique=True, isodate=None,
 
         # ADM if no mtls, look up the data model, return an empty array.
         if len(mtls) == 0:
-            fns = iglob(fileform.format("*"))
+            fns = iglob(fileforms[0].format("*"))
             fn = next(fns)
             mtl = read_mtl_ledger(fn, columns=columns, tabform=tabform)
-            outly = np.zeros(0, dtype=mtl.dtype)
+            dt = mtl.dtype.descr
+            if len(hpdirname) > 1:
+                dt += [("MTL_HIGHEST", ">i4"), ("MTL_WANTED", ">i4"),
+                       ("MTL_CONTAINS", ">i4")]
+            outly = np.zeros(0, dtype=dt)
             if returnfn:
                 return outly, outfns
             return outly

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -3448,7 +3448,7 @@ def read_mtl_in_hp(hpdirname, nside, pixlist, unique=True, isodate=None,
             raise IOError(msg)
 
         # ADM change the passed pixels to the nside of the file schema.
-        filepixlist.append(sorted(nside2nside(nside, filenside, pixlist)))
+        filepixlist = nside2nside(nside, filenside, pixlist)
 
         # ADM read in the files and concatenate the resulting targets.
         mtls = []

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -4057,11 +4057,16 @@ def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False,
                 columnscopy.append(radec)
                 addedcols.append(radec)
 
-    # ADM check some ways for which we must be reading MTLs.
+    # ADM check some ways for which we *must* be reading MTLs...
+    # ADM ...multi-mode must be MTL-like...
     if isinstance(hpdirname, list):
         mtlmode=True
+    # ADM ...a directory rather than a file must be MTL-like...
     elif os.path.isdir(hpdirname):
         mtlmode=True
+    # ADM ...a file isn't necessarily MTL-like unless mtl=True is passed.
+    else:
+        mtlmode=False
 
     # ADM if a directory was passed, do fancy HEALPixel parsing...
     if mtlmode or mtl:

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -3363,10 +3363,10 @@ def read_mtl_in_hp(hpdirname, nside, pixlist, unique=True, isodate=None,
     ----------
     hpdirname : :class:`str` or `list`
         if a string:
-            Full path to either a directory containing targets that
+            Full path to either a directory containing MTLs that
             have been partitioned by HEALPixel (i.e. as made by
             `select_targets` with the `bundle_files` option). Or the
-            name of a single file of targets.
+            name of a single MTL of targets.
         If a list:
             Then this must be a list of two strings, with the strings
             having the same meaning as if one string is passed. The code
@@ -3508,16 +3508,27 @@ def read_mtl_in_hp(hpdirname, nside, pixlist, unique=True, isodate=None,
 def read_targets_in_hp(hpdirname, nside, pixlist, columns=None, header=False,
                        quick=False, downsample=None, verbose=False, mtl=False,
                        unique=True, isodate=None, initial=False, leq=False,
-                       tabform='ascii.basic'):
+                       tabform='ascii.basic', maketwostyle=False):
     """Read in targets in a set of HEALPixels.
 
     Parameters
     ----------
-    hpdirname : :class:`str`
-        Full path to either a directory containing targets that
-        have been partitioned by HEALPixel (i.e. as made by
-        `select_targets` with the `bundle_files` option). Or the
-        name of a single file of targets.
+    hpdirname : :class:`str` or `list`
+        if a string:
+            Full path to either a directory containing MTLs or targets
+            partitioned by HEALPixel (i.e. as made by `select_targets`
+            with the `bundle_files` option). Or the name of a single MTL
+            or file of targets.
+        If a list:
+            Then this must be a list of two strings, with the strings
+            having the same meaning as if one string is passed. The code
+            switches to "multi-MTL" mode, where two MTLs are merged by
+            matching on TARGETID and taking the highest-priority target.
+            Extra columns are added to the output, indicating which of
+            the MTLs was interested in each target. The strings must be
+            the same input type, i.e. either two directories or files.
+            The directories or files must share the same `nside`. For
+            this mode, the input `mtl` must be ``True``.
     nside : :class:`int`
         The (NESTED) HEALPixel nside.
     pixlist : :class:`list` or `int` or `~numpy.ndarray`
@@ -3565,6 +3576,10 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None, header=False,
         ('ascii.basic') is standard for reading and writing MTL files.
         But 'ascii.ecsv' is useful for some of the mock/alt-MTL work.
         Only relevant when `mtl` is ``True``.
+    maketwostyle : :class:`bool`, optional, defaults to ``False``
+        If passed, add the extra columns that are added when running
+        :func:`read_two_mtl_ledgers()`, even if only reading one ledger.
+        Only works when reading in MTLs rather than target files.
 
     Returns
     -------
@@ -3589,7 +3604,7 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None, header=False,
     if mtl:
         return read_mtl_in_hp(
             hpdirname, nside, pixlist, unique=unique, isodate=isodate,
-            initial=initial, leq=leq, tabform=tabform)
+            initial=initial, leq=leq, tabform=tabform, maketwostyle=maketwostyle)
 
     # ADM allow an integer instead of a list to be passed.
     if isinstance(pixlist, int):
@@ -3927,16 +3942,27 @@ def read_targets_in_quick(hpdirname, shape=None,
 def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False,
                           quick=False, mtl=False, oldstyle=False, verbose=False,
                           unique=True, isodate=None, initial=False, leq=False,
-                          tabform='ascii.basic'):
+                          tabform='ascii.basic', maketwostyle=False):
     """Read targets in DESI tiles, assuming the "standard" data model.
 
     Parameters
     ----------
-    hpdirname : :class:`str`
-        Full path to either a directory containing targets that
-        have been partitioned by HEALPixel (e.g. as made by
-        `select_targets` with the `bundle_files` option). Or the
-        name of a single file of targets.
+    hpdirname : :class:`str` or `list`
+        if a string:
+            Full path to either a directory containing MTLs or targets
+            partitioned by HEALPixel (i.e. as made by `select_targets`
+            with the `bundle_files` option). Or the name of a single MTL
+            or file of targets.
+        If a list:
+            Then this must be a list of two strings, with the strings
+            having the same meaning as if one string is passed. The code
+            switches to "multi-MTL" mode, where two MTLs are merged by
+            matching on TARGETID and taking the highest-priority target.
+            Extra columns are added to the output, indicating which of
+            the MTLs was interested in each target. The strings must be
+            the same input type, i.e. either two directories or files.
+            The directories or files must share the same `nside`. For
+            this mode the input `mtl` must be ``True``.
     tiles : :class:`~numpy.ndarray`, optional
         Array of tiles in the desimodel format, or ``None`` to use all
         DESI tiles from :func:`desimodel.io.load_tiles`.
@@ -3983,6 +4009,10 @@ def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False,
         ('ascii.basic') is standard for reading and writing MTL files.
         But 'ascii.ecsv' is useful for some of the mock/alt-MTL work.
         Only relevant when `mtl` is ``True``.
+    maketwostyle : :class:`bool`, optional, defaults to ``False``
+        If passed, add the extra columns that are added when running
+        :func:`read_two_mtl_ledgers()`, even if only reading one ledger.
+        Only works when reading in MTLs rather than target files.
 
     Returns
     -------
@@ -4027,8 +4057,14 @@ def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False,
                 columnscopy.append(radec)
                 addedcols.append(radec)
 
+    # ADM check some ways for which we must be reading MTLs.
+    if isinstance(hpdirname, list):
+        mtlmode=True
+    elif os.path.isdir(hpdirname):
+        mtlmode=True
+
     # ADM if a directory was passed, do fancy HEALPixel parsing...
-    if os.path.isdir(hpdirname) or mtl:
+    if mtlmode or mtl:
         # ADM closest nside to DESI tile area of ~7 deg.
         nside = pixarea2nside(7.)
 
@@ -4039,7 +4075,7 @@ def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False,
         targets = read_targets_in_hp(
             hpdirname, nside, pixlist, columns=columnscopy, header=header,
             mtl=mtl, unique=unique, isodate=isodate, initial=initial, leq=leq,
-            tabform=tabform)
+            tabform=tabform, maketwostyle=maketwostyle)
     # ADM ...otherwise just read in the targets.
     else:
         targets = read_target_files(hpdirname, columns=columnscopy,

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -4060,13 +4060,13 @@ def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False,
     # ADM check some ways for which we *must* be reading MTLs...
     # ADM ...multi-mode must be MTL-like...
     if isinstance(hpdirname, list):
-        mtlmode=True
+        mtlmode = True
     # ADM ...a directory rather than a file must be MTL-like...
     elif os.path.isdir(hpdirname):
-        mtlmode=True
+        mtlmode = True
     # ADM ...a file isn't necessarily MTL-like unless mtl=True is passed.
     else:
-        mtlmode=False
+        mtlmode = False
 
     # ADM if a directory was passed, do fancy HEALPixel parsing...
     if mtlmode or mtl:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -2885,8 +2885,8 @@ def make_zcat_rr_backstop(zcatdir, tiles, obscon, survey):
 
 
 def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
-                numobs_from_ledger=True, secondary=False, reprocess=False
-                1b=False):
+                numobs_from_ledger=True, secondary=False, reprocess=False,
+                ext=False):
     """Execute full MTL loop, including reading files, updating ledgers.
 
     Parameters
@@ -2919,11 +2919,11 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
         the tiles-specstatus file later than their TIMESTAMP in the
         mtl-done-tiles file) instead of tiles that are newly done and
         process using special reprocessing logic.
-    1b : :class:`bool`, optional, defaults to ``False``
+    ext : :class:`bool`, optional, defaults to ``False``
         If ``True`` then we're operating in DESI extension mode for DARK
         or BRIGHT tiles. The tiles looked up will be, e.g., DARK1B tiles,
         but the ledgers (and rules) used for updating will be for DARK.
-        In this mode, the tile file is not updates indicating that a tile
+        In this mode, the tile file is not updated indicating that a tile
         has been considered, because, e.g., DARK1B tiles should only be
         marked as considered once the DARK1B ledgers are done.
 
@@ -2964,15 +2964,15 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
         resolve = None
     else:
         log.info(msg.format("PRIMARY", obscon, survey))
-    if 1b:
-        log.info(f"Running on {obscon} ledgers but using {obscon}{1B} tiles")
+    if ext:
+        log.info(f"Running on {obscon} ledgers but using {obscon}1B tiles")
     hpdirname = io.find_target_files(mtldir, flavor="mtl", resolve=resolve,
                                      survey=survey, obscon=obscon, ender=form)
     # ADM grab the zcat directory (in case we're relying on $ZCAT_DIR).
     zcatdir = get_zcat_dir(zcatdir)
 
     # ADM grab an array of tiles that are yet to be processed.
-    if 1b:
+    if ext:
         tiles = tiles_to_be_processed(zcatdir, mtltilefn, obscon+"1B", survey,
                                       reprocess=reprocess)
     else:
@@ -3037,7 +3037,7 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     # ADM write the processed tiles to the MTL tile file.
     # ADM although not in the 1b/extension case
     # ADM of, e.g., dark1b-tiles-with-dark-ledgers.
-    if not 1b:
+    if not ext:
         io.write_mtl_tile_file(mtltilefn, tiles)
 
     return hpdirname, mtltilefn, ztilefn, tiles

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -2965,7 +2965,7 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     else:
         log.info(msg.format("PRIMARY", obscon, survey))
     if ext:
-        log.info(f"Running on {obscon} ledgers but using {obscon}1B tiles")
+        log.info(f"1B: Running on {obscon} ledgers but using {obscon}1B tiles")
     hpdirname = io.find_target_files(mtldir, flavor="mtl", resolve=resolve,
                                      survey=survey, obscon=obscon, ender=form)
     # ADM grab the zcat directory (in case we're relying on $ZCAT_DIR).

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -2885,7 +2885,8 @@ def make_zcat_rr_backstop(zcatdir, tiles, obscon, survey):
 
 
 def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
-                numobs_from_ledger=True, secondary=False, reprocess=False):
+                numobs_from_ledger=True, secondary=False, reprocess=False
+                1b=False):
     """Execute full MTL loop, including reading files, updating ledgers.
 
     Parameters
@@ -2918,6 +2919,13 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
         the tiles-specstatus file later than their TIMESTAMP in the
         mtl-done-tiles file) instead of tiles that are newly done and
         process using special reprocessing logic.
+    1b : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then we're operating in DESI extension mode for DARK
+        or BRIGHT tiles. The tiles looked up will be, e.g., DARK1B tiles,
+        but the ledgers (and rules) used for updating will be for DARK.
+        In this mode, the tile file is not updates indicating that a tile
+        has been considered, because, e.g., DARK1B tiles should only be
+        marked as considered once the DARK1B ledgers are done.
 
     Returns
     -------
@@ -2956,15 +2964,20 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
         resolve = None
     else:
         log.info(msg.format("PRIMARY", obscon, survey))
+    if 1b:
+        log.info(f"Running on {obscon} ledgers but using {obscon}{1B} tiles")
     hpdirname = io.find_target_files(mtldir, flavor="mtl", resolve=resolve,
                                      survey=survey, obscon=obscon, ender=form)
     # ADM grab the zcat directory (in case we're relying on $ZCAT_DIR).
     zcatdir = get_zcat_dir(zcatdir)
 
     # ADM grab an array of tiles that are yet to be processed.
-    tiles = tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey,
-                                  reprocess=reprocess)
-
+    if 1b:
+        tiles = tiles_to_be_processed(zcatdir, mtltilefn, obscon+"1B", survey,
+                                      reprocess=reprocess)
+    else:
+        tiles = tiles_to_be_processed(zcatdir, mtltilefn, obscon, survey,
+                                      reprocess=reprocess)
     # ADM contruct the ZTILE filename, for logging purposes.
     ztilefn = get_ztile_file_name(survey=survey)
     # ADM directory structure used to be different for sv and main.
@@ -3022,6 +3035,9 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
             tiles["TIMESTAMP"] = get_utc_date(survey=survey)
 
     # ADM write the processed tiles to the MTL tile file.
-    io.write_mtl_tile_file(mtltilefn, tiles)
+    # ADM although not in the 1b/extension case
+    # ADM of, e.g., dark1b-tiles-with-dark-ledgers.
+    if not 1b:
+        io.write_mtl_tile_file(mtltilefn, tiles)
 
     return hpdirname, mtltilefn, ztilefn, tiles

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -704,7 +704,7 @@ def calc_priority(targets, zcat, obscon, state=False):
                     ii = (targets[desi_target] & desi_mask[name]) != 0
                     target_state[ii] = "CALIB"
 
-            names = ('ELG_VLO', 'ELG_LOP', 'ELG_HIP', 'LRG')
+            names = ('ELG_VLO', 'ELG_LOP', 'ELG_HIP', 'LRG', 'LGE')
             # ADM for sv3 the ELG guiding columns were ELG and ELG_HIP.
             if survey == 'sv3':
                 names = ('ELG_LOP', 'ELG_HIP', 'LRG')

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -1131,7 +1131,8 @@ def finalize(targets, desi_target, bgs_target, mws_target,
         If sent, then split `NUMOBS_INIT` and `PRIORITY_INIT` into
         `NUMOBS_INIT_DARK`, `NUMOBS_INIT_BRIGHT`, `PRIORITY_INIT_DARK`
         and `PRIORITY_INIT_BRIGHT` and calculate values appropriate
-        to "BRIGHT" and "DARK|GRAY" observing conditions.
+        to "BRIGHT" and "DARK|GRAY" observing conditions. Will also
+        split by, e.g. DARK1B for the extension.
     gaiadr : :class:`int`, optional, defaults to ``None``
         If passed and not ``None``, then build the `TARGETID` from the
         "GAIA_OBJID" and "GAIA_BRICKID" columns in the passed `targets`,
@@ -1226,11 +1227,12 @@ def finalize(targets, desi_target, bgs_target, mws_target,
 
     # ADM set the initial PRIORITY and NUMOBS.
     if darkbright:
-        # ADM populate bright/dark if splitting by survey OBSCONDITIONS.
-        ender = ["_DARK", "_BRIGHT", "_BACKUP"]
-        obscon = ["DARK|GRAY", "BRIGHT", "BACKUP"]
+        # ADM populate bright/dark/etc. if splitting by OBSCONDITIONS.
+        ender = ["_DARK", "_BRIGHT", "_BACKUP", "_DARK1B", "_BRIGHT1B"]
+        obscon = ["DARK|GRAY", "BRIGHT", "BACKUP", "DARK1B", "BRIGHT1B"]
     else:
-        ender, obscon = [""], ["DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18"]
+        ender, obscon = [""], \
+            ["DARK|GRAY|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18|DARK1B|BRIGHT1B"]
     for edr, oc in zip(ender, obscon):
         cols += ["{}_INIT{}".format(pn, edr) for pn in ["PRIORITY", "NUMOBS"]]
         vals += [nodata, nodata]


### PR DESCRIPTION
## This PR updates the MTL framework to use multiple MTLs for the DESI extension. 

Features include:

- New target classes for the extension.
- New ledger types for `DARK1B` and `BRIGHT1B`, which can be updated with redshifts in the usual fashion.
- Readers based on `io.read_mtl_ledger()` that can handle two MTLs. 
  * The MTLs are merged on the basis of the highest `PRIORITY` + `SUBPRIORITY` targets in each MTL, and three new columns `MTL_CONTAINS`, `MTL_WANTED` and `MTL_HIGHEST` are added to the combined MTL, indicating how the multiple MTLs compared targets that had the same `TARGETID`.
  
### From Eddie's careful summary of discussions between him, me, David S., Stephen and Segev:

Let me propose the following new fiberassign header keywords...

- MTL1 ... MTLN - ~paths to the MTLs from which the targets were pulled

and new fields in the FIBERASSIGN extension for each target:

- `HIGHEST`: bitmask where bit i is 1 if MTLi is the MTL that had the highest priority & subpriority for this target (?)
- `WANTED`: bitmask where bit i is 1 if MTLi has priority > DONE for this target, or priority = DONE if the highest priority over all MTLs for this target is DONE.
- `CONTAINS`: bitmask where bit i is 1 if MTLi contains the target

Then we can update the each MTL using the targets from a tile that have `(keyword & 2**i) != 0`.  Option 2 corresponds to HIGHEST, option 3 corresponds to WANTED, and option 1 corresponds to CONTAINS. I think all of the code options we discussed amount to which one of these three fields we use ... but it seems valuable to include all three columns in any case, and that will let us change our mind in later DRs as to what goes in the coadds.