### PR TITLE
Allow BRIGHT1B in mtl-done-tiles.ecsv file

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ desitarget Change Log
 3.3.0 (unreleased)
 ------------------
 
+* Expand program string in mtl-done file to allow BRIGHT1B [`PR #843`_].
 * Add numpy 2 compatibility; remove mockmaker.py and lyazcat.py [`PR #838`_].
 
 .. _`PR #838`: https://github.com/desihub/desitarget/pull/838
+.. _`PR #843`: https://github.com/desihub/desitarget/pull/843
 
 3.2.0 (2025-06-08)
 ------------------

--- a/py/desitarget/QA.py
+++ b/py/desitarget/QA.py
@@ -560,7 +560,7 @@ def qasystematics_skyplot(pixmap, colname, qadir='.', downclip=None, upclip=None
         warnings.simplefilter('ignore')
         from desiutil.plots import init_sky, plot_healpix_map
         ax = init_sky(galactic_plane_color='k')
-        ax = plot_healpix_map(pixmap, nest=True,  cmap='jet', label=label, ax=ax)
+        ax = plot_healpix_map(pixmap, nest=True, cmap='jet', label=label, ax=ax)
 
     pngfile = os.path.join(qadir, '{}-{}.png'.format(fileprefix, colname))
     plt.savefig(pngfile, bbox_inches='tight')

--- a/py/desitarget/ToO.py
+++ b/py/desitarget/ToO.py
@@ -220,7 +220,7 @@ def make_initial_ledger(toodir=None):
     data["TOO_TYPE"] = "TILE", "FIBER", "TILE"
     data["TOO_PRIO"] = "HI", "LO", "HI"
     data["MJD_BEGIN"] = 40811.04166667, 41811.14166667, 42811.14
-    data["MJD_END"] = 40811.95833333, 41811.85833333,  42811.85
+    data["MJD_END"] = 40811.95833333, 41811.85833333, 42811.85
     data["OCLAYER"] = "BRIGHT", "DARK", "DARK"
 
     # ADM write out the results.

--- a/py/desitarget/cmx/cmx_cuts.py
+++ b/py/desitarget/cmx/cmx_cuts.py
@@ -230,7 +230,7 @@ def isSV0_BGS(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
             gfluxivar=gfluxivar, rfluxivar=rfluxivar, zfluxivar=zfluxivar,
             maskbits=maskbits, Grr=Grr, w1snr=w1snr, gaiagmag=gaiagmag,
             objtype=objtype, primary=primary, south=False, targtype=targtype
-            )
+        )
         sv0_bgs |= bgs
 
     return sv0_bgs
@@ -734,7 +734,7 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         dchisq=dchisq, maskbits=maskbits,
         objtype=objtype, w1snr=w1snr, w2snr=w2snr,
         south=False
-        )
+    )
 
     qsorf_north = isQSO_randomforest(
         primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
@@ -742,7 +742,7 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         gnobs=gnobs, rnobs=rnobs, znobs=znobs,
         dchisq=dchisq, maskbits=maskbits,
         objtype=objtype, south=False
-        )
+    )
 
     qsohizf_north = isQSO_highz_faint(
         primary=primary, zflux=zflux, rflux=rflux, gflux=gflux,
@@ -750,12 +750,12 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         gnobs=gnobs, rnobs=rnobs, znobs=znobs,
         dchisq=dchisq, maskbits=maskbits,
         objtype=objtype, south=False
-        )
+    )
 
     qsocolor_high_z_north = isQSO_color_high_z(
         gflux=gflux, rflux=rflux, zflux=zflux,
         w1flux=w1flux, w2flux=w2flux, south=False
-        )
+    )
 
     qsoz5_north = isQSOz5_cuts(
         primary=primary, gflux=gflux, rflux=rflux, zflux=zflux,
@@ -764,7 +764,7 @@ def isSV0_QSO(gflux=None, rflux=None, zflux=None, w1flux=None, w2flux=None,
         w1flux=w1flux, w2flux=w2flux, w1snr=w1snr, w2snr=w2snr,
         dchisq=dchisq, maskbits=maskbits, objtype=objtype,
         south=False
-        )
+    )
 
     qsocolor_highz_north = (qsocolor_north & qsocolor_high_z_north)
     qsorf_highz_north = (qsorf_north & qsocolor_high_z_north)
@@ -1151,9 +1151,9 @@ def isQSO_highz_faint(gflux=None, rflux=None, zflux=None, w1flux=None,
         # Compute optimized proba cut (all different for SV).
         # The probabilities may be different for the north and the south.
         if south:
-            pcut = np.where(r_Reduced < 23.2,  0.40 + (r_Reduced-22.8)*.9, .76 + (r_Reduced-23.2)*.4)
+            pcut = np.where(r_Reduced < 23.2, 0.40 + (r_Reduced-22.8)*.9, .76 + (r_Reduced-23.2)*.4)
         else:
-            pcut = np.where(r_Reduced < 23.2,  0.40 + (r_Reduced-22.8)*.9, .76 + (r_Reduced-23.2)*.4)
+            pcut = np.where(r_Reduced < 23.2, 0.40 + (r_Reduced-22.8)*.9, .76 + (r_Reduced-23.2)*.4)
 
         # Add rf proba test result to "qso" mask
         qso[colorsReducedIndex] = (tmp_rf_proba >= pcut)
@@ -1609,7 +1609,7 @@ def isSTD_dither(obs_gflux=None, obs_rflux=None, obs_zflux=None,
     # ADM prioritize based on magnitude.
     # ADM OK to clip, as these are all Gaia matches.
     if _is_row(obs_rflux):
-        rflux = np.zeros_like([obs_rflux,]) + obs_rflux
+        rflux = np.zeros_like([obs_rflux, ]) + obs_rflux
     else:
         rflux = obs_rflux.copy()
     rmag = 22.5-2.5*np.log10(rflux.clip(1e-16))
@@ -1723,7 +1723,7 @@ def isSTD_dither_gaia(ra=None, dec=None, gmag=None, rmag=None, aen=None,
 
     # ADM prioritize based on magnitude.
     if _is_row(rmag):
-        rmag_prio = np.zeros_like([rmag,]) + rmag
+        rmag_prio = np.zeros_like([rmag, ]) + rmag
     else:
         rmag_prio = rmag.copy()
     prio = (10*(25-rmag_prio)).astype(int)
@@ -1781,7 +1781,7 @@ def isSTD_dither_spec(gaiagmag=None, gaiarmag=None, obs_rflux=None,
     # ADM prioritize based on magnitude.
     # ADM OK to clip, as these are all Gaia matches.
     if _is_row(obs_rflux):
-        rflux = np.zeros_like([obs_rflux,]) + obs_rflux
+        rflux = np.zeros_like([obs_rflux, ]) + obs_rflux
     else:
         rflux = obs_rflux.copy()
     rmag = 22.5-2.5*np.log10(rflux.clip(1e-16))
@@ -2221,9 +2221,9 @@ def apply_cuts(objects, cmxdir=None, noqso=False):
     if _is_row(objects):
         # BAW Promote to length-1 array for Numpy 2 compatibility.
         # primary = np.bool_(True)
-        primary = np.ones_like([1,], dtype=bool)
+        primary = np.ones_like([1, ], dtype=bool)
         # priority_shift = np.array(0)
-        priority_shift = np.zeros_like([0,], dtype=int)
+        priority_shift = np.zeros_like([0, ], dtype=int)
     else:
         primary = np.ones_like(objects, dtype=bool)
         priority_shift = np.zeros_like(objects, dtype=int)

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -263,7 +263,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
         parallaxovererror=parallaxovererror, photbprpexcessfactor=gaiabprpfactor,
         astrometricsigma5dmax=gaiasigma5dmax, gaiagmag=gaiagmag,
         gaiabmag=gaiabmag, gaiarmag=gaiarmag, paramssolved=gaiaparamssolved
-        )
+    )
 
     # ADM apply the Gaia quality cuts for standards.
     std &= isSTD_gaia(primary=primary, gaia=gaia, astrometricexcessnoise=gaiaaen,
@@ -2192,7 +2192,7 @@ def _prepare_gaia(objects, colnames=None):
     gaia = objects['REF_ID'] > 0
     refcat = objects['REF_CAT']
     if _is_row(objects):
-        refcat = np.array([refcat,])
+        refcat = np.array([refcat, ])
     if "REF_CAT" in colnames:
         gaia = (refcat == b'G2') | (refcat == 'G2')
         # ADM as of DR10, we use Gaia EDR3 rather than DR2.
@@ -2581,12 +2581,12 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         # ADM run the MWS target types for (potentially) both north and south.
         for south in south_cuts:
             mws_classes[int(south)] = isMWS_main(
-                    gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource,
-                    gflux=gflux, rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
-                    gnobs=gnobs, rnobs=rnobs, gfracmasked=gfracmasked,
-                    rfracmasked=rfracmasked, pmra=pmra, pmdec=pmdec,
-                    parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits,
-                    paramssolved=gaiaparamssolved, primary=primary, south=south
+                gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource,
+                gflux=gflux, rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
+                gnobs=gnobs, rnobs=rnobs, gfracmasked=gfracmasked,
+                rfracmasked=rfracmasked, pmra=pmra, pmdec=pmdec,
+                parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits,
+                paramssolved=gaiaparamssolved, primary=primary, south=south
             )
 
             # ADM impose bright limits for all MWS_MAIN targets.
@@ -2942,7 +2942,7 @@ def apply_cuts(objects, qso_selection='randomforest',
     if _is_row(objects):
         # BAW Promote to length-1 array for Numpy 2 compatibility.
         # primary = np.bool_(True)
-        primary = np.ones_like([1,], dtype=bool)
+        primary = np.ones_like([1, ], dtype=bool)
     else:
         primary = np.ones_like(objects, dtype=bool)
 
@@ -2974,7 +2974,7 @@ def apply_cuts(objects, qso_selection='randomforest',
         gaiaparamssolved, gaiabprpfactor, gaiasigma5dmax, galb,
         tcnames, qso_optical_cuts, qso_selection,
         maskbits, Grr, refcat, primary, resolvetargs=resolvetargs,
-        )
+    )
 
     return desi_target, bgs_target, mws_target
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -73,7 +73,7 @@ basetsdatamodel = np.array([], dtype=[
     ('FIBERTOTFLUX_G', '>f4'), ('FIBERTOTFLUX_R', '>f4'), ('FIBERTOTFLUX_Z', '>f4'),
     ('REF_EPOCH', '>f4'), ('WISEMASK_W1', '|u1'), ('WISEMASK_W2', '|u1'),
     ('MASKBITS', '>i2')
-    ])
+])
 
 # ADM columns that have updated dtypes in the DR10 data model.
 dr10replacecols = {('MASKBITS', '>i2'): ('MASKBITS', '>i4'),
@@ -104,7 +104,7 @@ dr8addedcols = np.array([], dtype=[
     ('SHAPEDEV_R_IVAR', '>f4'), ('SHAPEDEV_E1_IVAR', '>f4'), ('SHAPEDEV_E2_IVAR', '>f4'),
     ('SHAPEEXP_R', '>f4'), ('SHAPEEXP_E1', '>f4'), ('SHAPEEXP_E2', '>f4'),
     ('SHAPEEXP_R_IVAR', '>f4'), ('SHAPEEXP_E1_IVAR', '>f4'), ('SHAPEEXP_E2_IVAR', '>f4'),
-    ])
+])
 
 
 def desitarget_nside():
@@ -2349,7 +2349,7 @@ def read_external_file(filename, header=False, columns=["RA", "DEC"]):
     # ADM ...and fail if RA and DEC aren't columns.
     if not ("RA" in colnames and "DEC" in colnames):
         msg = 'Input file {} must contain both "RA" and "DEC" columns' \
-             .format(filename)
+            .format(filename)
         log.critical(msg)
         raise ValueError(msg)
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -87,7 +87,7 @@ zcatdatamodel = np.array([], dtype=[
 
 mtltilefiledm = np.array([], dtype=[
     ('TILEID', '>i4'), ('TIMESTAMP', 'U25'), ('VERSION', 'U14'),
-    ('PROGRAM', 'U6'), ('ZDATE', '>i8'), ('ARCHIVEDATE', '>i8')
+    ('PROGRAM', 'U8'), ('ZDATE', '>i8'), ('ARCHIVEDATE', '>i8')
 ])
 
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -56,7 +56,7 @@ mtlprimdatamodel = np.array([], dtype=[
     ('TARGETID', '<i8'), ('DESI_TARGET', '<i8'), ('BGS_TARGET', '<i8'),
     ('MWS_TARGET', '<i8'), ('SUBPRIORITY', '<f8'), ('OBSCONDITIONS', '<i4'),
     ('PRIORITY_INIT', '<i8'), ('NUMOBS_INIT', '<i8'), ('SCND_TARGET', '<i8'),
-    ('NUMOBS_MORE', '<i8'), ('NUMOBS', '<i8'),  ('Z', '<f8'), ('ZWARN', '<i8'),
+    ('NUMOBS_MORE', '<i8'), ('NUMOBS', '<i8'), ('Z', '<f8'), ('ZWARN', '<i8'),
     ('ZTILEID', '<i4'), ('Z_QN', '<f8'), ('IS_QSO_QN', '<i2'),
     ('DELTACHI2', '<f8'), ('TARGET_STATE', '<U30'), ('TIMESTAMP', '<U25'),
     ('VERSION', '<U14'), ('PRIORITY', '<i8')

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -51,7 +51,7 @@ skydatamodel = np.array([], dtype=[
     ('OBJID', '<i4'), ('RA', '>f8'), ('DEC', '>f8'), ('BLOBDIST', '>f4'),
     ('FIBERFLUX_G', '>f4'), ('FIBERFLUX_R', '>f4'), ('FIBERFLUX_Z', '>f4'),
     ('FIBERFLUX_IVAR_G', '>f4'), ('FIBERFLUX_IVAR_R', '>f4'), ('FIBERFLUX_IVAR_Z', '>f4')
-    ])
+])
 
 
 def get_brick_info(drdirs, counts=False, allbricks=False):
@@ -450,7 +450,7 @@ def sky_fibers_for_brick(survey, brickname, nskies=144, bands=['g', 'r', 'z'],
 
     # Now, do aperture photometry at these points in the coadd images.
     for band in bands:
-        imfn = survey.find_file('image',  brick=brickname, band=band)
+        imfn = survey.find_file('image', brick=brickname, band=band)
         ivfn = survey.find_file('invvar', brick=brickname, band=band)
 
         # ADM set the apertures for every band regardless of whether
@@ -604,7 +604,7 @@ def sky_fiber_plots(survey, brickname, skyfibers, basefn, bands=['g', 'r', 'z'])
 
     imgs = []
     for band in bands:
-        fn = survey.find_file('image',  brick=brickname, band=band)
+        fn = survey.find_file('image', brick=brickname, band=band)
         imgs.append(fitsio.read(fn))
     rgb = get_rgb(imgs, bands, **rgbkwargs)
 
@@ -717,7 +717,7 @@ def plot_good_bad_skies(survey, brickname, skies,
     # ADM find the images from the survey object and plot them.
     imgs = []
     for band in bands:
-        fn = survey.find_file('image',  brick=brickname, band=band)
+        fn = survey.find_file('image', brick=brickname, band=band)
         imgs.append(fitsio.read(fn))
 
     rgbkwargs = dict(mnmx=(-1, 100.), arcsinh=1.)

--- a/py/desitarget/skyhealpixs.py
+++ b/py/desitarget/skyhealpixs.py
@@ -72,11 +72,11 @@ class Skyhealpixs(object):
             )
         )
         log.info('the code will look for {} files'.format(
-                os.path.join(self.skyhealpixs_dir, 'skymap-{}.fits.gz'.format(
-                    "".join(np.repeat("?", npadpix)),
-                    )
-                ),
+            os.path.join(self.skyhealpixs_dir, 'skymap-{}.fits.gz'.format(
+                "".join(np.repeat("?", npadpix)),
             )
+            ),
+        )
         )
 
         # handle non-array iterables (eg lists) as inputs

--- a/py/desitarget/streams/io.py
+++ b/py/desitarget/streams/io.py
@@ -46,7 +46,7 @@ streamcolsLS = np.array([], dtype=[
 
 # ADM the Gaia part of the data model for working with streams.
 streamcolsGaia = np.array([], dtype=[
-    ('REF_EPOCH', '>f4'),  ('REF_ID', '>i8'),
+    ('REF_EPOCH', '>f4'), ('REF_ID', '>i8'),
     ('PARALLAX', '>f4'), ('PARALLAX_ERROR', '>f4'),
     ('PMRA', '>f4'), ('PMRA_ERROR', '>f4'),
     ('PMDEC', '>f4'), ('PMDEC_ERROR', '>f4'),

--- a/py/desitarget/sv1/sv1_cuts.py
+++ b/py/desitarget/sv1/sv1_cuts.py
@@ -87,7 +87,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
         parallaxovererror=parallaxovererror, photbprpexcessfactor=gaiabprpfactor,
         astrometricsigma5dmax=gaiasigma5dmax, gaiagmag=gaiagmag,
         gaiabmag=gaiabmag, gaiarmag=gaiarmag
-        )
+    )
 
     # ADM apply the Gaia quality cuts for standards.
     std &= isSTD_gaia(primary=primary, gaia=gaia, astrometricexcessnoise=gaiaaen,
@@ -1891,25 +1891,25 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         )
 
         mws_bhb = isMWS_bhb(
-                    primary=primary,
-                    objtype=objtype,
-                    gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource, gaiagmag=gaiagmag,
-                    gflux=gflux, rflux=rflux, zflux=zflux,
-                    w1flux=w1flux, w1snr=w1snr,
-                    gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                    gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                    parallax=parallax, parallaxerr=parallaxerr
-             )
+            primary=primary,
+            objtype=objtype,
+            gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource, gaiagmag=gaiagmag,
+            gflux=gflux, rflux=rflux, zflux=zflux,
+            w1flux=w1flux, w1snr=w1snr,
+            gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+            gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+            parallax=parallax, parallaxerr=parallaxerr
+        )
 
         # ADM run the MWS_MAIN target types for both north and south
         for south in south_cuts:
             mws_classes[int(south)] = isMWS_main_sv(
-                    gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource,
-                    gflux=gflux, rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
-                    gnobs=gnobs, rnobs=rnobs,
-                    gfracmasked=gfracmasked, rfracmasked=rfracmasked,
-                    pmra=pmra, pmdec=pmdec, parallax=parallax,
-                    primary=primary, south=south
+                gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource,
+                gflux=gflux, rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
+                gnobs=gnobs, rnobs=rnobs,
+                gfracmasked=gfracmasked, rfracmasked=rfracmasked,
+                pmra=pmra, pmdec=pmdec, parallax=parallax,
+                primary=primary, south=south
             )
     mws_n, mws_faint_n = mws_classes[0]
     mws_s, mws_faint_s = mws_classes[1]

--- a/py/desitarget/sv2/sv2_cuts.py
+++ b/py/desitarget/sv2/sv2_cuts.py
@@ -141,7 +141,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
         parallaxovererror=parallaxovererror, photbprpexcessfactor=gaiabprpfactor,
         astrometricsigma5dmax=gaiasigma5dmax, gaiagmag=gaiagmag,
         gaiabmag=gaiabmag, gaiarmag=gaiarmag
-        )
+    )
 
     # ADM apply the Gaia quality cuts for standards.
     std &= isSTD_gaia(primary=primary, gaia=gaia, astrometricexcessnoise=gaiaaen,
@@ -1985,25 +1985,25 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         )
 
         mws_bhb = isMWS_bhb(
-                    primary=primary,
-                    objtype=objtype,
-                    gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource, gaiagmag=gaiagmag,
-                    gflux=gflux, rflux=rflux, zflux=zflux,
-                    w1flux=w1flux, w1snr=w1snr,
-                    gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                    gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                    parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits
-             )
+            primary=primary,
+            objtype=objtype,
+            gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource, gaiagmag=gaiagmag,
+            gflux=gflux, rflux=rflux, zflux=zflux,
+            w1flux=w1flux, w1snr=w1snr,
+            gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+            gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+            parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits
+        )
 
         # ADM run the MWS target types for (potentially) both north and south.
         for south in south_cuts:
             mws_classes[int(south)] = isMWS_main(
-                    gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource,
-                    gflux=gflux, rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
-                    gnobs=gnobs, rnobs=rnobs, gfracmasked=gfracmasked,
-                    rfracmasked=rfracmasked, pmra=pmra, pmdec=pmdec,
-                    parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits,
-                    paramssolved=gaiaparamssolved, primary=primary, south=south
+                gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource,
+                gflux=gflux, rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
+                gnobs=gnobs, rnobs=rnobs, gfracmasked=gfracmasked,
+                rfracmasked=rfracmasked, pmra=pmra, pmdec=pmdec,
+                parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits,
+                paramssolved=gaiaparamssolved, primary=primary, south=south
             )
     mws_broad_n, mws_red_n, mws_blue_n = mws_classes[0]
     mws_broad_s, mws_red_s, mws_blue_s = mws_classes[1]

--- a/py/desitarget/sv3/sv3_cuts.py
+++ b/py/desitarget/sv3/sv3_cuts.py
@@ -177,7 +177,7 @@ def isGAIA_STD(ra=None, dec=None, galb=None, gaiaaen=None, pmra=None, pmdec=None
         parallaxovererror=parallaxovererror, photbprpexcessfactor=gaiabprpfactor,
         astrometricsigma5dmax=gaiasigma5dmax, gaiagmag=gaiagmag,
         gaiabmag=gaiabmag, gaiarmag=gaiarmag, paramssolved=gaiaparamssolved
-        )
+    )
 
     # ADM apply the Gaia quality cuts for standards.
     std &= isSTD_gaia(primary=primary, gaia=gaia, astrometricexcessnoise=gaiaaen,
@@ -429,24 +429,24 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
         lrg &= (
             (gmag - rmag > 1.3) & ((gmag - rmag) > -1.55 * (rmag - w1mag)+3.13)
             | (rmag - w1mag > 1.8)
-            )  # low-z cuts
+        )  # low-z cuts
         lrg &= (
             (rmag - w1mag > (w1mag - 17.26) * 1.8)
             & (rmag - w1mag > (w1mag - 16.36) * 1.)
             | (rmag - w1mag > 3.29)
-            )  # double sliding cuts and high-z extension
+        )  # double sliding cuts and high-z extension
     else:
         lrg &= zmag - w1mag > 0.8 * (rmag - zmag) - 0.6  # non-stellar cut
         lrg &= zfibermag < 21.72                   # faint limit
         lrg &= (
             (gmag - rmag > 1.34) & ((gmag - rmag) > -1.55 * (rmag - w1mag)+3.23)
             | (rmag - w1mag > 1.8)
-            )  # low-z cuts
+        )  # low-z cuts
         lrg &= (
             (rmag - w1mag > (w1mag - 17.24) * 1.83)
             & (rmag - w1mag > (w1mag - 16.33) * 1.)
             | (rmag - w1mag > 3.39)
-            )  # double sliding cuts and high-z extension
+        )  # double sliding cuts and high-z extension
 
     # Selection of the lower density subset
     if south:
@@ -455,24 +455,24 @@ def isLRG_colors(gflux=None, rflux=None, zflux=None, w1flux=None,
         lrg_lowdens &= (
             (gmag - rmag > 1.3) & ((gmag - rmag) > -1.55 * (rmag - w1mag)+3.13)
             | (rmag - w1mag > 1.8)
-            )  # low-z cuts
+        )  # low-z cuts
         lrg_lowdens &= (
             (rmag - w1mag > (w1mag - 17.07) * 1.8)
             & (rmag - w1mag > (w1mag - 16.17) * 1.)
             | (rmag - w1mag > 3.39)
-            )  # double sliding cuts and high-z extension
+        )  # double sliding cuts and high-z extension
     else:
         lrg_lowdens &= zmag - w1mag > 0.8 * (rmag - zmag) - 0.6  # non-stellar cut
         lrg_lowdens &= zfibermag < 21.72                   # faint limit
         lrg_lowdens &= (
             (gmag - rmag > 1.34) & ((gmag - rmag) > -1.55 * (rmag - w1mag)+3.23)
             | (rmag - w1mag > 1.8)
-            )  # low-z cuts
+        )  # low-z cuts
         lrg_lowdens &= (
             (rmag - w1mag > (w1mag - 17.05) * 1.83)
             & (rmag - w1mag > (w1mag - 16.14) * 1.)
             | (rmag - w1mag > 3.49)
-            )  # double sliding cuts and high-z extension
+        )  # double sliding cuts and high-z extension
 
     return lrg, lrg_lowdens
 
@@ -2200,27 +2200,27 @@ def set_target_bits(photsys_north, photsys_south, obs_rflux,
         mws_nearby &= ~too_bright
 
         mws_bhb = isMWS_bhb(
-                    primary=primary,
-                    objtype=objtype,
-                    gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource, gaiagmag=gaiagmag,
-                    gflux=gflux, rflux=rflux, zflux=zflux,
-                    w1flux=w1flux, w1snr=w1snr,
-                    gnobs=gnobs, rnobs=rnobs, znobs=znobs,
-                    gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
-                    parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits
-             )
+            primary=primary,
+            objtype=objtype,
+            gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource, gaiagmag=gaiagmag,
+            gflux=gflux, rflux=rflux, zflux=zflux,
+            w1flux=w1flux, w1snr=w1snr,
+            gnobs=gnobs, rnobs=rnobs, znobs=znobs,
+            gfracmasked=gfracmasked, rfracmasked=rfracmasked, zfracmasked=zfracmasked,
+            parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits
+        )
         # ADM impose bright limits for all MWS_BHB targets.
         mws_bhb &= ~too_bright
 
         # ADM run the MWS target types for (potentially) both north and south.
         for south in south_cuts:
             mws_classes[int(south)] = isMWS_main(
-                    gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource,
-                    gflux=gflux, rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
-                    gnobs=gnobs, rnobs=rnobs, gfracmasked=gfracmasked,
-                    rfracmasked=rfracmasked, pmra=pmra, pmdec=pmdec,
-                    parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits,
-                    paramssolved=gaiaparamssolved, primary=primary, south=south
+                gaia=gaia, gaiaaen=gaiaaen, gaiadupsource=gaiadupsource,
+                gflux=gflux, rflux=rflux, obs_rflux=obs_rflux, objtype=objtype,
+                gnobs=gnobs, rnobs=rnobs, gfracmasked=gfracmasked,
+                rfracmasked=rfracmasked, pmra=pmra, pmdec=pmdec,
+                parallax=parallax, parallaxerr=parallaxerr, maskbits=maskbits,
+                paramssolved=gaiaparamssolved, primary=primary, south=south
             )
             # ADM impose bright limits for all MWS_MAIN targets.
             mws_classes[int(south)] &= ~too_bright

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -1180,7 +1180,7 @@ def _cmx_calc_priority(targets, priority, obscon,
         if (obsconditions.mask(obscon) & pricon) != 0:
             ii = (targets['CMX_TARGET'] & cmx_mask[name]) != 0
             priority[ii & unobs] = np.maximum(priority[ii & unobs], cmx_mask[name].priorities['UNOBS'])
-            priority[ii & done] = np.maximum(priority[ii & done],  cmx_mask[name].priorities['DONE'])
+            priority[ii & done] = np.maximum(priority[ii & done], cmx_mask[name].priorities['DONE'])
             priority[ii & zgood] = np.maximum(priority[ii & zgood], cmx_mask[name].priorities['MORE_ZGOOD'])
             priority[ii & zwarn] = np.maximum(priority[ii & zwarn], cmx_mask[name].priorities['MORE_ZWARN'])
 

--- a/py/desitarget/test/test_cuts.py
+++ b/py/desitarget/test/test_cuts.py
@@ -263,7 +263,6 @@ class TestCuts(unittest.TestCase):
         self.assertEqual(len(bgs), 1)
         self.assertEqual(len(mws), 1)
 
-
     def test_astropy_fits(self):
         """Test astropy.fits I/O library
         """

--- a/py/desitarget/test/test_priorities.py
+++ b/py/desitarget/test/test_priorities.py
@@ -131,7 +131,7 @@ class TestPriorities(unittest.TestCase):
         t[bgs_target] = bgs_mask.BGS_BRIGHT
         t["PRIORITY_INIT"], t["NUMOBS_INIT"] = initial_priority_numobs(t)
         z['NUMOBS'] = [0, 100, 100]
-        z['ZWARN'] = [1,   1,   0]
+        z['ZWARN'] = [1, 1, 0]
         p = calc_priority(t, z, "BRIGHT")
 
         self.assertEqual(p[0], bgs_mask.BGS_BRIGHT.priorities['UNOBS'])

--- a/py/desitarget/test/test_top_level.py
+++ b/py/desitarget/test/test_top_level.py
@@ -18,7 +18,7 @@ class TestTopLevel(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.versionre = re.compile(
-                r'([0-9]+!)?([0-9]+)(\.[0-9]+)*((a|b|rc|\.post|\.dev)[0-9]+)?')
+            r'([0-9]+!)?([0-9]+)(\.[0-9]+)*((a|b|rc|\.post|\.dev)[0-9]+)?')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This PR updates the length of the `PROGRAM` string in the MTL data model to 8 characters to allow `BRIGHT1B` to be written to the `mtl-done-tiles.ecsv` file, which is essential for MTL updates to be made for `BRIGHT1B` observations.

I'll merge tomorrow and make a new tag that we can use for running the MTL update loop for the `BRIGHT1B` program.

This PR additionally cleans up some code style.



