### PR TITLE
Fix issue in isQSO_randomforest

### DIFF
--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -1910,6 +1910,8 @@ def isQSO_randomforest(gflux=None, rflux=None, zflux=None, maskbits=None,
     if maskbits is not None:
         # ADM default mask bits from the Legacy Surveys not set.
         preSelection &= imaging_mask(maskbits)
+        
+    preSelection = preSelection.astype('bool')
 
     # "qso" mask initialized to "preSelection" mask.
     qso = np.copy(preSelection)


### PR DESCRIPTION
I noticed that some objects in the ELGnotqso clustering catalogs were being classified as quasars in isQSO_randomforest. Specifically, I ran the following code snippet. The last two lines should have shape zero (because there should be no quasars in ELGnotqso) but they do not! It seems that preSelection was type int, but should have been type bool; this meant that preSelection was not being applied so objects with W1 > 22.3, W2 > 22.3, etc were being mistakenly classified as quasars.

```
import numpy as np
from astropy.io import fits
from astropy.table import Table, join
from desitarget.cuts import isELG_colors, notinELG_mask, isQSO_randomforest
import healpy as hp
from scipy.interpolate import RectBivariateSpline
from scipy.interpolate import NearestNDInterpolator

zmin = 0.8
zmax = 1.1

full_file = fits.open('/global/cfs/cdirs/desi/survey/catalogs/Y1/LSS/iron/LSScats/v1.5/ELG_LOPnotqso_full_HPmapcut.dat.fits')[1].data # Is this actually the right file? ok, need to look at my old scripts ....
cat = fits.open('/global/cfs/cdirs/desi/survey/catalogs/Y1/LSS/iron/LSScats/v1.5/ELG_LOPnotqso_clustering.dat.fits')[1].data

cat = join(cat, full_file, keys='TARGETID')
cat = cat[(cat['Z'] >= zmin) & (cat['Z'] <= zmax)]

import time

flux_g_ext_corr = 10**(0.4 * cat['EBV'] * 3.214) * cat['FLUX_G'] 
flux_r_ext_corr = 10**(0.4 * cat['EBV'] * 2.165) * cat['FLUX_R'] 
flux_z_ext_corr = 10**(0.4 * cat['EBV'] * 1.211) * cat['FLUX_Z']

flux_w1 = 10**(0.4 * cat['EBV'] * 0.184) * cat['FLUX_W1'] 
flux_w2 = 10**(0.4 * cat['EBV'] * 0.113) * cat['FLUX_W2'] 

outS = isQSO_randomforest(gflux=flux_g_ext_corr,
	rflux=flux_r_ext_corr,
	zflux=flux_z_ext_corr,
	maskbits=cat['MASKBITS'],
	w1flux=flux_w1,
	w2flux=flux_w2,
	objtype=cat['MORPHTYPE'],
	gnobs=cat['NOBS_G'],
	rnobs=cat['NOBS_R'],
	znobs=cat['NOBS_Z'],
	primary=np.ones_like(cat['NOBS_Z']),
	ra=cat['RA_1'],
	dec=cat['DEC_1'],
	south=True) # I guess south can be either True or False
	
outN = isQSO_randomforest(flux_g_ext_corr,
	flux_r_ext_corr,
	flux_z_ext_corr,
	cat['MASKBITS'],
	flux_w1,
	flux_w2,
	cat['MORPHTYPE'],
	cat['NOBS_G'],
	cat['NOBS_R'],
	cat['NOBS_Z'],
	np.ones_like(cat['NOBS_Z']),
	cat['RA_1'],
	cat['DEC_1'],
	south=False) # I guess south can be either True or False
	

# These should be zero but they're not!!!	
print(np.shape(np.where((outS == 1) & (cat['PHOTSYS_1'] == 'S') & (22.5-2.5*np.log10(flux_w1)
< 22.3) & (22.5-2.5*np.log10(flux_w2) < 22.3) & (22.5-2.5*np.log10(flux_r_ext_corr) < 23)
& (22.5-2.5*np.log10(flux_r_ext_corr) > 16.5) & (cat['MORPHTYPE'] == 'PSF')
)))

print(np.shape(np.where((outN == 1) & (cat['PHOTSYS_1'] == 'N')& (22.5-2.5*np.log10(flux_w1)
< 22.3) & (22.5-2.5*np.log10(flux_w2) < 22.3) & (22.5-2.5*np.log10(flux_r_ext_corr) < 23)
& (22.5-2.5*np.log10(flux_r_ext_corr) > 16.5) & (cat['MORPHTYPE'] == 'PSF')
)))
```