### PR TITLE
Change LyA decisions for the DESI 1B phase

### DIFF
--- a/bin/update_lya_1b
+++ b/bin/update_lya_1b
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+from desitarget.mtl import update_lya_1b
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description="Add two observations for LyA quasars for 1B.")
+ap.add_argument("--obscon",
+                help="String matching ONE obscondition in the bitmask yaml file \
+                (e.g. 'DARK'). Defaults to DARK.", default="DARK")
+ap.add_argument('--mtldir',
+                help="Full path to the directory that hosts the MTL ledgers.    \
+                Default is to use the $MTL_DIR environment variable.",
+                default=None)
+ap.add_argument('--timestamp',
+                help="Fixed time stamp at which to record updates.              \
+                Default is to use NOW.",
+                default=None)
+ap.add_argument("--donotupdatedonefile", action='store_true',
+                help="Do NOT record this action in the                          \
+                mtl-done-overrides.ecsv file.")
+
+
+ns = ap.parse_args()
+
+update_lya_1b(obscon=ns.obscon, mtldir=ns.mtldir, timestamp=ns.timestamp,
+              donefile=not(ns.donotupdatedonefile))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,14 @@ desitarget Change Log
 3.4.0 (unreleased)
 ------------------
 
-* No changes yet.
+* Change LyA decisions for DESI 1B phase [`PR #845`_].
+    * Include function to add 2 observations for every LyA QSO.
+        * Also sets priority for these QSOs to most recent LyA-like one.
+    * MTL logic sets 6 observations for ELG targets that are LyA QSOs.
+        * And sets priority to just below a QSO target that is a LyA QSO.
+	* Introduces new priority level `LY_1B_ELG`.
+
+.. _`PR #845`: https://github.com/desihub/desitarget/pull/845
 
 3.3.0 (2025-06-21)
 ------------------

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -241,6 +241,7 @@ obsmask:
     - [DONE,           2, "enough observations already obtained"]
     - [MORE_ZWARN,     3, "ambiguous redshift; need more observations"]
     - [MORE_ZGOOD,     4, "redshift known; need more observations"]
+    - [LYA_1B_ELG,     5, "ELG target from 1B program that has a LyA QSO redshift"]
     - [MORE_MIDZQSO,   8, "mid-z QSO; more observations at very low priority"]
     - [MORE_NOB1,      9, "good rv, reprioritize until reach NOBS1"]
     - [MORE_NOB2,     10, "reached first SN goal, reprioritize until reach NOBS2"]
@@ -295,7 +296,7 @@ priorities:
 #- Dark Survey: priorities 3000 - 3999
     desi_mask:
 
-        ELG: {UNOBS: 3000, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        ELG: {UNOBS: 3000, LYA_1B_ELG: 3340, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         LRG: {UNOBS: 3200, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 
 # ADM The MORE_MIDZQSO priority is driven by secondary programs from Gontcho a Gontcho (1.4 < z < 2.1)
@@ -307,7 +308,7 @@ priorities:
         LGE: {UNOBS: 3210, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 
 # ADM different priority ELGs.
-        ELG_LOP: {UNOBS: 3100, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        ELG_LOP: {UNOBS: 3100, LYA_1B_ELG: 3340, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         ELG_HIP: SAME_AS_LRG
         ELG_VLO: SAME_AS_ELG
 

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -241,7 +241,7 @@ obsmask:
     - [DONE,           2, "enough observations already obtained"]
     - [MORE_ZWARN,     3, "ambiguous redshift; need more observations"]
     - [MORE_ZGOOD,     4, "redshift known; need more observations"]
-    - [LYA_1B_ELG,     5, "ELG target from 1B program that has a LyA QSO redshift"]
+    - [LY_1B_ELG,      5, "ELG target from 1B program that has a LyA QSO redshift"]
     - [MORE_MIDZQSO,   8, "mid-z QSO; more observations at very low priority"]
     - [MORE_NOB1,      9, "good rv, reprioritize until reach NOBS1"]
     - [MORE_NOB2,     10, "reached first SN goal, reprioritize until reach NOBS2"]
@@ -296,7 +296,7 @@ priorities:
 #- Dark Survey: priorities 3000 - 3999
     desi_mask:
 
-        ELG: {UNOBS: 3000, LYA_1B_ELG: 3340, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        ELG: {UNOBS: 3000, LY_1B_ELG: 3340, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         LRG: {UNOBS: 3200, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 
 # ADM The MORE_MIDZQSO priority is driven by secondary programs from Gontcho a Gontcho (1.4 < z < 2.1)
@@ -308,7 +308,7 @@ priorities:
         LGE: {UNOBS: 3210, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
 
 # ADM different priority ELGs.
-        ELG_LOP: {UNOBS: 3100, LYA_1B_ELG: 3340, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
+        ELG_LOP: {UNOBS: 3100, LY_1B_ELG: 3340, MORE_ZGOOD: 2, MORE_ZWARN: 2, DONE: 2, OBS: 1, DONOTOBSERVE: 0, MORE_MIDZQSO: 0}
         ELG_HIP: SAME_AS_LRG
         ELG_VLO: SAME_AS_ELG
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1244,7 +1244,6 @@ def add_to_ledgers_in_hp(targets, pixlist, mtldir=None, obscon="DARK",
                     for col in reordered.dtype.names:
                         reordered[col] = mtlinpix[col]
                     oldmatches = np.concatenate([oldmatches, reordered])
-                # ADM append new state to bottom of existing file.
                 nt, fn = io.write_mtl(
                     mtldir, oldmatches, ecsv=True, survey="main", obscon=obscon,
                     nsidefile=nside, hpxlist=pix, scnd=scnd, extra=hdr,
@@ -1718,146 +1717,144 @@ def process_overrides(ledgerfn, tabform='ascii.basic'):
     return mtl
 
 
-def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
-                     mtldir=None, secondary=False, numoverride=999):
+def update_lya_1b(obscon="DARK", mtldir=None, timestamp=None, donefile=True):
     """
-    Create (or append to) a ledger to override the standard ledgers.
+    Effectively add two observations for LyA quasars for DESI-1B.
 
     Parameters
     ----------
-    overfn : :class:`str`
-        Full path to the filename that contains the override information.
-        Must contain at least `RA`, `DEC`, `TARGETID` and be in a format
-        that can be read automatically by astropy.table.Table.read().
-    obscon : :class:`str`
+    obscon : :class:`str`, optional, defaults to DARK
         A string matching ONE obscondition in the desitarget bitmask yaml
         file (i.e. in `desitarget.targetmask.obsconditions`), e.g. "DARK"
         Used to construct the directory to find the Main Survey ledgers.
-    colsub : :class:`dict`, optional
-        If passed, each key should correspond to the name of a ledger
-        column and each value should correspond to the name of a column
-        in `overfn`. The ledger columns are overwritten by the
-        corresponding column in `overfn` (for the appropriate TARGETID).
-    valsub : :class:`dict`, optional
-        If passed, each key should correspond to the name of a ledger
-        column and each value to a single number or string. The "value"
-        will be overwritten into the "key" column of the ledger. Takes
-        precedence over colsub.
+        It's likely we'll only ever want to do this for DARK, but worth
+        retaining the option for BRIGHT, too.
     mtldir : :class:`str`, optional, defaults to ``None``
         Full path to the directory that hosts the MTL ledgers and the MTL
         tile file. If ``None``, then look up the MTL directory from the
         $MTL_DIR environment variable.
-    secondary : :class:`bool`, optional, defaults to ``False``
-        If ``True`` then process secondary targets instead of primaries
-        for passed `obscon`.
-    numoverride : :class:`int`, optional, defaults to 999
-        The override ledger is read every time the MTL loop is run. This
-        is the number of times to override the standard results in the
-        MTL loop. Defaults to 999, i.e. essentially "always override."
+    timestamp : :class:`str`, defaults to ``None``
+        A date-like string or array of strings in either UTC or strict
+        UTC/ISO format. If ``None``, then the timestamp corresponding to
+        now is used.
+    donefile : :class:`bool`, defaults to ``True``
+        If ``True`` then update the mtl-done-overrides.ecsv (i.e the
+        OVERRIDE done file) to indicate the change. The special nature
+        of this update is that TILEID, ZDATE and ARCHIVEDATE are all set 
+        to -1.
 
     Returns
     -------
-    :class:`str`
-        The directory containing the ledgers that were updated.
+    Nothing, but relevant ledger files are updated.
 
     Notes
     -----
-    - Regardless of the inputs, the TIMESTAMP in the output override
-      ledger is always updated to now, the second part of TARGET_STATE is
-      always updated to OVERRIDE, the git VERSION is always updated and
-      the ZTILEID is always set to -1.
+    - This will only be run once but is coded as a standalone function so
+      it can be used by the alt-MTLs as well as the data MTLs.
+    - The algorithm is to look up the the highest-priority state (other 
+      than UNOBS) for each quasar target, revert to that state, and add 
+      two observations to NUMOBS_MORE and NUMOBS_INIT.
+    - Every ledger in the relevant MTL+obscon+main directory is updated.
     """
+    start = time()
+
+    # ADM get the current TIMESTAMP if one wasn't passed.
+    if timestamp is None:
+        timestamp = get_utc_date(survey="main")
+
     # ADM grab the MTL directory (in case we're relying on $MTL_DIR).
     mtldir = get_mtl_dir(mtldir)
 
     # ADM construct the relevant sub-directory for this survey and
     # ADM set of observing conditions.
-    resolve = True
     msg = "running on {} ledgers with obscon={} and survey=main"
-    if secondary:
-        log.info(msg.format("SECONDARY", obscon))
-        resolve = None
-    else:
-        log.info(msg.format("PRIMARY", obscon))
-    outdir = io.find_target_files(mtldir, flavor="mtl", obscon=obscon,
-                                  survey="main", resolve=resolve, override=True)
-    # ADM and create the sub-directory if it doesn't exist.
-    os.makedirs(outdir, exist_ok=True)
+    log.info(msg.format("PRIMARY", obscon))
+    outdir = io.find_target_files(mtldir, flavor="mtl", obscon=obscon)
 
-    # ADM read in the file with override information.
-    objs = Table.read(overfn)
-    # ADM be somewhat forgiving and convert lower-case columns.
-    for colname in ["RA", "DEC", "TARGETID"]:
-        try:
-            objs.rename_column(colname.lower(), colname)
-        except KeyError:
-            pass
-        # ADM check all required columns are present.
-        if colname not in objs.colnames:
-            msg = "{} must be a column in {}!".format(colname, overfn)
-            log.error(msg)
-            raise IOError(msg)
+    # ADM retrieve all of the relative ledgers.
+    fns = sorted(glob(os.path.join(outdir, "*ecsv")))
 
-    # ADM retrieve the current ledger entry for each target to be overrode.
-    nside = _get_mtl_nside()
-    theta, phi = np.radians(90-objs["DEC"]), np.radians(objs["RA"])
-    pixnum = hp.ang2pix(nside, theta, phi, nest=True)
-    for tid, pix in zip(objs["TARGETID"], pixnum):
-        # ADM construct the input/output ledger filenames.
-        infn = io.find_target_files(mtldir, flavor="mtl", survey="main", hp=pix,
-                                    resolve=resolve, obscon=obscon, ender="ecsv")
-        outfn = io.find_target_files(
-            mtldir, flavor="mtl", survey="main", hp=pix, resolve=resolve,
-            obscon=obscon, override=True, ender="ecsv")
+    # ADM we'll need the targeting mask information.
+    from desitarget.targetmask import desi_mask as dmx
 
-        ledger = Table(io.read_mtl_ledger(infn))
-        ii = ledger["TARGETID"] == tid
-        # ADM warn if one of the TARGETIDs seems incorrect.
-        if not np.any(ii):
-            msg = "TARGETID {} from {} not in file {}!".format(tid, overfn, infn)
-            log.warning(msg)
-        entry = ledger[ii]
+    # ADM loop through the ledgers and make the updates.
+    for fn in fns:
+        # ADM read in a ledger. Grab all entries to include full history.
+        ledger = io.read_mtl_ledger(fn, unique=False)
 
-        # ADM substitute the column entries, where requested.
-        ii = objs["TARGETID"] == tid
-        if colsub is not None:
-            for col in colsub:
-                if col not in ledger.colnames:
-                    msg = "column {} from colsub not in ledger!!!".format(col)
-                    log.error(msg)
-                    raise ValueError(msg)
-                entry[col] = objs[ii][colsub[col]]
-        # ADM overwrite ledger entries, where requested.
-        if valsub is not None:
-            for col, val in valsub.items():
-                if col not in ledger.colnames:
-                    msg = "column {} from valsub not in ledger!!!".format(col)
-                    log.error(msg)
-                    raise ValueError(msg)
-                entry[col] = val
+        # ADM restrict to just quasars.
+        ii = ledger["DESI_TARGET"] & dmx["QSO"] != 0
+        qsos = ledger[ii]
 
-        # ADM add the number of times to override to the ledger entry.
-        entry["NUMOVERRIDE"] = numoverride
-        # ADM add some other standardized column information.
-        entry = standard_override_columns(entry)
+        # ADM recover the entries for just OBSERVED quasars.
+        obs = qsos["PRIORITY"] != dmx["QSO"].priorities["UNOBS"]
 
-        # ADM finally write out the override ledger entry, after first
-        # ADM checking if the file exists.
-        if os.path.exists(outfn):
-            f = open(outfn, "a")
-            ascii.write(entry, f, format='no_header', formats=mtlformatdict)
-            f.close()
-            checkfn = outfn
-        else:
-            _, checkfn = io.write_mtl(
-                mtldir, entry.as_array(), indir=infn, ecsv=True, survey="main",
-                obscon=obscon, nsidefile=nside, hpxlist=pix, scnd=secondary,
-                override=True)
-        log.info('Wrote target {} from {} to {}'.format(tid, overfn, checkfn))
+        # ADM retrieve the unique TARGETIDs.
+        tids = np.unique(qsos["TARGETID"])
 
-    log.info("Touched pixels {}".format(",".join([str(pix) for pix in pixnum])))
+        # ADM to store all the updates for this ledger.
+        newentries = []
+        # ADM loop through and create a new entry for each TARGETID.
+        for tid in tids:
+            # ADM we won't want to consider some quasar types.
+            smells_like_lya = True
+            ii = qsos["TARGETID"] == tid
+            # ADM extract the final observation.
+            newentry = qsos[ii][-1]
+            newentry["NUMOBS_INIT"] += 2
+            newentry["NUMOBS_MORE"] += 2
+            newentry["TIMESTAMP"] = timestamp
+            newentry["VERSION"] = dt_version
+            # ADM have different handling for observed quasars.
+            if np.sum(ii) > 1:
+                # ADM extract the previous observation with the highest priority.
+                qsohi = qsos[ii & obs]
+                qsohi = qsohi[np.argmax(qsohi["PRIORITY"])]
+                # ADM only update quasars that were considered Ly-alpha.
+                if qsohi["PRIORITY"] in [dmx["QSO"].priorities["MORE_ZWARN"],
+                                         dmx["QSO"].priorities["MORE_ZGOOD"]]:
+                    # Assign the highest observed priority and state.
+                    newentry["PRIORITY"] = qsohi["PRIORITY"]
+                    newentry["TARGET_STATE"] = qsohi["TARGET_STATE"]
+                    # Assign a TILEID of -1.
+                    newentry["ZTILEID"] = -1
+                else:
+                    # ADM this isn't a LyA quasar.
+                    smells_like_lya = False
+            # ADM all done with creating a new entry for this quasar, if
+            # ADM it seems to be a Lyman-alpha quasar.
+            if smells_like_lya:
+                newentries.append(newentry)
 
-    return outdir
+        # ADM append the new entries to the ledger.
+        newentries = np.concatenate([newentries])
+        # ADM will need some keywords to know which file we read.
+        hpx = io.read_keyword_from_mtl_header(fn, "FILEHPX")
+        nside = io.read_keyword_from_mtl_header(fn, "FILENSID")
+
+        nt, filename = io.write_mtl(
+            mtldir, newentries, ecsv=True, survey="main", obscon=obscon,
+            nsidefile=nside, hpxlist=hpx, append=True)
+
+        log.info(f"Wrote {nt} new entries to {filename}..t={time()-start:.1f}s")
+
+    # ADM update the override tiles file to indicate this code was run.
+    mtltilefn = os.path.join(mtldir, get_mtl_tile_file_name(override=True))
+
+    # ADM initialize the output array and add the tiles.
+    mocktiles = np.zeros(1, dtype=mtltilefiledm.dtype)
+    mocktiles["TILEID"] = -1
+    mocktiles["TIMESTAMP"] = timestamp
+    mocktiles["VERSION"] = dt_version
+    mocktiles["PROGRAM"] = obscon
+    mocktiles["ZDATE"] = -1
+    mocktiles["ARCHIVEDATE"] = -1
+
+    io.write_mtl_tile_file(mtltilefn, mocktiles)
+
+    log.info(f"Done..t={time()-start:.1f}s")
+
+    return
 
 
 def force_overrides(obscon, survey='main', secondary=False, mtldir=None,

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -547,8 +547,8 @@ def check_archiving(obscon, survey='main', zcatdir=None, mtldir=None):
     return
 
 
-def make_mtl(targets, obscon, zcat=None, scnd=None,
-             trim=False, trimcols=False, trimtozcat=False):
+def make_mtl(targets, obscon, zcat=None, scnd=None, trim=False,
+             trimcols=False, trimtozcat=False, ext=False):
     """Add zcat columns to a targets table, update priorities and NUMOBS.
 
     Parameters
@@ -591,6 +591,10 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
         Only return targets that have been UPDATED (i.e. the targets with
         a match in `zcat`). Returns all targets if `zcat` is ``None``.
         See important Notes about `trimtozcat`=``False``!!!
+    ext : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then we're operating in DESI 1B mode for DARK or
+        BRIGHT tiles. When calculating priorities and numbers of
+        observations special 1B rules will be used.
 
     Returns
     -------
@@ -742,12 +746,13 @@ def make_mtl(targets, obscon, zcat=None, scnd=None,
             targets_zmatcher["NUMOBS_INIT"][ii] = desi_mask["QSO"].numobs
 
     # ADM update the number of observations for the targets.
-    ztargets['NUMOBS_MORE'] = calc_numobs_more(targets_zmatcher, ztargets, obscon)
+    ztargets['NUMOBS_MORE'] = calc_numobs_more(targets_zmatcher, ztargets,
+                                               obscon, ext=ext)
 
     # ADM assign priorities. Only things in the zcat can have changed
     # ADM priorities. Anything else is assigned PRIORITY_INIT, below.
     priority, target_state = calc_priority(
-        targets_zmatcher, ztargets, obscon, state=True)
+        targets_zmatcher, ztargets, obscon, state=True, ext=ext)
 
     # If priority went to 0==DONOTOBSERVE or 1==OBS or 2==DONE, then
     # NUMOBS_MORE should also be 0.
@@ -2251,7 +2256,7 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
 
 
 def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
-                  numobs_from_ledger=False, tabform='ascii.basic'):
+                  numobs_from_ledger=False, tabform='ascii.basic', ext=False):
     """
     Update relevant HEALPixel-split ledger files for some targets.
 
@@ -2282,6 +2287,10 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
         Format to pass to the astropy Table.read() function. The default
         ('ascii.basic') is standard for reading and writing MTL files.
         But 'ascii.ecsv' is useful for some of the mock/alt-MTL work.
+    ext : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then we're operating in DESI 1B mode for DARK or
+        BRIGHT tiles. When calculating priorities and numbers of
+        observations special 1B rules will be used.
 
     Returns
     -------
@@ -2321,7 +2330,8 @@ def update_ledger(hpdirname, zcat, targets=None, obscon="DARK",
         zcat["NUMOBS"][zii] = targets["NUMOBS"][tii] + 1
 
     # ADM run MTL, only returning the targets that are updated.
-    mtl = make_mtl(targets, oc, zcat=zcat, trimtozcat=True, trimcols=True)
+    mtl = make_mtl(targets, oc, zcat=zcat, trimtozcat=True, trimcols=True,
+                   ext=ext)
 
     # ADM this is redundant if targets wasn't sent, but it's quick.
     nside = _get_mtl_nside()
@@ -2923,8 +2933,8 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
         mtl-done-tiles file) instead of tiles that are newly done and
         process using special reprocessing logic.
     ext : :class:`bool`, optional, defaults to ``False``
-        If ``True`` then we're operating in DESI extension mode for DARK
-        or BRIGHT tiles. The tiles looked up will be, e.g., DARK1B tiles,
+        If ``True`` then we're operating in DESI 1B mode for DARK or
+        BRIGHT tiles. The tiles looked up will be, e.g., DARK1B tiles,
         but the ledgers (and rules) used for updating will be for DARK.
         In this mode, the tile file is not updated indicating that a tile
         has been considered, because, e.g., DARK1B tiles should only be
@@ -3022,7 +3032,7 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
         timedict = reprocess_ledger(hpdirname, zcat, obscon=obscon)
     else:
         update_ledger(hpdirname, zcat, obscon=obscon,
-                      numobs_from_ledger=numobs_from_ledger)
+                      numobs_from_ledger=numobs_from_ledger, ext=ext)
 
     # ADM for the main survey "holding pen" method, ensure the TIMESTAMP
     # ADM in the mtl-done-tiles file is always later than in the ledgers.

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -747,7 +747,7 @@ def calc_priority(targets, zcat, obscon, state=False, ext=False):
                         zwarn1b = zwarn & ~good_hiz
                         sbools = [unobs, done, zgood1b, zwarn1b, good_hiz]
                         snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_ZWARN",
-                                  "LYA_1B_ELG"]
+                                  "LY_1B_ELG"]
                     else:
                         sbools = [unobs, done, zgood, zwarn]
                         snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_ZWARN"]

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -522,7 +522,7 @@ def initial_priority_numobs(targets, scnd=False,
     return outpriority, outnumobs
 
 
-def calc_numobs_more(targets, zcat, obscon):
+def calc_numobs_more(targets, zcat, obscon, ext=False):
     """
     Calculate target NUMOBS_MORE from masks, observation/redshift status.
 
@@ -544,6 +544,10 @@ def calc_numobs_more(targets, zcat, obscon):
         file (specifically in `desitarget.targetmask.obsconditions`), e.g.
         "DARK". Governs the behavior of how priorities are set based
         on "obsconditions" in the desitarget bitmask yaml file.
+    ext : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then we're operating in DESI 1B mode for DARK or
+        BRIGHT tiles. When calculating priorities and numbers of
+        observations special 1B rules will be used.
 
     Returns
     -------
@@ -573,6 +577,17 @@ def calc_numobs_more(targets, zcat, obscon):
     # ADM main case, just decrement by NUMOBS.
     numobs_more = np.maximum(0, targets['NUMOBS_INIT'] - zcat['NUMOBS'])
 
+    # ADM special case for ELGs that turn out to be LyA quasars in the
+    # ADM DESI 1B phase. Should be scheduled for 6 total observations.
+    if ext:
+        iselgnotqso = ( (targets[desi_target] & desi_mask.ELG != 0) &
+                        (targets[desi_target] & desi_mask.QSO == 0) )
+        hiz = (zcat['Z'] >= zcut) | (
+            (zcat['Z_QN'] >= zcut) & (zcat["IS_QSO_QN"] == 1))
+        # ADM so these targets need 6-N more observations to match the 6
+        # ADM observations for LyA quasars in DESI 1B.
+        numobs_more[iselgnotqso & hiz] = 6 - zcat[iselgnotqso & hiz]['NUMOBS']
+
     # ADM apply special QSO behavior, but only in dark time and after
     # ADM some observations have occurred.
     if survey == 'main' and np.any(zcat["NUMOBS"] > 0):
@@ -583,6 +598,7 @@ def calc_numobs_more(targets, zcat, obscon):
             isqso = targets[desi_target] & desi_mask.QSO != 0
             # ADM "lock in" the numobs state for existing Ly-Alpha QSOs.
             lya = targets["PRIORITY"] == desi_mask["QSO"].priorities["MORE_ZGOOD"]
+
             # ADM the mocks may not include the secondary targets.
             if scnd_target in targets.dtype.names:
                 for scxname in scnd_mask.names():
@@ -600,7 +616,7 @@ def calc_numobs_more(targets, zcat, obscon):
     return numobs_more
 
 
-def calc_priority(targets, zcat, obscon, state=False):
+def calc_priority(targets, zcat, obscon, state=False, ext=False):
     """
     Calculate target priorities from masks, observation/redshift status.
 
@@ -627,6 +643,10 @@ def calc_priority(targets, zcat, obscon, state=False):
         was set. The state is a string combining the observational
         state (e.g. "DONE", "MORE_ZGOOD") from the targeting yaml file
         and the target type (e.g. "ELG", "LRG").
+    ext : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then we're operating in DESI 1B mode for DARK or
+        BRIGHT tiles. When calculating priorities and numbers of
+        observations special 1B rules will be used.
 
     Returns
     -------
@@ -714,10 +734,25 @@ def calc_priority(targets, zcat, obscon, state=False):
                 pricon = obsconditions.mask(desi_mask[name].obsconditions)
                 if (obsconditions.mask(obscon) & pricon) != 0:
                     ii = (targets[desi_target] & desi_mask[name]) != 0
-                    for sbool, sname in zip(
-                        [unobs, done, zgood, zwarn],
-                        ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_ZWARN"]
-                    ):
+                    # ADM for the DARK 1B program, we treat ELG targets
+                    # ADM that have LyA QSO redshifts as LyA QSOs.
+                    if ext and "ELG" in name:
+                        good_hiz = (zcat['Z'] >= zcut) | (
+                            (zcat['Z_QN'] >= zcut) & (zcat["IS_QSO_QN"] == 1))
+                        # ADM ensure we don't change behavior for quasar targets.
+                        good_hiz &= (targets[desi_target] & desi_mask["QSO"]) == 0
+                        # ADM make sure there are no overlaps between the
+                        # ADM LyA-like ELGs and other ELG observations.
+                        zgood1b = zgood & ~good_hiz
+                        zwarn1b = zwarn & ~good_hiz
+                        sbools = [unobs, done, zgood1b, zwarn1b, good_hiz]
+                        snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_ZWARN",
+                                  "LYA_1B_ELG"]
+                    else:
+                        sbools = [unobs, done, zgood, zwarn]
+                        snames = ["UNOBS", "DONE", "MORE_ZGOOD", "MORE_ZWARN"]
+
+                    for sbool, sname in zip(sbools, snames):
                         # ADM update priorities and target states.
                         Mxp = desi_mask[name].priorities[sname]
                         # ADM tiered system in SV3. Decrement MORE_ZWARN


### PR DESCRIPTION
This PR updates the LyA decisions for the DESI 1B phase. It includes:

- A function to add 2 observations for every LyA quasar in the MTL ledgers.
  - This function also sets the priority for these quasars back to the most recent LyA-like one.
  - This is necessary, for example, because LyA quasars that are "done" have a very low priority and would never be revisited without a priority update.
- New MTL logic that sets 6 observations for every ELG target that is observed to have a redshift consistent with a LyA QSO.
  - Such quasars are set to a new priority level, named `LY_1B_ELG`.
  - This new priority level is just below a QSO target that turns out to be a LyA quasar.

I've mocked up ledgers for both of these new sets of LyA decisions:

`/pscratch/sd/a/adamyers/1bqsocheck`: Contains the results of updating a couple of ledgers by adding +2 observations to every existing LyA-like quasar.

`/pscratch/sd/a/adamyers/1belgcheck`: Contains the results of running the new ELG-target-is-a-LyA-QSO logic on 4 tiles with tile IDs `102276`, `102277`, `102281` and `102282`.

@ashleyjross and @LNapolitano: It would be great if you could run some tests on the mocked up ledgers to see if the results look good and make sense.


