### PR TITLE
Add BACKUP standards to the BRIGHT1B M31/M33 target files

### DIFF
--- a/bin/select_M31_targets
+++ b/bin/select_M31_targets
@@ -31,6 +31,15 @@ ap.add_argument("--test", action="store_true",
                 help=("If True only read the first 500 objects from filename "
                 "for testing purposes.")
                 )
+ap.add_argument("--addstandards", action="store_true",
+                help=("If True add standard stars from the BACKUP program by "
+                "reading them from a directory of BACKUP files.")
+                )
+ap.add_argument("--backupdir", default=None,
+                help=("Use this as the directory that hosts the BACKUP target"
+                " files if --addstandards is passed. Defaults to: "
+                "$TARG_DIR/gaiadr2/2.2.0/targets/main/resolve/backup")
+                )
 ap.add_argument("--nside", type=int, default=None,
                 help=("Write targets split by (NESTED) HEALPixel at this nside.")
                 )
@@ -61,12 +70,14 @@ if ns.nside is not None:
 for hpx in set(hppix):
     # ADM note we hard code for BRIGHT, which is hidden in write_targets.
     if hpx == -1:
-        ntargs, outfile = io.write_targets(ns.dest, targets, hdr,
-                                           nsidecol=desitarget_nside())
+        ntargs, outfile = io.write_targets(
+            ns.dest, targets, hdr, nsidecol=desitarget_nside(),
+            addstandards=ns.addstandards, backupdir=ns.backupdir)
     else:
         ii = hppix == hpx
         ntargs, outfile = io.write_targets(
-            ns.dest, targets[ii], hdr, nside=ns.nside,
-            pixint=hpx, nsidecol=desitarget_nside())
+            ns.dest, targets[ii], hdr, nside=ns.nside, pixint=hpx,
+            nsidecol=desitarget_nside(), addstandards=ns.addstandards,
+            backupdir=ns.backupdir)
 
     log.info(f"{ntargs} targets written to {outfile}...t={time()-start:.1f}s")

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,12 @@
 desitarget Change Log
 =====================
 
-3.5.1 (unreleased)
+3.6.0 (unreleased)
 ------------------
 
-* No changes yet.
+* Add BACKUP standards to the BRIGHT1B M31/M33 target files [`PR #850`_].
+
+.. _`PR #850`: https://github.com/desihub/desitarget/pull/850
 
 3.5.0 (2025-08-07)
 ------------------

--- a/py/desitarget/data/targetmask.yaml
+++ b/py/desitarget/data/targetmask.yaml
@@ -128,8 +128,8 @@ mws_mask:
     
     # ADM Standard stars based only on Gaia.
     - [GAIA_STD_FAINT,      33, "Standard stars for dark/gray conditions",   {obsconditions: DARK|BACKUP|TWILIGHT12|TWILIGHT18}]
-    - [GAIA_STD_WD,         34, "White Dwarf stars",                         {obsconditions: DARK|BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18}]
-    - [GAIA_STD_BRIGHT,     35, "Standard stars for BRIGHT conditions",      {obsconditions: BRIGHT|BACKUP|TWILIGHT12|TWILIGHT18}]
+    - [GAIA_STD_WD,         34, "White Dwarf stars",                         {obsconditions: DARK|BRIGHT|BRIGHT1B|BACKUP|TWILIGHT12|TWILIGHT18}]
+    - [GAIA_STD_BRIGHT,     35, "Standard stars for BRIGHT conditions",      {obsconditions: BRIGHT|BRIGHT1B|BACKUP|TWILIGHT12|TWILIGHT18}]
 
     # ADM DESI 1B MWS targets part 2.
     - [MWS_GD1,             36, "DESI 1B GD1 stream target",                           {obsconditions: BRIGHT1B}]

--- a/py/desitarget/streams/M31cuts.py
+++ b/py/desitarget/streams/M31cuts.py
@@ -61,7 +61,7 @@ def add_backup_standards(targs, backupdir=None, nside=None, pixnum=None):
 
     Notes
     -----
-      - The `OBSCONDITIONS` column is updated to use the latest version 
+      - The `OBSCONDITIONS` column is updated to use the latest version
         for the GAIA_STD_BRIGHT and GAIA_STD_WD target classes. All
         other information is just copied across.
     """

--- a/py/desitarget/streams/M31cuts.py
+++ b/py/desitarget/streams/M31cuts.py
@@ -4,6 +4,7 @@ import astropy.table as atpy
 import numpy as np
 import sys
 import fitsio
+import os
 from matplotlib.path import Path
 
 from desitarget.streams.targets import finalize
@@ -34,10 +35,93 @@ def betw(x, xmin, xmax):
 plx_pad, pm_pad = 0.05, 0.05
 
 
+def add_backup_standards(targs, backupdir=None, nside=None, pixnum=None):
+    """
+    Add GAIA_STD_BRIGHT and GAIA_STD_WD standards from the BACKUP survey.
+
+    Parameters
+    ----------
+    targs : :class:`~numpy.ndarray`
+        An array of targets in their final format (i.e. as they appear
+        when read in from a file or just before being written to file.
+    backupdir : :class:`str`, optional, defaults to ``None``
+        Use this as the directory that is hosting the BACKUP target files
+        if nothing is passed, this defaults to:
+        $TARG_DIR/gaiadr2/2.2.0/targets/main/resolve/backup
+    nside : :class:`int`, optional, defaults to `None`
+        (NESTED) HEALPixel nside used with `pixint`.
+    pixint : :class:`int`, optional, defaults to `None`
+        If passed, limit the returned array of objects to lie within
+        (NESTED) HEALpixels at passed `nside`.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        The input `targs` array with the standard stars added.
+
+    Notes
+    -----
+      - The `OBSCONDITIONS` column is updated to use the latest version 
+        for the GAIA_STD_BRIGHT and GAIA_STD_WD target classes. All
+        other information is just copied across.
+    """
+    # ADM If pixnum is passed we'll also need to know nside.
+    io.check_both_set(pixnum, nside)
+
+    # ADM retrieve the BACKUP directory if it wasn't passed.
+    if backupdir is None:
+        backupdir = os.path.join(os.getenv("TARG_DIR"), "gaiadr2", "2.2.0",
+                                 "targets", "main", "resolve", "backup")
+
+    # ADM get the NSIDE for the files in the BACKUP directory.
+    from glob import iglob
+    fns = iglob(os.path.join(backupdir, "*fits"))
+    fn = next(fns)
+    # ADM grab the FILENSID from one of the files.
+    filenside = fitsio.read_header(fn, 1)["FILENSID"]
+
+    # ADM find the HEALPixels covered by the targets at this nside.
+    import healpy as hp
+    theta, phi = np.radians(90-targs["DEC"]), np.radians(targs["RA"])
+    hppix = hp.ang2pix(filenside, theta, phi, nest=True)
+
+    # ADM read in the BACKUP targets in these HEALPixels.
+    # ADM limiting to just GAIA_STD_BRIGHT and GAIA_STD_WD targets.
+    from desitarget.targetmask import mws_mask, obsconditions
+    backups = []
+    for i in set(hppix):
+        fn = os.path.join(backupdir, f"targets-backup-hp-{i}.fits")
+        backup = fitsio.read(fn)
+        ii = backup["MWS_TARGET"] & mws_mask.GAIA_STD_BRIGHT != 0
+        ii |= backup["MWS_TARGET"] & mws_mask.GAIA_STD_WD != 0
+        backups.append(backup[ii])
+    backups = np.concatenate(backups)
+
+    # ADM change the observing conditions to the latest value.
+    # ADM this is basically to pick up the BRIGHT1B obscon.
+    from desitarget.targets import set_obsconditions
+    backups["OBSCONDITIONS"] = set_obsconditions(backups)
+
+    # ADM concatenate the standards with the original targets.
+    done = np.zeros_like(targs, shape=len(backups))
+    for col in set(targs.dtype.names).intersection(set(backups.dtype.names)):
+        done[col] = backups[col]
+    done = np.concatenate([targs, done])
+
+    # ADM limit standards to just the passed HEALPixels, if requested.
+    if nside is not None:
+        theta, phi = np.radians(90-done["DEC"]), np.radians(done["RA"])
+        hppix = hp.ang2pix(nside, theta, phi, nest=True)
+        ii = hppix == pixnum
+        done = done[ii]
+
+    return done
+
+
 def downsampler(ra, dec, gal_b, subset, p_15, p_35, m31_rad=2.5, m33_rad=.5):
     """
     Compute the probability for downsampling to select with p_15 prob
-    at b=-15 and p_35 at b=-35
+    at b=-15 and p_35 at b=-35.
     """
     prob_sel = np.ones(len(gal_b))
     p_m31_central = 1

--- a/py/desitarget/streams/M31cuts.py
+++ b/py/desitarget/streams/M31cuts.py
@@ -44,7 +44,7 @@ def add_backup_standards(targs, backupdir=None, nside=None, pixnum=None):
     targs : :class:`~numpy.ndarray`
         An array of targets in their final format (i.e. as they appear
         when read in from a file or just before being written to file.
-    backupdir : :class:`str`, optional, defaults to ``None``
+    backupdir : :class:`str`, optional, defaults to `None`
         Use this as the directory that is hosting the BACKUP target files
         if nothing is passed, this defaults to:
         $TARG_DIR/gaiadr2/2.2.0/targets/main/resolve/backup

--- a/py/desitarget/streams/io.py
+++ b/py/desitarget/streams/io.py
@@ -389,7 +389,8 @@ def read_data_per_stream(swdir, rapol, decpol, mind, maxd, stream_name,
 
 
 def write_targets(dirname, targs, header, nside=None, pixint=None,
-                  subpriority=True, nsidecol=None):
+                  subpriority=True, nsidecol=None, addstandards=False,
+                  backupdir=None):
     """Write stream and dwarf targets to a FITS file.
 
     Parameters
@@ -417,6 +418,13 @@ def write_targets(dirname, targs, header, nside=None, pixint=None,
     nsidecol : :class:`int`, optional, defaults to `None`
         If passed, add a column to the targets array popluated
         with HEALPixels in the nested scheme at resolution `nsidecol`.
+    addstandards : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then add standard stars from the BACKUP program by
+        reading them from a directory of BACKUP files.
+    backupdir : :class:`str`, optional, defaults to `None`
+        Use this as the directory that hosts the BACKUP target files if
+        `addstandards` is ``True``. If `None` is passed, defaults to:
+        $TARG_DIR/gaiadr2/2.2.0/targets/main/resolve/backup
 
     Returns
     -------
@@ -506,6 +514,12 @@ def write_targets(dirname, targs, header, nside=None, pixint=None,
         ii = targs["SUBPRIORITY"] == 0.0
         targs["SUBPRIORITY"][ii] = np.random.random(len(targs))[ii]
         header["SUBPSEED"] = subpseed
+
+    # ADM add standard stars for BACKUP program, if requested.
+    if addstandards:
+        from desitarget.streams.M31cuts import add_backup_standards
+        targs = add_backup_standards(targs, backupdir=backupdir,
+                                     nside=nside, pixnum=pixint)
 
     # ADM add the DESI dependencies.
     depend.add_dependencies(header)


### PR DESCRIPTION
This PR adds `GAIA_STD_BRIGHT` and `GAIA_STD_WD` target classes from the `BACKUP` program directory to the `BRIGHT1B` M31/M33 target files.

The streams and dwarf galaxies for the `BRIGHT1B` program overlap the Main Survey area, so standards can be read from the `BRIGHT1B` files. But, the M31/M33 part of the program doesn't overlap the Main Survey footprint, so we need to explicitly add some standard stars.

See the [relevant Slack thread](https://desisurvey.slack.com/archives/C01HNN87Y7J/p1754673095290979?thread_ts=1754508356.925239&cid=C01HNN87Y7J) for more context.

I'll merge this as soon as tests pass so I can tag and run new target files. I've already checked that the actual targets are identical to those created using the code in PR #849, the only difference is the addition of the new standards.