### PR TITLE
module file set SKYHEALPIXS_DIR

### DIFF
--- a/etc/desitarget.module
+++ b/etc/desitarget.module
@@ -87,3 +87,4 @@ setenv TYCHO_DIR $env(DESI_ROOT)/target/tycho_dr2
 setenv TOO_DIR  $env(DESI_ROOT)/target/ToO
 setenv ZCAT_DIR $env(DESI_ROOT)/spectro/redux/daily
 setenv SKYBRICKS_DIR $env(DESI_ROOT)/target/skybricks/v3
+setenv SKYHEALPIXS_DIR $env(DESI_ROOT)/target/skyhealpixs/v1


### PR DESCRIPTION
This PR updates the desitarget module file to set `$SKYHEALPIXS_DIR` analogous to how it sets `$SKYBRICKS_DIR`.  This is used by the desitarget.skyhealpixs code to look up blank sky locations from Gaia data when off of the Legacy Survey imaging footprint.

Previously the desiproc user was setting this by hand in their .bashrc.ext file (albeit with a conceptual typo leading to an invalid path due to $DESI_ROOT not being set).  With this PR, this should no longer be necessary.