### PR TITLE
Fix ordering bug when reading two MTL ledgers

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 3.6.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix ordering bug when reading two MTL ledgers [`PR #856`_].
+
+.. _`PR #851`: https://github.com/desihub/desitarget/pull/851
 
 3.6.1 (2025-08-11)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2880,7 +2880,8 @@ def read_mtl_ledger(filename, unique=True, isodate=None, initial=False,
 
 
 def read_two_mtl_ledgers(filelist, unique=True, isodate=None, initial=False,
-                         leq=False, columns=None, tabform='ascii.basic'):
+                         leq=False, columns=None, tabform='ascii.basic',
+                         reorder=True):
     """Wrapper to read and merge two MTL ledger files.
 
     Parameters
@@ -2912,6 +2913,12 @@ def read_two_mtl_ledgers(filelist, unique=True, isodate=None, initial=False,
         Format to pass to the astropy Table.read() function. The default
         ('ascii.basic') is standard for reading and writing MTL files.
         But 'ascii.ecsv' is useful for some of the mock/alt-MTL work.
+    reorder : :class:`bool`, optional, defaults to ``True``
+        The original version of this function had a bug where if the two
+        passed ledgers had different column orders the output could be
+        mangled (see https://github.com/desihub/desitarget/issues/855).
+        If `reorder` is ``True``, then passed ledgers are first ordered
+        according to a fixed MTL data model to fix this bug.
 
     Returns
     -------
@@ -2934,6 +2941,22 @@ def read_two_mtl_ledgers(filelist, unique=True, isodate=None, initial=False,
     mtl2 = read_one_mtl_ledger(
         fn2, unique=unique, isodate=isodate, initial=initial, leq=leq,
         columns=columns, tabform=tabform)
+
+    # ADM if requested, reorder both MTLs according to the primary MTL
+    # ADM data model to fix the reorder bug noted in the docstring.
+    if reorder:
+        from desitarget.mtl import mtlprimdatamodel
+        dt = mtlprimdatamodel.dtype.descr
+        if mtl1.dtype.descr != dt:
+            mtl1new = np.zeros(len(mtl1), dtype=dt)
+            for col in mtlprimdatamodel.dtype.names:
+                mtl1new[col] = mtl1[col]
+            mtl1 = mtl1new
+        if mtl2.dtype.descr != dt:
+            mtl2new = np.zeros(len(mtl2), dtype=dt)
+            for col in mtlprimdatamodel.dtype.names:
+                mtl2new[col] = mtl2[col]
+            mtl2 = mtl2new
 
     # ADM determine which program/obscon corresponds to each filename.
     oc1 = fn1.split("mtl-")[-1].split("-")[0].upper()


### PR DESCRIPTION
This PR fixes the bug identified in issue #855. The issue was that [this line of code](https://github.com/desihub/desitarget/blob/deb0d0519c5b916ffa1e129d58d0094345f76177/py/desitarget/io.py#L2973):

```
mtlmerged = np.where(ii, mtl1match, mtl2match)
```

Expects the two MTL arrays (`mtl1match` and `mtl2match`) to have the same column ordering. But, the `BRIGHT` and `BRIGHT1B` MTLs have a different ordering for a few columns because the `BRIGHT1B` MTLs were initially derived from a set of secondary target ledgers.

The ordering of columns for the `BRIGHT` MTLs is:

```
RA,DEC,REF_EPOCH,PARALLAX,PMRA,PMDEC,TARGETID,DESI_TARGET,BGS_TARGET,MWS_TARGET,SUBPRIORITY,OBSCONDITIONS,PRIORITY_INIT,NUMOBS_INIT,SCND_TARGET,NUMOBS_MORE,NUMOBS,Z,ZWARN,ZTILEID,Z_QN,IS_QSO_QN,DELTACHI2,TARGET_STATE,TIMESTAMP,VERSION,PRIORITY
```

but for the `BRIGHT1B` MTLs it is:

```
RA,DEC,REF_EPOCH,PARALLAX,PMRA,PMDEC,TARGETID,DESI_TARGET,BGS_TARGET,MWS_TARGET,SCND_TARGET,SUBPRIORITY,OBSCONDITIONS,PRIORITY_INIT,NUMOBS_INIT,NUMOBS_MORE,NUMOBS,Z,ZWARN,ZTILEID,Z_QN,IS_QSO_QN,DELTACHI2,TARGET_STATE,TIMESTAMP,VERSION,PRIORITY
```

which produces the "shifting" discrepancies for `SUBPRIORITY`, `OBSCONDITIONS`, `PRIORITY_INIT`, `NUMOBS_INIT` and `SCND_TARGET` found by @dylanagreen in issue #855.

Huge credit to @dylanagreen for identifying this bug and @crockosi and Nathan Sandford for noticing that some MWS stream targets were not being assigned fibers.