### PR TITLE
Update read_one_mtl_ledger() function to read gzipped files

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 4.0.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Update :func:`read_one_mtl_ledger` to read gzipped files [`PR #858`_].
+
+.. _`PR #858`: https://github.com/desihub/desitarget/pull/858
 
 4.0.0 (2025-09-19)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -3024,6 +3024,124 @@ def read_one_mtl_ledger(filename, unique=True, isodate=None, initial=False,
         Name of a ledger file containing a Merged Target List. If the
         filename contains ".ecsv" then it will be read as an ECSV file.
         If it contains ".fits" then it will be read as a FITS file.
+        Input files can be gzipped.
+    unique : :class:`bool`, optional, defaults to ``True``
+        If ``True`` then only read targets with unique `TARGETID`, where
+        the last occurrence of the target in the ledger is the one that
+        is retained. If ``False`` then read the entire ledger.
+    isodate : :class:`str`, defaults to ``None``
+        A date in ISO format, such as returned by
+        :func:`desitarget.mtl.get_utc_date() `. The ledger is restricted
+        to entries strictly BEFORE `isodate` before being extracted.
+        If ``None`` is passed then no date restrictions are applied.
+    initial : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then only read targets with unique `TARGETID`, where
+        the FIRST occurrence of the target in the ledger is retained.
+        i.e. read the initial state of the ledger. Overrides `unique`.
+    leq : :class:`bool`, optional, defaults to ``False``
+        If ``True``, restrict the ledger to entries BEFORE or EQUAL TO
+        `isodate` instead of the default behavior of strictly before
+        `isodate`. Only relevant if `isodate` is passed.
+    columns : :class:`list`, optional
+        Only return these target columns.
+    tabform : :class:`str`, optional, defaults to 'ascii.basic'
+        Format to pass to the astropy Table.read() function. The default
+        ('ascii.basic') is standard for reading and writing MTL files.
+        But 'ascii.ecsv' is useful for some of the mock/alt-MTL work.
+    maketwostyle : :class:`bool`, optional, defaults to ``False``
+        If passed, add the extra columns that are added when running
+        :func:`read_two_mtl_ledgers()`.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        A structured numpy array of the MTL.
+    """
+    if ".ecsv" in filename:
+        from desitarget.mtl import mtldatamodel, survey_data_model
+        # ADM allow for the full set of possible columns.
+        mtldm = survey_data_model(mtldatamodel, survey="main")
+        # ADM read the data.
+        prelim = Table.read(filename, comment='#', format=tabform)
+        # ADM convoluted to ensure the data model remains identical.
+        dtdict = {col: typ for (col, typ) in mtldm.dtype.descr}
+        dt = [(col, dtdict[col]) for col in prelim.dtype.names]
+        mtl = np.zeros(len(prelim), dtype=dt)
+        for col in mtl.dtype.names:
+            mtl[col] = prelim[col]
+
+    elif ".fits" in filename:
+        mtl = fitsio.read(filename, extension="MTL")
+    else:
+        msg = "File not parsed ({}). Should be .fits or .ecsv".format(filename)
+        log.error(msg)
+        raise IOError(msg)
+
+    # ADM restrict to dates before isodate, if requested.
+    if isodate is not None:
+        # ADM try a couple of choices to guard against byte-type versus
+        # string-type errors.
+        try:
+            # ADM if `leq` is passed, restrict to before or on isodate...
+            if leq:
+                ii = mtl["TIMESTAMP"] <= isodate
+            # ADM ...otherwise, restrict to strictly before isodate.
+            else:
+                ii = mtl["TIMESTAMP"] < isodate
+        except TypeError:
+            # ADM if `leq` is passed, restrict to before or on isodate...
+            if leq:
+                ii = mtl["TIMESTAMP"] <= isodate.encode()
+            # ADM ...otherwise, restrict to strictly before isodate.
+            else:
+                ii = mtl["TIMESTAMP"] < isodate.encode()
+        mtl = mtl[ii]
+
+    if unique or initial:
+        # ADM the flip is because np.unique retains the FIRST unique
+        # ADM entry and we want the LAST unique entry.
+        if not initial:
+            mtl = np.flip(mtl)
+        _, ii = np.unique(mtl["TARGETID"], return_index=True)
+        mtl = mtl[ii]
+
+    # ADM if requested, add the columns expected in multi-MTL mode.
+    if maketwostyle:
+        # ADM determine which program/obscon corresponds to the filename.
+        oc = filename.split("mtl-")[-1].split("-")[0].upper()
+        # ADM add the new columns to the MTL data model.
+        dt = mtl.dtype.descr + [("MTL_HIGHEST", ">i4"), ("MTL_WANTED", ">i4"),
+                                ("MTL_CONTAINS", ">i4")]
+        # ADM simple output for a single mtl.
+        done = np.zeros(len(mtl), dtype=dt)
+        for col in mtl.dtype.names:
+            done[col] = mtl[col]
+        for col in ["MTL_HIGHEST", "MTL_WANTED", "MTL_CONTAINS"]:
+            done[col] = obsconditions[oc]
+        mtl = done
+
+    # ADM limit to certain columns, if only a subset were requested.
+    if columns is not None:
+        dt = [col for col in mtl.dtype.descr if col[0] in columns]
+        mtlredux = np.zeros(len(mtl), dtype=dt)
+        for col in mtlredux.dtype.names:
+            mtlredux[col] = mtl[col]
+        return mtlredux
+
+    return mtl
+
+
+def read_one_mtl_ledger_old(filename, unique=True, isodate=None, initial=False,
+                        leq=False, columns=None, tabform='ascii.basic',
+                        maketwostyle=False):
+    """Wrapper to read individual MTL ledger files.
+
+    Parameters
+    ----------
+    filename : :class:`str`
+        Name of a ledger file containing a Merged Target List. If the
+        filename contains ".ecsv" then it will be read as an ECSV file.
+        If it contains ".fits" then it will be read as a FITS file.
     unique : :class:`bool`, optional, defaults to ``True``
         If ``True`` then only read targets with unique `TARGETID`, where
         the last occurrence of the target in the ledger is the one that


### PR DESCRIPTION
This PR updates the `io.read_one_mtl_ledger()` function to enable it to read gzipped files (addressing issue #854). 

I've spooled through all of the MTL ledgers I can think of with the old version of the function and the new version of the function to check that the read results are identical.

I've left the old function in place in this PR for now (as `desitarget.io.read_one_mtl_ledger_old()`) in case anyone else (@ashleyjross?) wants to check the equivalence of the old and new reading approach. Such a check can (basically) be achieved via, e.g.:

```
a = read_one_mtl_ledger(fn)
b = read_one_mtl_ledger_old(fn)
```

I'll eventually delete the `read_one_mtl_ledger_old()` function before merging this PR.

I've also:
  - Checked the new version of `read_one_mtl_ledger()` actually _reads_ gzipped files.
  - Checked the new function is as fast as the old function (the new function is ~10% faster for unzipped files)


