### PR TITLE
Allow target files with different data models to be read in tiles and HEALPixels in the case of M31-like target files.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ desitarget Change Log
 4.1.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Allow target files with different data models to be read [`PR #860`_].
+    * Combined in a HEALPixel or a tile.
+    * But only for the very special case of M31-like target files.
+
+.. _`PR #860`: https://github.com/desihub/desitarget/pull/860
 
 4.1.1 (2025-10-06)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -3604,6 +3604,9 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None, header=False,
           grouped HEALPixels, as fewer files will need to be read.
         - If `mtl` is ``True`` then this is just a wrapper on
           read_mtl_in_hp().
+        - Will generally fail if the target files in a given `hpdirname`
+          are formatted differently BUT tries to allow a special DESI
+          case of an M31-program-like file and a standard DESI file.
     """
     # ADM if quick is True, use the quick-code.
     if quick:
@@ -3666,7 +3669,36 @@ def read_targets_in_hp(hpdirname, nside, pixlist, columns=None, header=False,
                 return notargs, nohdr
             else:
                 return notargs
-        targets = np.concatenate(targets)
+
+        try:
+            targets = np.concatenate(targets)
+        except TypeError:
+            # ADM special casing to allow mixing of some very specific
+            # ADM files with different formats, which are M31 target
+            # ADM files and SGC stream target files.
+            check = (
+                np.any([t.dtype.names[0] == "RELEASE" for t in targets]) &
+                np.any(np.array(["W1MPRO" in t.dtype.names for t in targets])) &
+                np.any(np.array(["RVS_FLAG" in t.dtype.names for t in targets])) &
+                np.any(np.array(["PANDAS_G" in t.dtype.names for t in targets]))
+            )
+            if check:
+                dtforce = [t.dtype.descr for t in targets
+                           if t.dtype.names[0] == "RELEASE"][0]
+                nomforce = [t.dtype.names for t in targets
+                            if t.dtype.names[0] == "RELEASE"][0]
+                newtargets = []
+                for t in targets:
+                    done = np.zeros(len(t), dtype=dtforce)
+                    for col in nomforce:
+                        done[col] = t[col]
+                    newtargets.append(done)
+                targets = np.concatenate(newtargets)
+            else:
+                msg = f"Mismatched data models for files in {hpdirname}"
+                log.critical(msg)
+                raise TypeError(msg)
+
     # ADM ...otherwise just read in the targets.
     else:
         targets, hdr = read_target_files(
@@ -3732,6 +3764,9 @@ def read_targets_in_tiles_quick(hpdirname, tiles=None, columns=None,
           TARGETIDs from this function and that approach should be
           identical, although the output may be ordered differently.
         - Based on a suggestion from Anand Raichoor.
+        - Will generally fail if the target files in a given `hpdirname`
+          are formatted differently BUT tries to allow a special DESI
+          case of an M31-program-like file and a standard DESI file.
     """
     start = time()
     # ADM generator for the FITS files in the passed directory.
@@ -3800,7 +3835,34 @@ def read_targets_in_tiles_quick(hpdirname, tiles=None, columns=None,
         # ADM return a zero-length array with the correct data model.
         targets = np.zeros(0, dtype=targets.dtype)
     else:
-        targets = np.concatenate(targets)
+        try:
+            targets = np.concatenate(targets)
+        except TypeError:
+            # ADM special casing to allow mixing of some very specific
+            # ADM files with different formats, which are M31 target
+            # ADM files and SGC stream target files.
+            check = (
+                np.any([t.dtype.names[0] == "RELEASE" for t in targets]) &
+                np.any(np.array(["W1MPRO" in t.dtype.names for t in targets])) &
+                np.any(np.array(["RVS_FLAG" in t.dtype.names for t in targets])) &
+                np.any(np.array(["PANDAS_G" in t.dtype.names for t in targets]))
+            )
+            if check:
+                dtforce = [t.dtype.descr for t in targets
+                           if t.dtype.names[0] == "RELEASE"][0]
+                nomforce = [t.dtype.names for t in targets
+                            if t.dtype.names[0] == "RELEASE"][0]
+                newtargets = []
+                for t in targets:
+                    done = np.zeros(len(t), dtype=dtforce)
+                    for col in nomforce:
+                        done[col] = t[col]
+                    newtargets.append(done)
+                targets = np.concatenate(newtargets)
+            else:
+                msg = f"Mismatched data models for files in {hpdirname}"
+                log.critical(msg)
+                raise TypeError(msg)
 
     if header:
         return targets, hdr
@@ -3913,7 +3975,6 @@ def read_targets_in_quick(hpdirname, shape=None,
 
     # ADM determine the relevant HEALPixels for the file NSIDE.
     filepixlist = nside2nside(nside, filenside, pixlist)
-
     targets = []
     for pix in filepixlist:
         infile = formatter.format(pix)


### PR DESCRIPTION
This PR should fix the crash noted in `desisurveyops` issue [#370](https://github.com/desihub/desisurveyops/issues/370).

The crash was occurring because M31 static target files have a different data model to `BRIGHT1B` stream target files. The solution was to combine files according to the data model in the stream target files.

This requires some special casing, but that special casing should only be applicable for M31-like files.

This problem will only arise in the SGC where we can potentially have M31 targets and `BRIGHT1B` stream targets on the same tile. In practice, this actually never happens, but a `BRIGHT1B` tile in the layer added in the SGC can touch multiple `nside=2` HEALPixels for which it _might_ have happened.

I'll merge-and-tag once tests pass, as this is the quickest way I could think of to prevent future crashes in Afternoon Planning.