### PR TITLE
Circumvent warnings when running with Python >3.12

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desitarget Change Log
 ------------------
 
 * Circumvent warnings when running with Python >3.12 [`PR #870`_].
-    * Addresses `issue #865`_ and `issue #866`_.
+    * Should address `issue #865`_ and `issue #866`_.
 
 .. _`issue #865`: https://github.com/desihub/desitarget/issues/865
 .. _`issue #866`: https://github.com/desihub/desitarget/issues/866

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,7 @@ desitarget Change Log
 ------------------
 
 * Circumvent warnings when running with Python >3.12 [`PR #870`_].
-  * Addresses `issue #865`_ and `issue #866`_.
+    * Addresses `issue #865`_ and `issue #866`_.
 
 .. _`issue #865`: https://github.com/desihub/desitarget/issues/865
 .. _`issue #866`: https://github.com/desihub/desitarget/issues/866

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,12 @@ desitarget Change Log
 4.5.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Circumvent warnings when running with Python >3.12 [`PR #870`_].
+  * Addresses `issue #865`_ and `issue #866`_.
+
+.. _`issue #865`: https://github.com/desihub/desitarget/issues/865
+.. _`issue #866`: https://github.com/desihub/desitarget/issues/866
+.. _`PR #870`: https://github.com/desihub/desitarget/pull/870
 
 4.5.0 (2025-12-16)
 ------------------

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2085,10 +2085,11 @@ def _prepare_optical_wise(objects, mask=True):
     # ADM flag whether we're using northen (BASS/MZLS) or
     # ADM southern (DECaLS) photometry.
     photsys_north = _isonnorthphotsys(objects["PHOTSYS"])
-    photsys_south = ~photsys_north
-    # ADM catch case where single object or row is passed.
+    # ADM make sure to catch the case of a single object or row.
     if isinstance(photsys_north, bool):
         photsys_south = not(photsys_north)
+    else:
+        photsys_south = ~photsys_north
 
     # ADM the observed r-band flux (used for F standards and MWS, below).
     # ADM make copies of values that we may reassign due to NaNs.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2199,7 +2199,8 @@ def _prepare_gaia(objects, colnames=None):
         # ADM the same outcome more explicitly without a warning.
         if np.ma.is_masked(refcat):
             refcat = np.array([np.nan])
-        refcat = np.array([refcat, ])
+        else:
+            refcat = np.array([refcat, ])
     if "REF_CAT" in colnames:
         gaia = (refcat == b'G2') | (refcat == 'G2')
         # ADM as of DR10, we use Gaia EDR3 rather than DR2.

--- a/py/desitarget/cuts.py
+++ b/py/desitarget/cuts.py
@@ -2192,6 +2192,12 @@ def _prepare_gaia(objects, colnames=None):
     gaia = objects['REF_ID'] > 0
     refcat = objects['REF_CAT']
     if _is_row(objects):
+        # ADM A single-element masked array is converted to array([nan])
+        # ADM by np.array([]), which is fine for our purposes, but as of
+        # ADM Python 3.12 this triggers a warning. This workaround gets
+        # ADM the same outcome more explicitly without a warning.
+        if np.ma.is_masked(refcat):
+            refcat = np.array([np.nan])
         refcat = np.array([refcat, ])
     if "REF_CAT" in colnames:
         gaia = (refcat == b'G2') | (refcat == 'G2')


### PR DESCRIPTION
This PR addresses issues #865 and #866.

In both cases, the warnings that were being raised by the unit tests for Python 3.12 and 3.13 were benign.

- For issue #865 we were already converting single Booleans using `not` and Boolean arrays using `~`. I just had to restructure this conversion to place the `~` case in an `if/else` block.

- For issue #866 the conversion of a single-element masked array to `NaN` was expected. I just had to make this conversion more explicit to prevent a warning being triggered.