### PR TITLE
Catch a corner case where the number of additional required observations drops to -1 for LyA quasars during 1b

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 4.7.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Catch case where NUMOBS_MORE drops to -1 for LyA quasars [`PR #878`_].
+
+.. _`PR #878`: https://github.com/desihub/desitarget/pull/878
 
 4.7.0 (2026-04-20)
 ------------------

--- a/py/desitarget/targets.py
+++ b/py/desitarget/targets.py
@@ -586,7 +586,8 @@ def calc_numobs_more(targets, zcat, obscon, ext=False):
             (zcat['Z_QN'] >= zcut) & (zcat["IS_QSO_QN"] == 1))
         # ADM so these targets need 6-N more observations to match the 6
         # ADM observations for LyA quasars in DESI 1B.
-        numobs_more[iselgnotqso & hiz] = 6 - zcat[iselgnotqso & hiz]['NUMOBS']
+        numobs_more[iselgnotqso & hiz] = np.maximum(
+            0, 6 - zcat[iselgnotqso & hiz]['NUMOBS'])
 
     # ADM apply special QSO behavior, but only in dark time and after
     # ADM some observations have occurred.


### PR DESCRIPTION
This PR catches a case where `NUMOBS_MORE` drops to -1 for LyA quasars during the 1b program, and sets the required numbers of obervations to 0 in such cases.

This case was unexpected because I thought we could only ever have two additional 1b layers for LyA quasars. But the possibility that a target can be observed in _both_ bright time and dark time increases the possible numbers of observations above 2 even if there are only two passes.

The target that triggered this failure mode was `39633339769946683`, which is both an `ELG` target and a `BGS_WISE` target (but is actually a z > 2.1 quasar).

I'll merge-and-tag soon as I'll need this PR to make MTL updates today.