### PR TITLE
Allow RE-processing of Merged Target Ledgers on 1B tiles.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,13 @@ desitarget Change Log
 4.7.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Catch reprocessing bug where 1B tile list can change size [`PR #879`_].
+    * The input tile list can be bigger than the output tile list.
+    * This is because not every 1B tile changes a 1A target.
+    * Notably M31 BRIGHT1B tiles which don't overlap any BRIGHT tiles.
+    * We don't write any tile information when `ext=True` anyway.
+
+.. _`PR #879`: https://github.com/desihub/desitarget/pull/879
 
 4.7.1 (2026-04-23)
 ------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -3233,7 +3233,7 @@ def loop_ledger(obscon, survey='main', zcatdir=None, mtldir=None,
     if survey == "main":
         # ADM when re-processing, a delay was already added, so get the
         # ADM TIMESTAMP from the dictionary returned by reprocess_ledger.
-        if reprocess:
+        if reprocess and not ext:
             tiles["TIMESTAMP"] = [timedict[tid] for tid in tiles["TILEID"]]
             # ADM sort tiles chronologically when reprocessing.
             tiles = tiles[np.argsort(tiles["TIMESTAMP"])]


### PR DESCRIPTION
This PR updates the MTL re-processing code to run seamlessly on `1B` tiles.

The existing code from the original survey worked for `1B` tiles too, except for one clause. The code could fail because the input and output list of tiles to be re-processed could change size. This is because it is not always the case that every `1B` tile will affect original survey targets — most notably for M31 `BRIGHT1B` tiles which don't overlap any original survey `BRIGHT` tiles.

The clause that is changed in this PR was inconsequential anyway, as in the case of re-processing MTLs for 1B tiles, we don't want to write the list of re-processed tiles _twice_. Although, for example, `BRIGHT1B` and `BRIGHT` targets will both need re-processing on `BRIGHT1B` tiles, as a consequence of both sets of targets being processed on `BRIGHT1B` tiles, the tile list only needs updated _once_, with the details for the `1B` tile.

I'll merge-and-tag in the next 24 hours or so as this simple code change is needed to re-process the tiles Anthony updated to address [desisurveyops/444](https://github.com/desihub/desisurveyops/issues/444).