### PR TITLE
 Add code to make a DR9/DR11 bricks file

### DIFF
--- a/bin/make_dr_nexp_brick_file
+++ b/bin/make_dr_nexp_brick_file
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from desitarget.geomask import dr_nexp_all_bricks
+from time import time
+t0 = time()
+
+import multiprocessing
+nproc = multiprocessing.cpu_count() // 2
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description="Generate file of exposures in bricks for an imaging data release.")
+ap.add_argument("drdir",
+                help="Root path to an LS imaging data release directory, e.g. \
+                /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/south/ at NERSC.")
+ap.add_argument("dest",
+                help="Output file name (full path)")
+ap.add_argument("--numproc", type=int,
+                help='number of concurrent processes to use [defaults to {}]'.format(nproc),
+                default=nproc)
+
+ns = ap.parse_args()
+
+done = dr_nexp_all_bricks(ns.drdir, numproc=ns.numproc, outfn=ns.dest)
+
+nb = len(done)
+elapsed = time() - t0
+
+log.info(f"Information for {nb} bricks written to {ns.dest}...t={elapsed:.1f}s")
+

--- a/bin/make_dr_nexp_brick_file
+++ b/bin/make_dr_nexp_brick_file
@@ -23,6 +23,8 @@ ap.add_argument("--numproc", type=int,
 
 ns = ap.parse_args()
 
+log.info(f"Running on {ns.numproc} processors")
+
 done = dr_nexp_all_bricks(ns.drdir, numproc=ns.numproc, outfn=ns.dest)
 
 nb = len(done)

--- a/bin/make_dr_survey_bricks_file
+++ b/bin/make_dr_survey_bricks_file
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+from desitarget.geomask import dr9_or_dr11_brick_file
+from time import time
+t0 = time()
+
+from desiutil.log import get_logger
+log = get_logger()
+
+tf = 0.25
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description="From DR9/DR11 brick files, create survey file of which bricks are in DR9/DR11.")
+ap.add_argument("surveybrickfn",
+                help="Root path to a Legacy Surveys general brick file, e.g., at NERSC, \
+                /global/cfs/cdirs/cosmo/data/legacysurvey/dr11/survey-bricks.fits.gz")
+ap.add_argument("dr9nfn",
+                help="Root path to a DR9 north NEXP all bricks file, as made \
+                by, e.g., make_dr_nexp_brick_file")
+ap.add_argument("dr9sfn",
+                help="Root path to a DR9 south NEXP all bricks file, as made \
+                by, e.g., make_dr_nexp_brick_file")
+ap.add_argument("dr11fn",
+                help="Root path to a DR11 NEXP all bricks file, as made by, \
+                e.g., make_dr_nexp_brick_file")
+ap.add_argument("dest",
+                help="Output file name (full path)")
+ap.add_argument("--threshfrac", type=float,
+                help=f"Threshold by which a DR11 brick has to exceed a DR9 brick \
+                in terms of the fraction of area covered by at least one \
+                observation in all of the g, r, z filters (`FALLPRIMGE1` in the \
+                NEXP all bricks files) [defaults to {tf}].",
+                default=tf)
+
+ns = ap.parse_args()
+
+done = dr9_or_dr11_brick_file(ns.surveybrickfn, ns.dr9nfn, ns.dr9sfn, ns.dr11fn,
+                              threshfrac=ns.threshfrac, outfn=ns.dest)
+
+nb = len(done)
+elapsed = time() - t0
+
+log.info(f"Information for {nb} bricks written to {ns.dest}...t={elapsed:.1f}s")

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desitarget Change Log
 4.7.3 (unreleased)
 ------------------
 
-* No changes yet.
+* Add code to make a DR9/DR11 bricks file [`PR #881`_].
+
+.. _`PR #881`: https://github.com/desihub/desitarget/pull/881
 
 4.7.2 (2026-04-29)
 ------------------

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -622,7 +622,7 @@ def make_gaia_light_dr3(numproc=128):
         inobjs = fitsio.read(infile)
 
         # ADM construct and write the lightweight versions.
-        done = np.zeros(len(inobjs), dtype = dr3datamodellight.dtype)
+        done = np.zeros(len(inobjs), dtype=dr3datamodellight.dtype)
         for col in done.dtype.names:
             done[col] = inobjs[col]
 
@@ -1775,9 +1775,9 @@ def match_gaia_to_primary_post_dr3(objs, matchrad=0.2, dr="dr3", maglim=None,
     for fn in gaiafiles:
         g = read_gaia_file(fn, dr=dr, lightweight=lightweight)
         if maglim is not None:
-            ii = (g['PHOT_G_MEAN_MAG'] < maglim) & (g['PHOT_G_MEAN_MAG'] !=0)
-            ii |= (g['PHOT_BP_MEAN_MAG'] < maglim) & (g['PHOT_BP_MEAN_MAG'] !=0)
-            ii |= (g['PHOT_RP_MEAN_MAG'] < maglim) & (g['PHOT_RP_MEAN_MAG'] !=0)
+            ii = (g['PHOT_G_MEAN_MAG'] < maglim) & (g['PHOT_G_MEAN_MAG'] != 0)
+            ii |= (g['PHOT_BP_MEAN_MAG'] < maglim) & (g['PHOT_BP_MEAN_MAG'] != 0)
+            ii |= (g['PHOT_RP_MEAN_MAG'] < maglim) & (g['PHOT_RP_MEAN_MAG'] != 0)
             g = g[ii]
         gaia.append(g)
     gaia = np.concatenate(gaia)

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -388,6 +388,145 @@ def dr_nexp_all_bricks(drdir, numproc=1, outfn=None):
     return done
 
 
+def dr9_or_dr11_brick_file(surveybrickfn, dr9nfn, dr9sfn, dr11fn,
+                           threshfrac=0.25, outfn=None):
+    """From DR9/DR11 brick files, determine which bricks are in DR9/DR11.
+
+    Parameters
+    ----------
+    surveybrickfn : :class:`str`
+        Root path to a Legacy Surveys general brick file, e.g., at NERSC,
+        /global/cfs/cdirs/cosmo/work/legacysurvey/dr11/survey-bricks.fits.gz
+    dr9nfn : :class:`str`
+        Root path to a DR9 north NEXP all bricks file, as made by
+        :func:`dr_nexp_all_bricks`
+    dr9sfn : :class:`str`
+        Root path to a DR9 south NEXP all bricks file, as made by
+        :func:`dr_nexp_all_bricks`
+    dr11fn : :class:`str`
+        Root path to a DR11 NEXP all bricks file, as made by
+        :func:`dr_nexp_all_bricks`
+    threshfrac : :class:`float`, optional, defaults to 0.25
+        Threshold by which a DR11 brick has to exceed a DR9 brick in the
+        fraction of area covered by at least one observation in all the
+        g, r, z filters (`FALLPRIMGE1` in the NEXP all bricks files).
+    outfn : :class:`str`, optional, defaults to ``None``
+        If passed, write the output array to this file path.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        Brick file that resembles `surveybrickfn` but with `FALLPRIMGE1`
+        added for DR9 north (DR9N), DR9 south (DR9S) and DR11 (see
+        :func:`dr_nexp_per_brick` for an explanation of this parameter)
+        and `DRVERSION` added, which is (9) 11 for a DR9 (DR11) brick.
+    """
+    # ADM read in the various file names.
+    sbf = fitsio.read(surveybrickfn)
+    dr9n = fitsio.read(dr9nfn)
+    dr9s = fitsio.read(dr9sfn)
+    dr11 = fitsio.read(dr11fn)
+
+    # ADM the output version of the survey brick file.
+    newc = ["FALLPRIMGE1DR9N", "FALLPRIMGE1DR9S", "FALLPRIMGE1DR11", "DRVERSION"]
+    nsbf = len(sbf)
+    newv = [np.zeros(nsbf), np.zeros(nsbf), np.zeros(nsbf), np.zeros(nsbf)]
+    newd = [">f8", ">f8", ">f8", ">i2"]
+    sbfout = rfn.append_fields(sbf, newc, newv, newd, usemask=False)
+
+    # ADM add the FALLPRIMGE1 values to the output file.
+    # ADM this maps from BRICKNAME to row in the output file.
+    dlookup = {row["BRICKNAME"]: row["BRICKID"]-1 for row in sbfout}
+    # ADM add the values for dr9 north, dr9 south and dr11.
+    for dr, nom in zip([dr9n, dr9s, dr11], ["DR9N", "DR9S", "DR11"]):
+        ii = np.array([dlookup[bn] for bn in dr["BRICKNAME"]])
+        sbfout[f"FALLPRIMGE1{nom}"][ii] = dr["FALLPRIMGE1"]
+
+    # ADM restrict to official southern declinations, which requires
+    # ADM finding the declinations for the DR11 bricks.
+    from desitarget.io import desitarget_resolve_dec
+    ii = np.array([dlookup[bn] for bn in dr11["BRICKNAME"]])
+    sbfoutdr11 = sbfout[ii]
+    # ADM limit to southern declinations.
+    ii = sbfoutdr11["DEC"] < desitarget_resolve_dec()
+    dr11 = dr11[ii]
+
+    allbricknames = set(dr11["BRICKNAME"])
+    allbricknames |= set(dr9n["BRICKNAME"])
+    allbricknames |= set(dr9s["BRICKNAME"])
+
+    # ADM set any populated brick to DR9, initially.
+    ii = np.array([bn in allbricknames for bn in sbfout["BRICKNAME"]])
+    sbfout["DRVERSION"][ii] = 9
+
+    # ADM make look-ups for brick name and FALLPRIMGE1 for DR9 and DR11.
+    dr9nd = {d["BRICKNAME"]: d["FALLPRIMGE1"] for d in dr9n}
+    dr9sd = {d["BRICKNAME"]: d["FALLPRIMGE1"] for d in dr9s}
+    dr11d = {d["BRICKNAME"]: d["FALLPRIMGE1"] for d in dr11}
+    # ADM this hold the list of brick names that are in DR11.
+    dr11bns = []
+    # ADM spool through the DR11 bricks.
+    for bn in dr11d:
+        # ADM if a brick is in DR11 it's a DR11 brick...
+        isdr11 = True
+        # ADM ...unless it appears in DR9 north and doesn't improve
+        # ADM on the fractional completeness by at least 50%...
+        try:
+            if dr9nd[bn] > 0 and dr11d[bn] <= dr9nd[bn] + threshfrac:
+                isdr11 = False
+        except KeyError:
+            pass
+        # ADM ...or it appears in DR9 south and doesn't improve
+        # ADM on the fractional completeness by at least 50%...
+        try:
+            if dr9sd[bn] > 0 and dr11d[bn] <= dr9sd[bn] + threshfrac:
+                isdr11 = False
+        except KeyError:
+            pass
+        # ADM ...or it doesn't have FALL coverage in DR9 or DR11.
+        if dr11d[bn] == 0:
+            try:
+                if dr9nd[bn] == 0:
+                    isdr11 = False
+            except KeyError:
+                pass
+            try:
+                if dr9sd[bn] == 0:
+                    isdr11 = False
+            except KeyError:
+                pass
+        # ADM finally, append truly DR11 bricks to the list.
+        if isdr11:
+            dr11bns.append(bn)
+
+    # ADM add the DR11 bricks to the output brick file.
+    sdr11bns = set(dr11bns)
+    ii = np.array([bn in sdr11bns for bn in sbfout["BRICKNAME"]])
+    sbfout["DRVERSION"][ii] = 11
+
+    # ADM fill some missing areas in the NGC at
+    # ADM low declinations with DR11 bricks.
+    isngc = is_in_gal_box([sbfout["RA"], sbfout["DEC"]], [0., 360., 10., 90.], radec=True)
+    ii = isngc & (sbfout["DEC"] < -10.2)
+    sbfout["DRVERSION"][ii] = 11
+
+    # ADM special case one brick to make areas more contiguous.
+    ii = sbfout["BRICKNAME"] == "3227p290"
+    sbfout["DRVERSION"][ii] = 9
+
+    # ADM if requested, write the output to somewhere.
+    if outfn is not None:
+        hdr = fitsio.FITSHDR()
+        hdr["THRESH"] = threshfrac
+        hdr["SURVEYBF"] = surveybrickfn
+        hdr["DR9NBF"] = dr9nfn
+        hdr["DR9SBF"] = dr9sfn
+        hdr["DR11BF"] = dr11fn
+        fitsio.write(outfn, sbfout, header=hdr)
+
+    return sbfout
+
+
 def ellipse_matrix(r, e1, e2):
     """Calculate transformation matrix from half-light-radius to ellipse
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -15,6 +15,7 @@ import numpy as np
 import os
 import fitsio
 from time import time
+from glob import glob
 
 from astropy.coordinates import SkyCoord
 from astropy import units as u
@@ -149,7 +150,8 @@ def get_imaging_maskbits(bitnamelist=None):
     - For the definitions of the mask bits, see, e.g.,
       https://www.legacysurvey.org/dr8/bitmasks/#maskbits
     """
-    bitdict = {"BRIGHT": 1, "ALLMASK_G": 5, "ALLMASK_R": 6, "ALLMASK_Z": 7,
+    bitdict = {"NPRIMARY": 0, "BRIGHT": 1,
+               "ALLMASK_G": 5, "ALLMASK_R": 6, "ALLMASK_Z": 7,
                "BAILOUT": 10, "MEDIUM": 11, "GALAXY": 12, "CLUSTER": 13}
 
     # ADM look up the bit value for each passed bit name.
@@ -232,6 +234,158 @@ def imaging_mask(maskbits, bitnamelist=get_default_maskbits(),
         mb &= ((maskbits & 2**bit) == 0)
 
     return mb
+
+
+def dr_nexp_per_brick(brickpath):
+    """Find number of exposures in one brick of an imaging data release.
+
+    Parameters
+    ----------
+    brickpath : :class:`str`
+        Path to a brick directory from an LS imaging data release, e.g.
+        /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/south/coadd/000/0001m322
+        at NERSC.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        An array of information for the passed brick, including:
+        BRICKNAME: Name of the brick.
+        NPIXPRIM: Number of pixels in the primary LS area of the brick.
+        NGPIXPRIMGE1: Number of pixels in g filter with >= 1 exposure.
+        NGPIXPRIMGE2: Number of pixels in g filter with >= 2 exposures.
+        NGPIXPRIMGE3: Number of pixels in g filter with >= 3 exposures.
+        NRPIXPRIMGE1: Number of pixels in r filter with >= 1 exposure.
+        NRPIXPRIMGE2: Number of pixels in r filter with >= 2 exposures.
+        NRPIXPRIMGE3: Number of pixels in r filter with >= 3 exposures.
+        NZPIXPRIMGE1: Number of pixels in z filter with >= 1 exposure.
+        NZPIXPRIMGE2: Number of pixels in z filter with >= 2 exposures.
+        NZPIXPRIMGE3: Number of pixels in z filter with >= 3 exposures.
+        NALLPRIMGE1: Number of pixels in all filters with >= 1 exposure.
+        NALLPRIMGE2: Number of pixels in all filters with >= 2 exposures.
+        NALLPRIMGE3: Number of pixels in all filters with >= 3 exposures.
+        FALLPRIMGE1: Pixel fraction in all filters with >= 1 exposure.
+            (i.e. NALLPRIMGE1/NPIXPRIM).
+        FALLPRIMGE2: Pixel fraction in all filters with >= 2 exposures.
+        FALLPRIMGE3: Pixel fraction in all filters with >= 3 exposures.
+    """
+    # ADM filename formats for Legacy Surveys NEXP and MASKBITS files.
+    maskbitsform = "legacysurvey-{}-maskbits.fits.fz"
+    nform = "legacysurvey-{}-nexp-{}.fits.fz"
+
+    # ADM the datatype for the output information.
+    dt = [("BRICKNAME", "U8"), ("NPIXPRIM", "i4"),
+          ("NGPIXPRIMGE1", "i4"), ("NGPIXPRIMGE2", "i4"), ("NGPIXPRIMGE3", "i4"),
+          ("NRPIXPRIMGE1", "i4"), ("NRPIXPRIMGE2", "i4"), ("NRPIXPRIMGE3", "i4"),
+          ("NZPIXPRIMGE1", "i4"), ("NZPIXPRIMGE2", "i4"), ("NZPIXPRIMGE3", "i4"),
+          ("NALLPRIMGE1", "i4"), ("NALLPRIMGE2", "i4"), ("NALLPRIMGE3", "i4"),
+          ("FALLPRIMGE1", "f8"), ("FALLPRIMGE2", "f8"), ("FALLPRIMGE3", "f8")]
+
+    # ADM to store the output.
+    outrow = np.zeros(1, dt)
+    # ADM the brick name.
+    bn = os.path.basename(brickpath)
+    # ADM read the maskbits and filter files.
+    maskbits = fitsio.read(os.path.join(brickpath, maskbitsform.format(bn)))
+    # ADM the trys are as some files don't exist. When that is so,
+    # ADM assume we have zero exposures everywhere for that filter.
+    try:
+        nexpg = fitsio.read(os.path.join(brickpath, nform.format(bn, "g")))
+    except OSError:
+        nexpg = np.zeros_like(maskbits)
+    try:
+        nexpr = fitsio.read(os.path.join(brickpath, nform.format(bn, "r")))
+    except OSError:
+        nexpr = np.zeros_like(maskbits)
+    try:
+        nexpz = fitsio.read(os.path.join(brickpath, nform.format(bn, "z")))
+    except OSError:
+        nexpz = np.zeros_like(maskbits)
+
+    # ADM the (integer) bit that corresponds to a non-primary pixel.
+    notprim = 2**get_imaging_maskbits(bitnamelist=["NPRIMARY"])[0]
+    # ADM the mask of primary pixels
+    primpix = maskbits & notprim == 0
+    # ADM populate the output quantities.
+    outrow["BRICKNAME"] = bn
+    outrow["NPIXPRIM"] = np.sum(primpix)
+    for i in range(1, 4):
+        outrow[f"NGPIXPRIMGE{i}"] = np.sum((nexpg >= i) & primpix)
+        outrow[f"NRPIXPRIMGE{i}"] = np.sum((nexpr >= i) & primpix)
+        outrow[f"NZPIXPRIMGE{i}"] = np.sum((nexpz >= i) & primpix)
+        outrow[f"NALLPRIMGE{i}"] = np.sum((nexpg >= i) & (nexpr >= i) &
+                                          (nexpz >= i) & primpix)
+        outrow[f"FALLPRIMGE{i}"] = outrow[f"NALLPRIMGE{i}"] / outrow["NPIXPRIM"]
+
+    return outrow
+
+
+def dr_nexp_all_bricks(drdir, numproc=1, outfn=None):
+    """Find number of exposures in all bricks of an imaging data release.
+
+    Parameters
+    ----------
+    drdir : :class:`str`
+        Root path to an LS imaging data release directory, e.g.
+        /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/south/ at NERSC.
+    numproc : :class:`int`, optional, defaults to 1
+        The number of parallel processes to use. `numproc`=128 results in
+        approximately 100 bricks being processed per second.
+    outfn : :class:`str`, optional, defaults to ``None``
+        If passed, write the output array to this file path.
+
+    Returns
+    -------
+    :class:`~numpy.ndarray`
+        Array of information for all bricks in the passed data release.
+        See :func:`dr_nexp_per_brick` for the returned columns.
+    """
+    t0 = time()
+    # ADM filename formats for Legacy Surveys NEXP and MASKBITS files.
+    maskbitsform = "legacysurvey-{}-maskbits.fits.fz"
+    nform = "legacysurvey-{}-nexp-{}.fits.fz"
+
+    # ADM all of the brick directories in the Data Release directory.
+    brickpaths = sorted(glob(os.path.join(drdir, "coadd", "*", "*")))
+
+    def _nexp_per_brick(brickpath):
+        """run dr_nexp_per_brick on the file path to a single brick"""
+
+        return dr_nexp_per_brick(brickpath)
+
+    # ADM to count the bricks and the passage of time.
+    nbrick = np.zeros((), dtype='i8')
+    t0 = time()
+
+    def _update_status(result):
+        """wrapper for the main parallelized reduction operation"""
+        if nbrick % 500 == 0 and nbrick > 0:
+            elapsed = time() - t0
+            rate = nbrick / elapsed
+            log.info("{}/{} bricks; {:.1f} bricks/sec; {:.1f} total mins elapsed"
+                     .format(nbrick, len(brickpaths), rate, elapsed/60.))
+
+        nbrick[...] += 1
+        return result
+
+    # ADM serial or parallel process the bricks.
+    if numproc > 1:
+        pool = sharedmem.MapReduce(np=numproc)
+        with pool:
+            done = pool.map(_nexp_per_brick, brickpaths,
+                            reduce=_update_status)
+    else:
+        done = []
+        for brickpath in brickpaths:
+            done.append(_update_status(_nexp_per_brick(brickpath)))
+
+    done = np.concatenate(done)
+
+    # ADM if requested, write the output to somewhere.
+    if outfn is not None:
+        fitsio.write(outfn, done)
+
+    return done
 
 
 def ellipse_matrix(r, e1, e2):

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -265,7 +265,7 @@ def dr_nexp_per_brick(brickpath):
         NALLPRIMGE2: Number of pixels in all filters with >= 2 exposures.
         NALLPRIMGE3: Number of pixels in all filters with >= 3 exposures.
         FALLPRIMGE1: Pixel fraction in all filters with >= 1 exposure.
-            (i.e. NALLPRIMGE1/NPIXPRIM).
+        (i.e. NALLPRIMGE1/NPIXPRIM).
         FALLPRIMGE2: Pixel fraction in all filters with >= 2 exposures.
         FALLPRIMGE3: Pixel fraction in all filters with >= 3 exposures.
     """
@@ -329,7 +329,7 @@ def dr_nexp_all_bricks(drdir, numproc=1, outfn=None):
         Root path to an LS imaging data release directory, e.g.
         /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/south/ at NERSC.
     numproc : :class:`int`, optional, defaults to 1
-        The number of parallel processes to use. `numproc`=128 results in
+        The number of parallel processes to use. numproc=128 results in
         approximately 100 bricks being processed per second.
     outfn : :class:`str`, optional, defaults to ``None``
         If passed, write the output array to this file path.

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -383,7 +383,7 @@ def dr_nexp_all_bricks(drdir, numproc=1, outfn=None):
 
     # ADM if requested, write the output to somewhere.
     if outfn is not None:
-        fitsio.write(outfn, done)
+        fitsio.write(outfn, done, clobber=True)
 
     return done
 
@@ -396,7 +396,7 @@ def dr9_or_dr11_brick_file(surveybrickfn, dr9nfn, dr9sfn, dr11fn,
     ----------
     surveybrickfn : :class:`str`
         Root path to a Legacy Surveys general brick file, e.g., at NERSC,
-        /global/cfs/cdirs/cosmo/work/legacysurvey/dr11/survey-bricks.fits.gz
+        /global/cfs/cdirs/cosmo/data/legacysurvey/dr11/survey-bricks.fits.gz
     dr9nfn : :class:`str`
         Root path to a DR9 north NEXP all bricks file, as made by
         :func:`dr_nexp_all_bricks`
@@ -407,9 +407,9 @@ def dr9_or_dr11_brick_file(surveybrickfn, dr9nfn, dr9sfn, dr11fn,
         Root path to a DR11 NEXP all bricks file, as made by
         :func:`dr_nexp_all_bricks`
     threshfrac : :class:`float`, optional, defaults to 0.25
-        Threshold by which a DR11 brick has to exceed a DR9 brick in the
-        fraction of area covered by at least one observation in all the
-        g, r, z filters (`FALLPRIMGE1` in the NEXP all bricks files).
+        Threshold by which a DR11 brick has to exceed a DR9 brick in terms
+        of the fraction of area covered by at least one observation in all
+        the g, r, z filters (`FALLPRIMGE1` in the NEXP all bricks files).
     outfn : :class:`str`, optional, defaults to ``None``
         If passed, write the output array to this file path.
 
@@ -522,7 +522,7 @@ def dr9_or_dr11_brick_file(surveybrickfn, dr9nfn, dr9sfn, dr11fn,
         hdr["DR9NBF"] = dr9nfn
         hdr["DR9SBF"] = dr9sfn
         hdr["DR11BF"] = dr11fn
-        fitsio.write(outfn, sbfout, header=hdr)
+        fitsio.write(outfn, sbfout, header=hdr, clobber=True)
 
     return sbfout
 

--- a/py/desitarget/test/make_testveto.py
+++ b/py/desitarget/test/make_testveto.py
@@ -35,8 +35,8 @@ if __name__ == "__main__":
     badtable["TARGETID"] = tids[:2] + tids[:1]
     badtable["RA"] = [20.91128333333333, 20.646224999999998, 22.07405]
     badtable["TIMESTAMP"] = ['2025-10-09T20:21:10+00:00',
-                              '2025-10-13T23:33:13+00:00',
-                              '2025-10-07T23:20:13+00:00']
+                             '2025-10-13T23:33:13+00:00',
+                             '2025-10-07T23:20:13+00:00']
 
     # ADM write the good and bad test data.
     os.makedirs("t/main/veto/bright1b/good", exist_ok=True)
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     ii = np.array([tid in tids for tid in egmtl1["TARGETID"]])
     _, fn1 = io.write_mtl(mtldir, egmtl1[ii], ecsv=True, survey="main",
-                        obscon="bright1b", nsidefile=nside, hpxlist=661)
+                          obscon="bright1b", nsidefile=nside, hpxlist=661)
 
     ii = np.array([tid in tids for tid in egmtl2["TARGETID"]])
     _, fn2 = io.write_mtl(mtldir, egmtl2[ii], ecsv=True, survey="main",

--- a/py/desitarget/test/test_veto.py
+++ b/py/desitarget/test/test_veto.py
@@ -13,6 +13,7 @@ import numpy as np
 from desitarget import io
 from desitarget.mtl import process_vetoes
 
+
 class TestVETO(unittest.TestCase):
 
     @classmethod
@@ -40,7 +41,7 @@ class TestVETO(unittest.TestCase):
         """Test a good veto file can be read but a bad one can't"""
         # ADM check the good data reads as expected.
         data = io.read_mtl_veto_file(self.test_goodfn)
-        self.assertTrue(type(data),  astropy.table.table.Table)
+        self.assertTrue(type(data), astropy.table.table.Table)
 
         # ADM check the bad data fails all of the ways.
         badmsg = "good so far!"
@@ -60,21 +61,21 @@ class TestVETO(unittest.TestCase):
 
         amtl1 = io.read_mtl_ledger(os.path.join(self.testdir, "main", "bright1b",
                                                 "mtl-bright1b-hp-661.ecsv"),
-                                                initial=True)
+                                   initial=True)
         amtl2 = io.read_mtl_ledger(os.path.join(self.testdir, "main", "bright1b",
                                                 "mtl-bright1b-hp-704.ecsv"),
-                                                initial=True)
+                                   initial=True)
         bmtl1 = io.read_mtl_ledger(os.path.join(self.testdir, "main", "bright1b",
                                                 "mtl-bright1b-hp-661.ecsv"))
         bmtl2 = io.read_mtl_ledger(os.path.join(self.testdir, "main", "bright1b",
                                                 "mtl-bright1b-hp-704.ecsv"))
 
         # ADM test all the initial states...
-        self.assertTrue(np.all(amtl1["TARGET_STATE"]==["M31_GIANT|UNOBS"]))
-        self.assertTrue(np.all(amtl2["TARGET_STATE"]==["M31_GIANT|UNOBS"]))
+        self.assertTrue(np.all(amtl1["TARGET_STATE"] == ["M31_GIANT|UNOBS"]))
+        self.assertTrue(np.all(amtl2["TARGET_STATE"] == ["M31_GIANT|UNOBS"]))
         # ADM ...have turned into the vetoed states.
-        self.assertTrue(np.all(bmtl1["TARGET_STATE"]==["VETO|DONE"]))
-        self.assertTrue(np.all(bmtl2["TARGET_STATE"]==["VETO|DONE"]))
+        self.assertTrue(np.all(bmtl1["TARGET_STATE"] == ["VETO|DONE"]))
+        self.assertTrue(np.all(bmtl2["TARGET_STATE"] == ["VETO|DONE"]))
 
         # ADM also check that the final priorities are the DONE priority
         # ADM and the initial priorities were higher than that.


### PR DESCRIPTION
This PR adds code to make a Legacy Surveys imaging bricks file that includes information about which bricks are formally in DR9 and which bricks are formally in DR11.

The first step to producing this file is to make individual files of the fractional areal coverage in each brick as a function of number of exposures. Something like the following commands need to be run to make files for each of DR9 north, DR9 south and DR11:

```
make_dr_nexp_brick_file /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/north $MTL_DIR/dr9-north-nexp-bricks.fits
make_dr_nexp_brick_file /global/cfs/cdirs/cosmo/data/legacysurvey/dr9/south $MTL_DIR/dr9-south-nexp-bricks.fits
make_dr_nexp_brick_file /global/cfs/cdirs/cosmo/work/legacysurvey/dr11/south $MTL_DIR/dr11-south-nexp-bricks.fits
```

The second step is to use the resulting files to make the ultimate bricks file using a command similar to:

```
make_dr_survey_bricks_file $surveybrickfn $MTL_DIR/dr9-north-nexp-bricks.fits $MTL_DIR/dr9-south-nexp-bricks.fits $MTL_DIR/dr11-south-nexp-bricks.fits $MTL_DIR/survey-bricks-dr.fits
```

where `$surveybrickfn` is a standard survey bricks file, such as `/global/cfs/cdirs/cosmo/work/legacysurvey/dr11/survey-bricks.fits.gz` at NERSC.
