### PR TITLE
Further facilitate RE-processing of Merged Target Ledgers on individual 1B tiles.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,14 @@ desitarget Change Log
 4.7.3 (unreleased)
 ------------------
 
-* No changes yet.
+* Catch further reprocessing bugs related to `PR #879`_ [`PR #882`_]:
+    * `PR #879`_ worked as buggy tiles were batched with other tiles.
+    * For individual buggy `1B` tiles, reprocessing can still fail.
+    * This PR catches 2 new corner cases for such individual tiles.
+    * The case caught in `PR #879`_.
+    * The case for which a `1B` tile contains no secondary targets.
+
+.. _`PR #882`: https://github.com/desihub/desitarget/pull/882
 
 4.7.2 (2026-04-29)
 ------------------

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -2249,6 +2249,16 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
     nuniq = len(set(targets["TARGETID"]))
     log.info("Retained {}/{} targets with {} unique TARGETIDs...t={:.1f}s"
              .format(len(targets), ntargs, nuniq, time()-t0))
+    # ADM there is a possible corner case where there are no secondary
+    # ADM targets that need reprocessed. For example, when running a 1B
+    # ADM tile from before secondary targets were assigned to 1B tiles.
+    # ADM In this case, the code will need run with the --nosec flag.
+    if len(targets) == 0 and "1B" in obscon:
+        msg = f"No targets to reprocess in {obscon} conditions. You may be "
+        msg += "reprocessing a tile from before secondaries were added to 1B "
+        msg += "tiles. If so, try re-running with the --nosec flag added."
+        log.error(msg)
+        raise ValueError(msg)
 
     # ADM split off the updated target states from the unobserved states.
     _, ii = np.unique(targets["TARGETID"], return_index=True)

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -2177,7 +2177,6 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
     :class:`dict`
         A dictionary where the keys are the integer TILEIDs and the values
         are the TIMESTAMP at which that tile was reprocessed.
-
     """
     t0 = time()
     log.info("Reprocessing based on zcat with {} entries...t={:.1f}s"
@@ -2220,6 +2219,16 @@ def reprocess_ledger(hpdirname, zcat, obscon="DARK"):
     pixnum = hp.ang2pix(nside, theta, phi, nest=True)
     pixnum = list(set(pixnum))
     targets = io.read_mtl_in_hp(hpdirname, nside, pixnum, unique=False)
+
+    # ADM there is a possible corner case where we are reprocessing a 1B
+    # ADM tile that includes no 1A targets. For example, an M31 tile that
+    # ADM doesn't overlap the DESI original survey. In the case of no
+    # ADM targets, return an empty timedict without maling updates.
+    if len(targets) == 0:
+        msg = "No targets need reprocessed. Should only happen when reprocessing"
+        msg += " 1A targets on 1B tiles that do not overlap the original survey!"
+        log.info(msg)
+        return timedict
 
     # ADM remove OVERRIDE entries, which should never need reprocessed.
     targets, _ = remove_overrides(targets)


### PR DESCRIPTION
This PR extends #879 to _individual_ `1B` tiles.

The updates in PR #879 worked when problematic `1B` tiles were combined in _batches with other tiles_ as this masked instances where there were _zero_ targets on individual `1B` tiles, because there were some targets on the other tiles in the batch.

This PR extends the fix for the specific bug detailed in #879 to also work for individual tiles for which there are no `1A` targets on a `1B` tile. It also captures a case where there are no secondary targets on `1B` tiles, which was typical prior to [recent updates to `fiberassign`](https://github.com/desihub/fiberassign/pull/504).

The updates in this PR will be needed to re-process M31 tile `123214` mentioned in [`desisurveyops/444`](https://github.com/desihub/desisurveyops/issues/444). But, that re-processing is not urgent so I'll wait until we've tagged a new version of `desitarget` for other reasons before addressing [`desisurveyops/444`](https://github.com/desihub/desisurveyops/issues/444).