### PR TITLE
Fix incorrect MTL concatenation in `read_mtl_in_hp` that would change entire ledger column values.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -12,9 +12,11 @@ desitarget Change Log
     * The case caught in `PR #879`_.
     * The case for which a `1B` tile contains no secondary targets.
 * Add code to make a DR9/DR11 bricks file [`PR #881`_].
+* Correct the concatenation of MTL ledgers in read_mtl_in_hp [`PR #884`_]
 
 .. _`PR #881`: https://github.com/desihub/desitarget/pull/881
 .. _`PR #882`: https://github.com/desihub/desitarget/pull/882
+.. _`PR #884`: https://github.com/desihub/desitarget/pull/884
 
 4.7.2 (2026-04-29)
 ------------------

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -2944,11 +2944,11 @@ def read_mtl_ledger(filename, unique=True, isodate=None, initial=False,
         # ADM need to catch cases where only one file actually exists.
         f1exists = os.path.isfile(filename[0])
         f2exists = os.path.isfile(filename[1])
-        if f1exists & ~f2exists:
+        if f1exists and (not f2exists):
             return read_one_mtl_ledger(
                 filename[0], unique=unique, isodate=isodate, initial=initial,
                 leq=leq, columns=columns, tabform=tabform, maketwostyle=True)
-        elif f2exists & ~f1exists:
+        elif f2exists and (not f1exists):
             return read_one_mtl_ledger(
                 filename[1], unique=unique, isodate=isodate, initial=initial,
                 leq=leq, columns=columns, tabform=tabform, maketwostyle=True)

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -3094,7 +3094,10 @@ def read_two_mtl_ledgers(filelist, unique=True, isodate=None, initial=False,
     done3["MTL_WANTED"] |= (mtl1match["PRIORITY"] > 2) * obsconditions[oc1]
     done3["MTL_WANTED"] |= (mtl2match["PRIORITY"] > 2) * obsconditions[oc2]
 
-    return np.concatenate([done1, done2, done3])
+    # DG - define output datatype to avoid the concatenate casting
+    # everything to big endian instead of maintaining the little endian
+    # type of all input MTLS.
+    return np.concatenate([done1, done2, done3], dtype=done3.dtype)
 
 
 def read_one_mtl_ledger(filename, unique=True, isodate=None, initial=False,
@@ -3580,7 +3583,10 @@ def read_mtl_in_hp(hpdirname, nside, pixlist, unique=True, isodate=None,
                 return outly, outfns
             return outly
 
-        mtl = np.concatenate(mtls)
+        # TODO Reproduce old behaviour with concatenate.
+        # mtl = np.concatenate(mtls)
+        mtl = rfn.stack_arrays(mtls, asrecarray=True, usemask=True)
+
     # ADM ...if a directory wasn't passed, just read in the targets.
     else:
         # ADM turn the list back into a string.
@@ -4203,6 +4209,9 @@ def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False,
 
     if header and not mtl:
         return targets, hdr
+
+    print(f"BISCUITS, {targets.dtype}")
+    print(targets[0:5])
     return targets
 
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -4210,8 +4210,6 @@ def read_targets_in_tiles(hpdirname, tiles=None, columns=None, header=False,
     if header and not mtl:
         return targets, hdr
 
-    print(f"BISCUITS, {targets.dtype}")
-    print(targets[0:5])
     return targets
 
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -3453,7 +3453,8 @@ def find_mtl_file_format_from_header(hpdirname, returnoc=False,
 
 def read_mtl_in_hp(hpdirname, nside, pixlist, unique=True, isodate=None,
                    returnfn=False, initial=False, leq=False, columns=None,
-                   tabform='ascii.basic', maketwostyle=False):
+                   tabform='ascii.basic', maketwostyle=False,
+                   use_concatenate=False):
     """Read Merged Target List ledgers in a set of HEALPixels.
 
     Parameters
@@ -3508,6 +3509,12 @@ def read_mtl_in_hp(hpdirname, nside, pixlist, unique=True, isodate=None,
     maketwostyle : :class:`bool`, optional, defaults to ``False``
         If passed, add the extra columns that are added when running
         :func:`read_two_mtl_ledgers()`, even if only reading one ledger.
+    use_concatenate : :class:`bool`, optional, defaults to ``False``
+        If passed, use `np.concatenate()` rather than `stack_arrays` to stack
+        the list of mtls. This reproduces buggy behaviour described in
+        https://github.com/desihub/desitarget/issues/883, where different
+        column orders of `read_two_mtl_ledgers()` and `read_one_mtl_ledger()`
+        was ignored in the concatenation process.
 
     Returns
     -------
@@ -3583,9 +3590,30 @@ def read_mtl_in_hp(hpdirname, nside, pixlist, unique=True, isodate=None,
                 return outly, outfns
             return outly
 
-        # TODO Reproduce old behaviour with concatenate.
-        # mtl = np.concatenate(mtls)
-        mtl = rfn.stack_arrays(mtls, asrecarray=True, usemask=True)
+        # DG - Reproduce old behaviour with concatenate, explained in the ticket
+        # in the docstring.
+        if use_concatenate:
+            # DG - this was the version that changed concatenate, so
+            # above this version we have to manually recreate the behaviour
+            if np.__version__ >= "1.23.0":
+                # DG - We will have to concatenate each column individually to
+                # avoid field name clash errors.
+                # Previous behaviour used the last MTL to determine column naming.
+                chosen_dtype = mtls[-1].dtype
+                # Inner list comprehension pulls the column indixed by this index,
+                # by pulling the name of the column at this index from the dtype
+                # of that mtl.
+                mtl = np.zeros(np.sum([len(m) for m in mtls]), dtype=chosen_dtype)
+                for i, name in enumerate(chosen_dtype.names):
+                    mtl[name] = np.concatenate([m[m.dtype.names[i]] for m in mtls])
+
+            # DG - Below that version we can just call np.concatenate.
+            else:
+                mtl = np.concatenate(mtls)
+        else:
+            # DG - It is faster to have `usemask=True` and there are not adverse
+            # downstream effects, in my testing, so we are safe to use it.
+            mtl = rfn.stack_arrays(mtls, asrecarray=True, usemask=True)
 
     # ADM ...if a directory wasn't passed, just read in the targets.
     else:

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -41,7 +41,7 @@ mtldatamodel = np.array([], dtype=[
     ('PMRA', '>f4'), ('PMDEC', '>f4'), ('REF_EPOCH', '>f4'),
     ('DESI_TARGET', '>i8'), ('BGS_TARGET', '>i8'), ('MWS_TARGET', '>i8'),
     ('SCND_TARGET', '>i8'), ('TARGETID', '>i8'),
-    ('SUBPRIORITY', '>f8'), ('OBSCONDITIONS', 'i4'),
+    ('SUBPRIORITY', '>f8'), ('OBSCONDITIONS', '>i4'),
     ('PRIORITY_INIT', '>i8'), ('NUMOBS_INIT', '>i8'), ('PRIORITY', '>i8'),
     ('NUMOBS', '>i8'), ('NUMOBS_MORE', '>i8'), ('Z', '>f8'), ('ZWARN', '>i8'),
     ('TIMESTAMP', 'U25'), ('VERSION', 'U14'), ('TARGET_STATE', 'U30'),
@@ -51,27 +51,27 @@ mtldatamodel = np.array([], dtype=[
 # ADM at some point the primary and secondary data models for the MTLs
 # ADM are trimmed and reordered. These record their exact format on disk.
 mtlprimdatamodel = np.array([], dtype=[
-    ('RA', '<f8'), ('DEC', '<f8'), ('REF_EPOCH', '<f4'),
-    ('PARALLAX', '<f4'), ('PMRA', '<f4'), ('PMDEC', '<f4'),
-    ('TARGETID', '<i8'), ('DESI_TARGET', '<i8'), ('BGS_TARGET', '<i8'),
-    ('MWS_TARGET', '<i8'), ('SUBPRIORITY', '<f8'), ('OBSCONDITIONS', '<i4'),
-    ('PRIORITY_INIT', '<i8'), ('NUMOBS_INIT', '<i8'), ('SCND_TARGET', '<i8'),
-    ('NUMOBS_MORE', '<i8'), ('NUMOBS', '<i8'), ('Z', '<f8'), ('ZWARN', '<i8'),
-    ('ZTILEID', '<i4'), ('Z_QN', '<f8'), ('IS_QSO_QN', '<i2'),
-    ('DELTACHI2', '<f8'), ('TARGET_STATE', '<U30'), ('TIMESTAMP', '<U25'),
-    ('VERSION', '<U14'), ('PRIORITY', '<i8')
+    ('RA', '>f8'), ('DEC', '>f8'), ('REF_EPOCH', '>f4'),
+    ('PARALLAX', '>f4'), ('PMRA', '>f4'), ('PMDEC', '>f4'),
+    ('TARGETID', '>i8'), ('DESI_TARGET', '>i8'), ('BGS_TARGET', '>i8'),
+    ('MWS_TARGET', '>i8'), ('SUBPRIORITY', '>f8'), ('OBSCONDITIONS', '>i4'),
+    ('PRIORITY_INIT', '>i8'), ('NUMOBS_INIT', '>i8'), ('SCND_TARGET', '>i8'),
+    ('NUMOBS_MORE', '>i8'), ('NUMOBS', '>i8'), ('Z', '>f8'), ('ZWARN', '>i8'),
+    ('ZTILEID', '>i4'), ('Z_QN', '>f8'), ('IS_QSO_QN', '>i2'),
+    ('DELTACHI2', '>f8'), ('TARGET_STATE', '<U30'), ('TIMESTAMP', '<U25'),
+    ('VERSION', '<U14'), ('PRIORITY', '>i8')
 ])
 
 mtlsecdatamodel = np.array([], dtype=[
-    ('RA', '<f8'), ('DEC', '<f8'), ('PMRA', '<f4'), ('PMDEC', '<f4'),
-    ('REF_EPOCH', '<f4'), ('PARALLAX', '<f4'), ('TARGETID', '<i8'),
-    ('DESI_TARGET', '<i8'), ('SCND_TARGET', '<i8'), ('SUBPRIORITY', '<f8'),
-    ('OBSCONDITIONS', '<i4'), ('PRIORITY_INIT', '<i8'), ('NUMOBS_INIT', '<i8'),
-    ('BGS_TARGET', '<i8'), ('MWS_TARGET', '<i8'), ('NUMOBS_MORE', '<i8'),
-    ('NUMOBS', '<i8'), ('Z', '<f8'), ('ZWARN', '<i8'), ('ZTILEID', '<i4'),
-    ('Z_QN', '<f8'), ('IS_QSO_QN', '<i2'), ('DELTACHI2', '<f8'),
+    ('RA', '>f8'), ('DEC', '>f8'), ('PMRA', '>f4'), ('PMDEC', '>f4'),
+    ('REF_EPOCH', '>f4'), ('PARALLAX', '>f4'), ('TARGETID', '>i8'),
+    ('DESI_TARGET', '>i8'), ('SCND_TARGET', '>i8'), ('SUBPRIORITY', '>f8'),
+    ('OBSCONDITIONS', '>i4'), ('PRIORITY_INIT', '>i8'), ('NUMOBS_INIT', '>i8'),
+    ('BGS_TARGET', '>i8'), ('MWS_TARGET', '>i8'), ('NUMOBS_MORE', '>i8'),
+    ('NUMOBS', '>i8'), ('Z', '>f8'), ('ZWARN', '<i8'), ('ZTILEID', '>i4'),
+    ('Z_QN', '>f8'), ('IS_QSO_QN', '>i2'), ('DELTACHI2', '>f8'),
     ('TARGET_STATE', '<U30'), ('TIMESTAMP', '<U25'), ('VERSION', '<U14'),
-    ('PRIORITY', '<i8')
+    ('PRIORITY', '>i8')
 ])
 
 
@@ -1824,8 +1824,8 @@ def process_vetoes(obscon, survey="main", mtldir=None, tabform='ascii.basic'):
     io.write_mtl_tile_file(mtldonefn, vetodone)
 
     return
-        
-    
+
+
 def process_overrides(ledgerfn, tabform='ascii.basic'):
     """
     Recover MTL entries from override ledgers and update those ledgers.


### PR DESCRIPTION
This fixes the crash identified in fiberassign triggered by `read_mtl_in_hp`, in issue #883. 

The fix is done, at base level, by using `np.recfunctions.stack_array` instead of `np.concatenate` to concatenate the MTLs. The former function correctly matches on columns, and stacks columns as expected. The latter in `numpy < 1.23.0` concatenated the recarrays without concern for column ordering, which caused problems because `read_two_mtl_ledgers` and `read_one_mtl_ledger` can return different MTL column orders. This happens when reading a tile that has some ledgers _only_ in 1B (read with `read_one_mtl_ledger`, with the 1B MTL data model) and some ledgers in both 1A and 1B (read with `read_two_mtl_ledgers` and thus using the 1A data model, due to the fix in #855).  In `numpy >= 1.23.0` this triggers a crash, because `np.concatenate` added a check that the data model of all input arrays is exactly identical and it is not in this case.

Fixing this crash additionally required changing the endianness of `mtlprimdatamodel` and `mtlsecdatamodel` dtypes so that `read_two_ledgers` returns the same endianness as `read_one_ledger`, even when the columns are not in the same order.