### PR TITLE
Process targets and skies from DR11 imaging.

### DIFF
--- a/bin/select_skies
+++ b/bin/select_skies
@@ -151,6 +151,8 @@ else:
         skies = np.array(skies, dtype=object)
         ii = [sk is not None for sk in skies]
         skies = np.concatenate(skies[ii])
+    else:
+        skies = np.concatenate(skies)
 
     # ADM resolve any duplicates between imaging data releases. 
     resolved = resolve(skies)

--- a/bin/select_skies
+++ b/bin/select_skies
@@ -147,9 +147,10 @@ else:
         )
 
     # ADM redact empty output (where there were no bricks in a survey).
-    skies = np.array(skies, dtype=object)
-    ii = [sk is not None for sk in skies]
-    skies = np.concatenate(skies[ii])
+    if len(surveys) > 1:
+        skies = np.array(skies, dtype=object)
+        ii = [sk is not None for sk in skies]
+        skies = np.concatenate(skies[ii])
 
     # ADM resolve any duplicates between imaging data releases. 
     resolved = resolve(skies)

--- a/bin/select_targets
+++ b/bin/select_targets
@@ -116,7 +116,7 @@ if len(infiles) == 0:
 # ADM (e.g. DR6 or above). Fail for earlier Data Releases.
 # ADM Guard against a single file being passed.
 fn = infiles
-if ~isinstance(infiles, str):
+if not isinstance(infiles, str):
     fn = infiles[0]
 data = fitsio.read(fn, columns=["RELEASE","PMRA"], upper=True)
 if np.any(data["RELEASE"] < 6000):

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desitarget Change Log
 4.7.3 (unreleased)
 ------------------
 
-* Update desitarget code to process targets and skies [`PR #885`_]:
+* Update code to process targets and skies from DR11 [`PR #885`_]:
     * Mostly handles updates to the DR11 imaging data model.
     * In particular, adds new `RELEASE` numbers for DR11/south.
     * Also updates the FITS extension from which the blob maps are read.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -20,7 +20,7 @@ desitarget Change Log
 
 .. _`PR #881`: https://github.com/desihub/desitarget/pull/881
 .. _`PR #882`: https://github.com/desihub/desitarget/pull/882
-.. _`PR #882`: https://github.com/desihub/desitarget/pull/885
+.. _`PR #885`: https://github.com/desihub/desitarget/pull/885
 
 4.7.2 (2026-04-29)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,11 @@ desitarget Change Log
 4.7.3 (unreleased)
 ------------------
 
+* Update desitarget code to process targets and skies [`PR #885`_]:
+    * Mostly handles updates to the DR11 imaging data model.
+    * In particular, adds new `RELEASE` numbers for DR11/south.
+    * Also updates the FITS extension from which the blob maps are read.
+    * And adds some slurm scripts to improve batching using GNU parallel.
 * Catch further reprocessing bugs related to `PR #879`_ [`PR #882`_]:
     * `PR #879`_ worked as buggy tiles were batched with other tiles.
     * For individual buggy `1B` tiles, reprocessing can still fail.
@@ -15,6 +20,7 @@ desitarget Change Log
 
 .. _`PR #881`: https://github.com/desihub/desitarget/pull/881
 .. _`PR #882`: https://github.com/desihub/desitarget/pull/882
+.. _`PR #882`: https://github.com/desihub/desitarget/pull/885
 
 4.7.2 (2026-04-29)
 ------------------

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1241,24 +1241,6 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     if nnodes > 48:
         nnodes = 48
 
-    print("#######################################################")
-    print("Possible salloc command if you want to run on the Cori interactive queue:")
-    print("")
-    print("salloc -N {} -C haswell -t 0{}:00:00 --qos interactive -L SCRATCH,project"
-          .format(nnodes, maxeta))
-
-    print("")
-    print("#######################################################")
-    print('Example shell script for slurm:')
-    print('')
-    print('#!/bin/bash -l')
-    print('#SBATCH -q regular')
-    print('#SBATCH -N {}'.format(nnodes))
-    print('#SBATCH -t 0{}:00:00'.format(maxeta))
-    print('#SBATCH -L SCRATCH,project')
-    print('#SBATCH -C haswell')
-    print('')
-
     # ADM extract the Data Release number from the survey directory
     dr = surveydir.split("dr")[-1].split(os.path.sep)[0]
     # ADM if an integer can't be extracted, use X instead.
@@ -1266,6 +1248,23 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
         drstr = "-dr{}".format(int(dr))
     except ValueError:
         drstr = ""
+
+    print("#######################################################")
+    print("Possible salloc command for Perlmutter interactive queue:")
+    print("")
+    print("salloc --nodes 4 --qos interactive --time 04:00:00 --constraint cpu")
+    print("")
+    print("#######################################################")
+    print('Example shell script for slurm:')
+    print('')
+    print('#!/bin/bash -l')
+    print('#SBATCH -q regular')
+    print(f'#SBATCH -N {nnodes}')
+    print(f'#SBATCH -t 0{maxeta}:00:00')
+    print('#SBATCH -L scratch,cfs')
+    print('#SBATCH -C cpu')
+    print(f'#SBATCH -o {prefix}{drstr}.log')
+    print('')
 
     # ADM to handle inputs that look like "svX_targets".
     prefix2 = prefix

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1268,7 +1268,9 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
 
     # ADM also write the various batch files needed for GNU parallel.
     # ADM this counts the command line args, as parallel expects that.
-    argscnt = 6 + len(extra.split()) + int(surveydir2 != None) 
+    argscnt = 6 + int(surveydir2 != None)
+    if extra is not None:
+        argscnt += len(extra.split())
     args = " ".join(["{"+str(i)+"}" for i in np.arange(argscnt)+1])
     with open(f"{prefix}{drstr}-driver.sh", 'w') as driverfn:
         driverfn.write("""#!/bin/bash\n""")

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1266,6 +1266,43 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     print(f'#SBATCH -o {prefix}{drstr}.log')
     print('')
 
+    # ADM also write the various batch files needed for GNU parallel.
+    # ADM this counts the command line args, as parallel expects that.
+    argscnt = 6 + len(extra.split()) + int(surveydir2 != None) 
+    args = " ".join(["{"+str(i)+"}" for i in np.arange(argscnt)+1])
+    with open(f"{prefix}{drstr}-driver.sh", 'w') as driverfn:
+        driverfn.write("""#!/bin/bash\n""")
+        driverfn.write("""if [[ -z "${SLURM_NODEID}" ]]; then\n""")
+        driverfn.write("""    echo "need \$SLURM_NODEID set"\n""")
+        driverfn.write("""    exit\n""")
+        driverfn.write("""fi\n""")
+        driverfn.write("""if [[ -z "${SLURM_NNODES}" ]]; then\n""")
+        driverfn.write("""    echo "need \$SLURM_NNODES set"\n""")
+        driverfn.write("""    exit\n""")
+        driverfn.write("""fi\n""")
+        driverfn.write("""cat $1 |                                               \\""")
+        driverfn.write("\n")
+        driverfn.write('''awk -v NNODE="$SLURM_NNODES" -v NODEID="$SLURM_NODEID" \\''')
+        driverfn.write("\n")
+        driverfn.write("""'NR % NNODE == NODEID' |                               \\""")
+        driverfn.write("\n")
+        driverfn.write(f"parallel --colsep ' ' select_{prefix} {args}\n")
+
+    with open(f"{prefix}{drstr}-gnu-parallel.sh", 'w') as gpfn:
+        gpfn.write("""#!/bin/bash\n""")
+        gpfn.write('#SBATCH -q regular\n')
+        gpfn.write(f'#SBATCH -N 64\n')
+        gpfn.write(f'#SBATCH -t 00:30:00\n')
+        gpfn.write('#SBATCH -L scratch,cfs\n')
+        gpfn.write('#SBATCH -C cpu\n')
+        gpfn.write('#SBATCH --ntasks-per-node 1\n')
+        gpfn.write(f'#SBATCH -o {prefix}{drstr}.log\n')
+        gpfn.write(f"# Alternative for the Perlmutter interactive queue:\n")
+        gpfn.write(f"# salloc --nodes 4 --qos interactive --time 04:00:00 --constraint cpu\n")
+        gpfn.write(f"# srun --no-kill --ntasks=4 --ntasks-per-node 1 --wait=0 ./{prefix}{drstr}-driver.sh {prefix}{drstr}.tasks\n")
+        gpfn.write("\n")
+        gpfn.write(f"srun --no-kill --ntasks=64 --wait=0 ./{prefix}{drstr}-driver.sh $1")
+
     # ADM to handle inputs that look like "svX_targets".
     prefix2 = prefix
     if prefix[0:2] == "sv":
@@ -1273,7 +1310,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
 
     s2 = ""
     if surveydir2 is not None:
-        s2 = "-s2 {}".format(surveydir2)
+        s2 = "-s2 {} ".format(surveydir2)
 
     cmd = "select"
     if prefix == "supp-skies":
@@ -1282,7 +1319,12 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
 
     from desitarget.io import _check_hpx_length, find_target_files
 
+    # ADM expand the scratch directory as it's safer than batching on
+    # ADM the environment variable.
+    scratch = os.getenv("SCRATCH")
     pixtracker = []
+    # ADM taskstext holds the output tasks for gnu parallel.
+    taskstext = ""
     for bin in bins:
         num = np.array(bin)[:, 0]
         pix = np.array(bin)[:, 1]
@@ -1296,8 +1338,12 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             pixtracker.append(strgoodpix)
             if extra is not None:
                 strgoodpix += extra
-            print("srun -N 1 {}_{} {} $SCRATCH {} --nside {} --healpixels {} &"
-                  .format(cmd, prefix2, surveydir, s2, nside, strgoodpix))
+            taskstring = "{} {} {}--nside {} --healpixels {}".format(
+                surveydir, scratch, s2, nside, strgoodpix)
+            taskstext += f"{taskstring}\n"
+            print(f"srun -N 1 {cmd}_{prefix2} {taskstring} &")
+    with open(f"{prefix}{drstr}.tasks", 'w') as tasksfn:
+        tasksfn.write(taskstext)
     print("wait")
     print("")
     if gather:
@@ -1308,11 +1354,11 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
             outfiles = []
             for pix in pixtracker:
                 outfn = find_target_files(
-                    "$SCRATCH", dr=ddrr, flavor=prefix, seed=seed, hp=pix,
+                    scratch, dr=ddrr, flavor=prefix, seed=seed, hp=pix,
                     resolve=resolve, region=region)
                 outfiles.append(outfn)
             outfn = find_target_files(
-                "$SCRATCH", dr=ddrr, flavor=prefix, seed=seed, nohp=True,
+                scratch, dr=ddrr, flavor=prefix, seed=seed, nohp=True,
                 resolve=resolve, region=region)
             print("")
             # ADM split each pixel-file into 10 smaller catalogs.

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -86,6 +86,18 @@ dr10replacecols = {('MASKBITS', '>i2'): ('MASKBITS', '>i4'),
                    ('LC_MJD_W1', '>f8', (15,)): ('LC_MJD_W1', '>f8', (17,)),
                    ('LC_MJD_W2', '>f8', (15,)): ('LC_MJD_W2', '>f8', (17,))}
 
+# ADM columns that have updated dtypes in the DR11 data model.
+dr11replacecols = {('MASKBITS', '>i2'): ('MASKBITS', '>i4'),
+                   ('LC_FLUX_W1', '>f4', (15,)): ('LC_FLUX_W1', '>f4', (19,)),
+                   ('LC_FLUX_W2', '>f4', (15,)): ('LC_FLUX_W2', '>f4', (19,)),
+                   ('LC_FLUX_IVAR_W1', '>f4', (15,)): ('LC_FLUX_IVAR_W1', '>f4', (19,)),
+                   ('LC_FLUX_IVAR_W2', '>f4', (15,)): ('LC_FLUX_IVAR_W2', '>f4', (19,)),
+                   ('LC_NOBS_W1', '>i2', (15,)): ('LC_NOBS_W1', '>i2', (19,)),
+                   ('LC_NOBS_W2', '>i2', (15,)): ('LC_NOBS_W2', '>i2', (19,)),
+                   ('LC_MJD_W1', '>f8', (15,)): ('LC_MJD_W1', '>f8', (19,)),
+                   ('LC_MJD_W2', '>f8', (15,)): ('LC_MJD_W2', '>f8', (19,))}
+
+
 # ADM columns that are new for the DR9 data model.
 dr9addedcols = np.array([], dtype=[
     ('LC_FLUX_W1', '>f4', (15,)), ('LC_FLUX_W2', '>f4', (15,)),
@@ -213,7 +225,9 @@ def read_tractor(filename, header=False, columns=None, gaiasub=False):
             [], dtype=basetsdatamodel.dtype.descr + dr8addedcols.dtype.descr)
     else:
         newdt = basetsdatamodel.dtype.descr + dr9addedcols.dtype.descr
-        if "FLUX_I" in indata.dtype.names:  # ADM i-fluxes were added for DR10.
+        if "LS_ID_DR11" in indata.dtype.names:  # ADM LS ID was added for DR11.
+            newdt = [dr11replacecols.get(tup, tup) for tup in newdt]
+        elif "FLUX_I" in indata.dtype.names:  # ADM i-fluxes were added for DR10.
             newdt = [dr10replacecols.get(tup, tup) for tup in newdt]
         tsdatamodel = np.array([], dtype=newdt)
 

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -90,14 +90,14 @@ dr10replacecols = {('MASKBITS', '>i2'): ('MASKBITS', '>i4'),
 
 # ADM columns that have updated dtypes in the DR11 data model.
 dr11replacecols = {('MASKBITS', '>i2'): ('MASKBITS', '>i4'),
-                   ('LC_FLUX_W1', '>f4', (15,)): ('LC_FLUX_W1', '>f4', (19,)),
-                   ('LC_FLUX_W2', '>f4', (15,)): ('LC_FLUX_W2', '>f4', (19,)),
-                   ('LC_FLUX_IVAR_W1', '>f4', (15,)): ('LC_FLUX_IVAR_W1', '>f4', (19,)),
-                   ('LC_FLUX_IVAR_W2', '>f4', (15,)): ('LC_FLUX_IVAR_W2', '>f4', (19,)),
-                   ('LC_NOBS_W1', '>i2', (15,)): ('LC_NOBS_W1', '>i2', (19,)),
-                   ('LC_NOBS_W2', '>i2', (15,)): ('LC_NOBS_W2', '>i2', (19,)),
-                   ('LC_MJD_W1', '>f8', (15,)): ('LC_MJD_W1', '>f8', (19,)),
-                   ('LC_MJD_W2', '>f8', (15,)): ('LC_MJD_W2', '>f8', (19,))}
+                   ('LC_FLUX_W1', '>f4', (15,)): ('LC_FLUX_W1', '>f4', (25,)),
+                   ('LC_FLUX_W2', '>f4', (15,)): ('LC_FLUX_W2', '>f4', (25,)),
+                   ('LC_FLUX_IVAR_W1', '>f4', (15,)): ('LC_FLUX_IVAR_W1', '>f4', (25,)),
+                   ('LC_FLUX_IVAR_W2', '>f4', (15,)): ('LC_FLUX_IVAR_W2', '>f4', (25,)),
+                   ('LC_NOBS_W1', '>i2', (15,)): ('LC_NOBS_W1', '>i2', (25,)),
+                   ('LC_NOBS_W2', '>i2', (15,)): ('LC_NOBS_W2', '>i2', (25,)),
+                   ('LC_MJD_W1', '>f8', (15,)): ('LC_MJD_W1', '>f8', (25,)),
+                   ('LC_MJD_W2', '>f8', (15,)): ('LC_MJD_W2', '>f8', (25,))}
 
 
 # ADM columns that are new for the DR9 data model.

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -46,8 +46,8 @@ releasedict = {
     3000: 'S', 4000: 'N', 5000: 'S', 6000: 'N', 7000: 'S', 7999: 'S',
     8000: 'S', 8001: 'N', 9000: 'S', 9001: 'N', 9002: 'S', 9003: 'N',
     9004: 'S', 9005: 'N', 9006: 'S', 9007: 'N', 9008: 'S', 9009: 'N',
-    9010: 'S', 9011: 'N', 9012: 'S', 9013: 'N', 10000: 'S', 10099: 'S'
-}
+    9010: 'S', 9011: 'N', 9012: 'S', 9013: 'N', 10000: 'S', 10099: 'S',
+    11010: 'S'}
 
 # ADM This is an empty array of most of the TS data model columns and
 # ADM dtypes. Note that other columns are added in read_tractor and

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -42,10 +42,12 @@ log = get_logger()
 # ADM photometric system. This will expand with the definition of RELEASE in the
 # ADM Data Model (e.g. https://desi.lbl.gov/trac/wiki/DecamLegacy/DR4sched).
 # ADM 7999 were the dr8a test reductions, for which only 'S' surveys were processed.
-releasedict = {3000: 'S', 4000: 'N', 5000: 'S', 6000: 'N', 7000: 'S', 7999: 'S',
-               8000: 'S', 8001: 'N', 9000: 'S', 9001: 'N', 9002: 'S', 9003: 'N',
-               9004: 'S', 9005: 'N', 9006: 'S', 9007: 'N', 9008: 'S', 9009: 'N',
-               9010: 'S', 9011: 'N', 9012: 'S', 9013: 'N', 10000: 'S'}
+releasedict = {
+    3000: 'S', 4000: 'N', 5000: 'S', 6000: 'N', 7000: 'S', 7999: 'S',
+    8000: 'S', 8001: 'N', 9000: 'S', 9001: 'N', 9002: 'S', 9003: 'N',
+    9004: 'S', 9005: 'N', 9006: 'S', 9007: 'N', 9008: 'S', 9009: 'N',
+    9010: 'S', 9011: 'N', 9012: 'S', 9013: 'N', 10000: 'S', 10099: 'S'
+}
 
 # ADM This is an empty array of most of the TS data model columns and
 # ADM dtypes. Note that other columns are added in read_tractor and

--- a/py/desitarget/io.py
+++ b/py/desitarget/io.py
@@ -310,7 +310,7 @@ def release_to_photsys(release):
 
     Parameters
     ----------
-    objects : :class:`int` or :class:`~numpy.ndarray`
+    release : :class:`int` or :class:`~numpy.ndarray`
         RELEASE column from a numpy rec array of targets.
 
     Returns

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -388,15 +388,31 @@ def sky_fibers_for_brick(survey, brickname, nskies=144, bands=['g', 'r', 'z'],
     # SB import photutils only if required instead of at module import time
     import photutils.aperture
 
+    # ADM the data model for blob maps changed after DR10.
+    # ADM so check the data release.
+    basedir = survey.survey_dir
+    # ADM Assuming this is dr8+, dr-name directory is one up.
+    basedir = basedir.rstrip('/')
+    drname = os.path.basename(os.path.dirname(basedir))
+    postdr10 = False
+    if drname[:2] == 'dr' and int(drname.split('dr')[-1]) >= 11:
+        postdr10 = True
+
     fn = survey.find_file('blobmap', brick=brickname)
     # ADM if the file doesn't exist, warn and return immediately.
     if not os.path.exists(fn):
         log.warning('blobmap {} does not exist!!!'.format(fn))
         return None
-    blobs = fitsio.read(fn)
+
+    if postdr10:
+        blobs = fitsio.read(fn, ext="BLOB-MAP")
+        header = fitsio.read_header(fn, ext="BLOB-MAP")
+    else:
+        blobs = fitsio.read(fn)
+        header = fitsio.read_header(fn)
+
     # log.info('Blob maximum value and minimum value in brick {}: {} {}'
     #         .format(brickname,blobs.min(),blobs.max()))
-    header = fitsio.read_header(fn)
     wcs = WCS(header)
 
     goodpix = (blobs == -1)

--- a/py/desitarget/skyutilities/legacypipe/util.py
+++ b/py/desitarget/skyutilities/legacypipe/util.py
@@ -213,7 +213,7 @@ class LegacySurveyData(object):
             # ADM directory up. Assuming this is dr8+.
             basedir = basedir.rstrip('/')
             check = os.path.basename(os.path.dirname(basedir))
-            if check[:2] == 'dr' and int(check[-1]) >= 8:
+            if check[:2] == 'dr' and int(check.split('dr')[-1]) >= 8:
                 truebasedir = os.path.dirname(basedir)
             else:
                 truebasedir = basedir


### PR DESCRIPTION
This PR makes the necessary updates to process targets and sky locations selected from the DR11 imaging. Major changes include:

- Updates to handle the DR11 imaging data model.
  * For instance, the new `RELEASE` numbers for `DR11/south`.
- Changes the FITS extension from which the blob maps are read.
  * The blob maps are used to determine blank-sky locations
  * As of DR11 we now read the maps from extension 1 not extension 0 (while maintaining backward compatibility to earlier data releases).
- Adds some slurm scripts to improve batching using GNU parallel.
  * We previously used naked `srun` commands on Cori but `parallel` yields better performance on Perlmutter.
