### PR TITLE
Update the default masking on MASKBITS for DR11

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desitarget Change Log
 5.0.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Update the default set of imaging mask bits for DR11 [`PR #886`_]:
+    * Now always include new `RESOLVED`, `MCLOUDS` and `WISE_GAIA` bits.
+
+.. _`PR #886`: https://github.com/desihub/desitarget/pull/886
 
 5.0.0 (2026-05-28)
 ------------------

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -162,7 +162,7 @@ def get_imaging_maskbits(bitnamelist=None):
     return bitdict
 
 
-def get_default_maskbits(bgs=False, mws=False):
+def get_default_maskbits(bgs=False, mws=False, dr11=False):
     """Return the names of the default MASKBITS for targets.
 
     Parameters
@@ -173,6 +173,8 @@ def get_default_maskbits(bgs=False, mws=False):
     mws : :class:`bool`, defaults to ``False``.
         If ``True`` load the "default" scheme for Milky Way Survey
         targets. Otherwise, load the default for other target classes.
+    dr11 : :class:`bool`, defaults to ``False``.
+        If ``True`` use default MASKBITS for DR11 instead of pre-DR11.
 
     Returns
     -------
@@ -188,9 +190,9 @@ def get_default_maskbits(bgs=False, mws=False):
         log.critical(msg)
         raise ValueError(msg)
 
-    # ADM use the updated maskbits for DR11, if they exist.
+    # ADM use the updated maskbits for DR11, if requested..
     dr11extra = []
-    if "RESOLVED" in get_imaging_maskbits():
+    if dr11:
         dr11extra = ["RESOLVED", "MCLOUDS", "WISE_GAIA"]
 
     if bgs:

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -234,7 +234,7 @@ def imaging_mask(maskbits, bitnamelist=get_default_maskbits(),
     # ADM DR10. If it's type int32 instead of int16 it's safe to use the
     # ADM dr11 version of the MASKBITS cuts.
     dr11 = False
-    if basetsdatamodel.dtype['MASKBITS'].newbyteorder("=") == np.int32:
+    if maskbits.dtype['MASKBITS'].newbyteorder("=") == np.int32:
         dr11 = True
 
     # ADM now re-retrieve the default MASKBITS with all flags set.

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -230,9 +230,15 @@ def imaging_mask(maskbits, bitnamelist=get_default_maskbits(),
     -----
     - Only one of `bgsmask` or `mwsmask` can be ``True``.
     """
-    # ADM default for the BGS or MWS..
-    if bgsmask or mwsmask:
-        bitnamelist = get_default_maskbits(bgs=bgsmask, mws=mwsmask)
+    # ADM check the dtype of the maskbits column, as we expanded it for
+    # ADM DR10. If it's type int32 instead of int16 it's safe to use the
+    # ADM dr11 version of the MASKBITS cuts.
+    dr11 = False
+    if basetsdatamodel.dtype['MASKBITS'].newbyteorder("=") == np.int32:
+        dr11 = True
+
+    # ADM now re-retrieve the default MASKBITS with all flags set.
+    bitnamelist = get_default_maskbits(bgs=bgsmask, mws=mwsmask, dr11=dr11)
 
     # ADM get the bit values for the passed (or default) bit names.
     bits = get_imaging_maskbits(bitnamelist)

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -234,7 +234,7 @@ def imaging_mask(maskbits, bitnamelist=get_default_maskbits(),
     # ADM DR10. If it's type int32 instead of int16 it's safe to use the
     # ADM dr11 version of the MASKBITS cuts.
     dr11 = False
-    if maskbits.dtype['MASKBITS'].newbyteorder("=") == np.int32:
+    if maskbits.dtype.newbyteorder("=") == np.int32:
         dr11 = True
 
     # ADM now re-retrieve the default MASKBITS with all flags set.

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -188,7 +188,7 @@ def get_default_maskbits(bgs=False, mws=False):
         log.critical(msg)
         raise ValueError(msg)
 
-    # ADM use the updated maskbits, if they exist.
+    # ADM use the updated maskbits for DR11, if they exist.
     dr11extra = []
     if "RESOLVED" in get_imaging_maskbits():
         dr11extra = ["RESOLVED", "MCLOUDS", "WISE_GAIA"]

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1275,11 +1275,11 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     with open(f"{prefix}{drstr}-driver.sh", 'w') as driverfn:
         driverfn.write("""#!/bin/bash\n""")
         driverfn.write("""if [[ -z "${SLURM_NODEID}" ]]; then\n""")
-        driverfn.write("""    echo "need \$SLURM_NODEID set"\n""")
+        driverfn.write("""    echo "need \\$SLURM_NODEID set"\n""")
         driverfn.write("""    exit\n""")
         driverfn.write("""fi\n""")
         driverfn.write("""if [[ -z "${SLURM_NNODES}" ]]; then\n""")
-        driverfn.write("""    echo "need \$SLURM_NNODES set"\n""")
+        driverfn.write("""    echo "need \\$SLURM_NNODES set"\n""")
         driverfn.write("""    exit\n""")
         driverfn.write("""fi\n""")
         driverfn.write("""cat $1 |                                               \\""")

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -152,7 +152,8 @@ def get_imaging_maskbits(bitnamelist=None):
     """
     bitdict = {"NPRIMARY": 0, "BRIGHT": 1,
                "ALLMASK_G": 5, "ALLMASK_R": 6, "ALLMASK_Z": 7,
-               "BAILOUT": 10, "MEDIUM": 11, "GALAXY": 12, "CLUSTER": 13}
+               "BAILOUT": 10, "MEDIUM": 11, "GALAXY": 12, "CLUSTER": 13,
+               "RESOLVED": 17, "MCLOUDS": 18, "WISE_GAIA": 19}
 
     # ADM look up the bit value for each passed bit name.
     if bitnamelist is not None:
@@ -186,12 +187,18 @@ def get_default_maskbits(bgs=False, mws=False):
         msg = "Only one of bgs or mws can be passed as True"
         log.critical(msg)
         raise ValueError(msg)
-    if bgs:
-        return ["BRIGHT", "CLUSTER"]
-    if mws:
-        return ["BRIGHT", "GALAXY"]
 
-    return ["BRIGHT", "GALAXY", "CLUSTER"]
+    # ADM use the updated maskbits, if they exist.
+    dr11extra = []
+    if "RESOLVED" in get_imaging_maskbits():
+        dr11extra = ["RESOLVED", "MCLOUDS", "WISE_GAIA"]
+
+    if bgs:
+        return ["BRIGHT", "CLUSTER"] + dr11extra
+    if mws:
+        return ["BRIGHT", "GALAXY"] + dr11extra
+
+    return ["BRIGHT", "GALAXY", "CLUSTER"] + dr11extra
 
 
 def imaging_mask(maskbits, bitnamelist=get_default_maskbits(),

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -1206,11 +1206,16 @@ def pixmap(randoms, targets, rand_density, nside=256, gaialoc=None):
     # ADM change target column names, and retrieve associated survey information.
     _, Mx, survey, targets = main_cmx_or_sv(targets, rename=True)
 
-    # ADM areal coverage for some combinations of MASKBITS.
+    # ADM check the dtype of the maskbits column, as we expanded it for
+    # ADM DR10. If it's type int32 instead of int16 it's safe to use the
+    # ADM dr11 version of the MASKBITS cuts.
+    dr11 = False
+    if randoms.dtype['MASKBITS'].newbyteorder("=") == np.int32:
+        dr11 = True
     mbcomb = []
     mbstore = []
-    for mb in [get_imaging_maskbits(get_default_maskbits()),
-               get_imaging_maskbits(get_default_maskbits(bgs=True))]:
+    for mb in [get_imaging_maskbits(get_default_maskbits(dr11=dr11)),
+               get_imaging_maskbits(get_default_maskbits(bgs=True, dr11=dr11))]:
         bitint = np.sum(2**np.array(mb))
         mbcomb.append(bitint)
         log.info('Determining footprint for maskbits not in {}...t = {:.1f}s'

--- a/py/desitarget/randoms.py
+++ b/py/desitarget/randoms.py
@@ -543,7 +543,7 @@ def quantities_at_positions_in_a_brick(ras, decs, brickname, drdir,
     # ADM only process the WCS if there's a file for this filter.
     mnames = zip([extn_nb, extn_nb+1, extn_nb+2],
                  ['maskbits', 'wisemask_w1', 'wisemask_w2'],
-                 ['>i2', '|u1', '|u1'])
+                 ['>i4', '|u1', '|u1'])
     if justlist:
         fnlist.append(fn)
     else:


### PR DESCRIPTION
This PR updates the default set of imaging mask bits for DR11 to additionally include the new `RESOLVED`, `MCLOUDS` and `WISE_GAIA` bits from the [MASKBITS](https://github.com/legacysurvey/legacypipe/blob/DR11.0.9/py/legacypipe/bits.py#L81-L102) bit mask.

I've tested that this does indeed remove a substantial number of targets in, e.g., the Large Magellanic Cloud. As the update occurs directly in the function that sets the default masking, it will propagate to both targets and random catalogs.