### PR TITLE
Final updates to facilitate running all of the different targeting file types on DR11 imaging.

### DIFF
--- a/bin/add_to_mtl_ledgers
+++ b/bin/add_to_mtl_ledgers
@@ -19,12 +19,12 @@ ap.add_argument("targfile",
 ap.add_argument("--dest",
                 help="Full path to the output directory to host the ledger. The \
                 filename and full directory structure are built on-the-fly from \
-                file headers in targdirname. [defaults to {})".format(mtldir),
+                file headers in targdirname. [defaults to {}]".format(mtldir),
                 default=mtldir)
 ap.add_argument("--obscon",
                 help="String matching ONE obscondition in the bitmask yaml file \
                 (e.g. 'BRIGHT'). Controls priorities when merging targets and   \
-                where the ledger is written. [defaults to {})".format(obscon),
+                where the ledger is written. [defaults to {}]".format(obscon),
                 default=obscon)
 ap.add_argument("--numproc", type=int,
                 help='number of concurrent processes to use [defaults to {}]'.

--- a/bin/make_initial_mtl_ledger
+++ b/bin/make_initial_mtl_ledger
@@ -47,6 +47,10 @@ ap.add_argument('--append', action='store_true',
                 Particularly useful when adding new secondary targets")
 ap.add_argument('--tcnames', default=None,
                 help="Comma-separated names of target classes to run (e.g. QSO,LGE).")
+ap.add_argument('--dr', type=int, default=None,
+                help="Limit targets to a Legacy Surveys Data Release, e.g. pass \
+                11 to limit to DR11 bricks. Expects survey-bricks-dr.fits to    \
+                exist in the output directory.")
 
 
 ns = ap.parse_args()
@@ -64,4 +68,4 @@ else:
 
 make_ledger(ns.targdir, ns.dest, pixlist=pixlist, obscon=ns.obscon,
             numproc=ns.numproc, timestamp=ns.timestamp, append=ns.append,
-            tcnames=tcnames)
+            tcnames=tcnames, dr=ns.dr)

--- a/bin/select_gfas
+++ b/bin/select_gfas
@@ -24,8 +24,8 @@ ap.add_argument("surveydir",
 ap.add_argument("dest",
                 help="Output GFA targets directory (the file name is built on-the-fly from other inputs)")
 ap.add_argument("--gaiadr",
-                help="Gaia Data Release on which to base GFAs. Options are dr2 or edr3. Defaults to dr2.",
-                default="dr2")
+                help="Gaia Data Release on which to base GFAs. Defaults to dr2.",
+                default="dr2", choices=["dr2", "edr3"])
 ap.add_argument('-m', '--maglim', type=float,
                 help="Magnitude limit on GFA targets in Gaia G-band (defaults to [21])",
                 default=21)

--- a/bin/supplement_skies
+++ b/bin/supplement_skies
@@ -41,7 +41,7 @@ ap.add_argument("--gaiadir", type=str,
                 default=None)
 ap.add_argument("--gaiadr", type=str,
                 help="Name of a Gaia data release from which to draw sources. Defaults to dr2 for backward compatibility",
-                default="dr2")
+                choices=["dr2", "edr", "dr3"], default="dr2")
 ap.add_argument('--nside', type=int,
                 help="Process supplemental skies in HEALPixels at this resolution (defaults to None). See also the 'healpixels' input flag",
                 default=None)
@@ -136,7 +136,7 @@ if ns.bundlefiles is None:
     supp_skies = supplement_skies(nskiespersqdeg=nskiespersqdeg, numproc=ns.numproc,
                                   gaiadir=gaiadir, radius=ns.radius, nside=ns.nside,
                                   pixlist=pixlist, mindec=ns.mindec,
-                                  mingalb=ns.mingalb, gaiadr=gaiadr)
+                                  mingalb=ns.mingalb, gaiadr=ns.gaiadr)
 
     # ADM mask the supplemental sky locations using a bright star mask.
     if do_mask:

--- a/bin/supplement_skies
+++ b/bin/supplement_skies
@@ -136,7 +136,7 @@ if ns.bundlefiles is None:
     supp_skies = supplement_skies(nskiespersqdeg=nskiespersqdeg, numproc=ns.numproc,
                                   gaiadir=gaiadir, radius=ns.radius, nside=ns.nside,
                                   pixlist=pixlist, mindec=ns.mindec,
-                                  mingalb=ns.mingalb, gaiadr=ns.gaiadr)
+                                  mingalb=ns.mingalb, dr=ns.gaiadr)
 
     # ADM mask the supplemental sky locations using a bright star mask.
     if do_mask:

--- a/bin/supplement_skies
+++ b/bin/supplement_skies
@@ -39,6 +39,9 @@ ap.add_argument("--numproc", type=int,
 ap.add_argument("--gaiadir", type=str,
                 help="Pass to set the GAIA_DIR environment variable directly in the code (i.e. the input directory that stores Gaia files)",
                 default=None)
+ap.add_argument("--gaiadr", type=str,
+                help="Name of a Gaia data release from which to draw sources. Defaults to dr2 for backward compatibility",
+                default="dr2")
 ap.add_argument('--nside', type=int,
                 help="Process supplemental skies in HEALPixels at this resolution (defaults to None). See also the 'healpixels' input flag",
                 default=None)
@@ -96,6 +99,7 @@ log.info('Generating sky positions at a density of {}'.format(nskiespersqdeg))
 extra = " --numproc {}".format(ns.numproc)
 extra += " --nskiespersqdeg {}".format(nskiespersqdeg)
 extra += " --gaiadir {}".format(gaiadir)
+extra += " --gaiadr {}".format(ns.gaiadr)
 nsdict = vars(ns)
 for nskey in ["mindec", "mingalb", "radius", "nomasking", "maskdir",
               "sky_subpriorities"]:
@@ -132,7 +136,7 @@ if ns.bundlefiles is None:
     supp_skies = supplement_skies(nskiespersqdeg=nskiespersqdeg, numproc=ns.numproc,
                                   gaiadir=gaiadir, radius=ns.radius, nside=ns.nside,
                                   pixlist=pixlist, mindec=ns.mindec,
-                                  mingalb=ns.mingalb)
+                                  mingalb=ns.mingalb, gaiadr=gaiadr)
 
     # ADM mask the supplemental sky locations using a bright star mask.
     if do_mask:

--- a/bin/turn_off_mtls_in_dr11
+++ b/bin/turn_off_mtls_in_dr11
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+from desitarget.mtl import turn_off_dr11, get_mtl_dir, _get_mtl_nside
+
+nproc = 32
+# ADM retrieve the $MTL_DIR environment variable.
+mtldir = get_mtl_dir()
+mtlnside = _get_mtl_nside()
+# ADM default obsconditions.
+obscon = "DARK"
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description=
+                    "Set targets in MTLs that are in DR11 bricks to PRIORITY 0")
+ap.add_argument("--mtldir",
+                help=f"Location of the MTL directory [defaults to {mtldir}]",
+                default=mtldir)
+ap.add_argument("--obscon",
+                help=f"String matching ONE observing condition in the bitmask \
+                yaml file (e.g. 'BRIGHT') [defaults to {obscon}]",
+                default=obscon)
+ap.add_argument("--numproc", type=int,
+                help=f'number of concurrent processes [defaults to {nproc}]',
+                default=nproc)
+ap.add_argument('--healpixels',
+                help=f"HEALPixels corresponding to `nside` (e.g. '6,9,57').     \
+                Only update ledgers for targets in these pixels, at the default \
+                nside, which is [{mtlnside}]",
+                default=None)
+
+ns = ap.parse_args()
+
+# ADM parse the list of HEALPixels in which to run.
+pixlist = ns.healpixels
+if pixlist is not None:
+    pixlist = [int(pix) for pix in pixlist.split(',')]
+
+turn_off_dr11(pixlist=pixlist, mtldir=ns.mtldir, obscon=ns.obscon,
+              numproc=ns.numproc)
+

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,17 @@ desitarget Change Log
 5.0.0 (2026-05-28)
 ------------------
 
+* Final updates to run targeting files on DR11 [`PR #887`_]. Includes:
+    * New `RELEASE` number/schema for `SAFE` / `BAD_SKY` skies.
+        * They now get assigned a release number of `RELEASE`//1000.
+        * But only if `RELEASE`//1000 > 10 for backward compatibility.
+        * Prevents `TARGETID` duplication with DR9 supplemental skies.
+        * As `SAFE` / `BAD_SKY` skies used to receive `RELEASE==0`.
+    * Update supplemental skies to use Gaia DR3.
+        * This guarantees `SKY` targets won't duplicate a DR9 `TARGETID`.
+    * Add gnu parallel for supplemental skies in bundling function.
+    * Functionality to only add DR11 targets to MTLs in DR11 bricks.
+    * New code to turn off DR9 targets in DR11 bricks.
 * Update code to process targets and skies from DR11 [`PR #885`_]:
     * Mostly handles updates to the DR11 imaging data model.
     * In particular, adds new `RELEASE` numbers for DR11/south.
@@ -28,6 +39,7 @@ desitarget Change Log
 .. _`PR #882`: https://github.com/desihub/desitarget/pull/882
 .. _`PR #884`: https://github.com/desihub/desitarget/pull/884
 .. _`PR #885`: https://github.com/desihub/desitarget/pull/885
+.. _`PR #887`: https://github.com/desihub/desitarget/pull/887
 
 4.7.2 (2026-04-29)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,7 +14,7 @@ desitarget Change Log
     * New `RELEASE` number/schema for `SAFE` / `BAD_SKY` skies.
         * They now get assigned a release number of `RELEASE`//1000.
         * But only if `RELEASE`//1000 > 10 for backward compatibility.
-        * Prevents `TARGETID` duplication with DR9 supplemental skies.
+        * Prevents `TARGETID` duplication with DR9 `SAFE` locations.
         * As `SAFE` / `BAD_SKY` skies used to receive `RELEASE==0`.
     * Update supplemental skies to use Gaia DR3.
         * This guarantees `SKY` targets won't duplicate a DR9 `TARGETID`.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,6 @@ desitarget Change Log
 5.0.1 (unreleased)
 ------------------
 
-* No changes yet.
-
-5.0.0 (2026-05-28)
-------------------
-
 * Final updates to run targeting files on DR11 [`PR #887`_]. Includes:
     * New `RELEASE` number/schema for `SAFE` / `BAD_SKY` skies.
         * They now get assigned a release number of `RELEASE`//1000.
@@ -21,6 +16,12 @@ desitarget Change Log
     * Add gnu parallel for supplemental skies in bundling function.
     * Functionality to only add DR11 targets to MTLs in DR11 bricks.
     * New code to turn off DR9 targets in DR11 bricks.
+
+.. _`PR #887`: https://github.com/desihub/desitarget/pull/887
+
+5.0.0 (2026-05-28)
+------------------
+
 * Update code to process targets and skies from DR11 [`PR #885`_]:
     * Mostly handles updates to the DR11 imaging data model.
     * In particular, adds new `RELEASE` numbers for DR11/south.
@@ -39,7 +40,6 @@ desitarget Change Log
 .. _`PR #882`: https://github.com/desihub/desitarget/pull/882
 .. _`PR #884`: https://github.com/desihub/desitarget/pull/884
 .. _`PR #885`: https://github.com/desihub/desitarget/pull/885
-.. _`PR #887`: https://github.com/desihub/desitarget/pull/887
 
 4.7.2 (2026-04-29)
 ------------------

--- a/py/desitarget/brightmask.py
+++ b/py/desitarget/brightmask.py
@@ -840,12 +840,28 @@ def get_safe_targets(targs, sourcemask, bricks_are_hpx=False):
     # ADM first, check the GAIA DR number for these skies.
     _, _, _, _, _, gdr = decode_targetid(targs["TARGETID"])
     if len(set(gdr)) != 1:
-        msg = "Skies are based on multiple Gaia Data Releases:".format(set(gdr))
+        msg = f"Skies are based on multiple Gaia Data Releases: {set(gdr)}"
         log.critical(msg)
         raise ValueError(msg)
 
+    # ADM we need to distinguish SAFE skies in different Data Releases.
+    # ADM So, starting with DR11 we'll encode the RELEASE as the imaging
+    # ADM RELEASE divided by 1000. This should make it distinct from the
+    # ADM skies which have the imaging RELEASE but NOT divided by 1000.
+    release = targs["RELEASE"]//1000
+    if len(set(release)) != 1:
+        msg = f"Targets for safe skies come from multiple DRs: {set(release)}."
+        msg += " Think harder about how to set the RELEASE for safe skies."
+        log.critical(msg)
+        raise ValueError(msg)
+    release = release[0]
+    if release <= 10:
+        release =0
+    safes["RELEASE"] = release
+
     safes["TARGETID"] = encode_targetid(objid=safes['BRICK_OBJID'],
                                         brickid=safes['BRICKID'],
+                                        release=release,
                                         sky=1,
                                         gaiadr=gdr[0])
 

--- a/py/desitarget/gaiamatch.py
+++ b/py/desitarget/gaiamatch.py
@@ -548,7 +548,7 @@ def gaia_dr_from_ref_cat(refcat):
 
     Notes
     -----
-        - In reality, only strips the final integer off strings like
+        - In reality, base code strips the final integer off strings like
           "X3". So, can generically be used for that purpose.
     """
     # ADM if an integer was passed.
@@ -557,7 +557,11 @@ def gaia_dr_from_ref_cat(refcat):
     if isinstance(refcat[0], bytes):
         return np.array([int(i.decode()[-1]) for i in refcat])
     else:
-        return np.array([int(i[-1]) for i in refcat])
+        try:
+            return np.array([int(i[-1]) for i in refcat])
+        except ValueError:
+            # ADM if there's a value error we likely hit "GW" (Gaia DR3).
+            return np.array([int("GW"[-1] == "W")*3])
 
     return gaiadr
 

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1266,6 +1266,20 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
     print(f'#SBATCH -o {prefix}{drstr}.log')
     print('')
 
+    # ADM to handle inputs that look like "svX_targets".
+    prefix2 = prefix
+    if prefix[0:2] == "sv":
+        prefix2 = "sv_targets"
+
+    s2 = ""
+    if surveydir2 is not None:
+        s2 = "-s2 {} ".format(surveydir2)
+
+    cmd = "select"
+    if prefix == "supp-skies":
+        cmd = "supplement"
+        prefix2 = "skies"
+
     # ADM also write the various batch files needed for GNU parallel.
     # ADM this counts the command line args, as parallel expects that.
     argscnt = 6 + int(surveydir2 != None)
@@ -1288,7 +1302,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
         driverfn.write("\n")
         driverfn.write("""'NR % NNODE == NODEID' |                               \\""")
         driverfn.write("\n")
-        driverfn.write(f"parallel --colsep ' ' select_{prefix} {args}\n")
+        driverfn.write(f"parallel --colsep ' ' {cmd}_{prefix2} {args}\n")
 
     with open(f"{prefix}{drstr}-gnu-parallel.sh", 'w') as gpfn:
         gpfn.write("""#!/bin/bash\n""")
@@ -1304,20 +1318,6 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
         gpfn.write(f"# srun --no-kill --ntasks=4 --ntasks-per-node 1 --wait=0 ./{prefix}{drstr}-driver.sh {prefix}{drstr}.tasks\n")
         gpfn.write("\n")
         gpfn.write(f"srun --no-kill --ntasks=64 --wait=0 ./{prefix}{drstr}-driver.sh $1")
-
-    # ADM to handle inputs that look like "svX_targets".
-    prefix2 = prefix
-    if prefix[0:2] == "sv":
-        prefix2 = "sv_targets"
-
-    s2 = ""
-    if surveydir2 is not None:
-        s2 = "-s2 {} ".format(surveydir2)
-
-    cmd = "select"
-    if prefix == "supp-skies":
-        cmd = "supplement"
-        prefix2 = "skies"
 
     from desitarget.io import _check_hpx_length, find_target_files
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1188,10 +1188,10 @@ def purge_tiles(tiles, obscon, mtldir=None, secondary=False, verbose=True):
     return Table(np.concatenate(gonetargs)), gonetiles
 
 
-def turn_off_dr9_in_dr11(pixlist, bricks=None, dr11brickids=None, mtldir=None,
-                         obscon="DARK", verbose=True, updatedonefile=True):
+def turn_off_in_dr11(pixlist, bricks=None, dr11brickids=None, mtldir=None,
+                     obscon="DARK", verbose=True, updatedonefile=True):
     """
-    Set DR9 targets in DR11 bricks to PRIORITY of 0 in MTLs.
+    Set targets that are officially in DR11 bricks to PRIORITY 0 in MTLs.
 
     Parameters
     ----------
@@ -1241,11 +1241,16 @@ def turn_off_dr9_in_dr11(pixlist, bricks=None, dr11brickids=None, mtldir=None,
         from desiutil import brick
         bricks = brick.Bricks(bricksize=0.25)
 
+    # ADM if the BRICKIDs that are in DR11 weren't sent, read them from
+    # ADM the dr9-or-dr11 bricks file.
     if dr11brickids is None:
         brickfn = os.path.join(mtldir, get_bricks_file_name())
         dr9ordr11bricks = fitsio.read(brickfn)
         ii = dr9ordr11bricks["DRVERSION"] == 11
         dr11brickids = dr9ordr11bricks[ii]["BRICKID"]
+
+    # ADM using the set of dr11 BRICKIDs will be quicker for look-ups.
+    sdr11bids = set(dr11brickids)
 
     for pix in pixlist:
         fn = io.find_target_files(mtldir, flavor="mtl", survey="main",
@@ -1253,14 +1258,27 @@ def turn_off_dr9_in_dr11(pixlist, bricks=None, dr11brickids=None, mtldir=None,
                                   ender="ecsv")
         try:
             mtl = io.read_mtl_ledger(fn)
-            # ADM the file may not exist, in which case there's nothing
-            # ADM to be done.
+            # ADM determine the brick for each coordinate in the ledger.
+            brickids = bricks.brickid(mtl["RA"], mtl["DEC"])
+            # ADM update the relevant entries that are in DR11 bricks...
+            ii = np.array([bid in sdr11bids for bid in brickids])
+            newrows = standard_off_columns(mtl[~ii])
+            # ADM ...and write these updates to the end of the ledger.
+            if len(newrows) > 0:
+                nrows, filename = io.write_mtl(
+                    mtldir, newrows, ecsv=True, survey="main", obscon=obscon,
+                    nsidefile=nside, hpxlist=pix, append=True)
+
+        log.info(f"Turned off {nrows} DR11 entries in {filename}")
+
+        # ADM the file may not exist for this HEALPixel, in which case
+        # ADM there's nothing to be done.
         except FileNotFoundError:
-            return
-        brickid = bricks.brickid(mtl["RA"], mtl["DEC"])
+            pass
+
+    return
 
 
-        
 def add_to_ledgers_in_hp(targets, pixlist, mtldir=None, obscon="DARK",
                          timestamp=None, verbose=True, updatedonefiles=False):
     """
@@ -1784,7 +1802,7 @@ def standard_override_columns(mtl):
     Returns
     -------
     :class:`~astropy.table.Table`
-        The input table with IMESTAMP updated to now, the second part of
+        The input table with TIMESTAMP updated to now, the second part of
         TARGET_STATE updated to be OVERRIDE, the git VERSION updated, and
         ZTILEID set to -1.
     """
@@ -1795,6 +1813,35 @@ def standard_override_columns(mtl):
         mtl["TARGET_STATE"] = np.array(newts)
         mtl["VERSION"] = dt_version
         mtl["ZTILEID"] = -1
+
+    return mtl
+
+
+def standard_off_columns(mtl):
+    """
+    Add column entries to an mtl Table when turning off targets.
+
+    Parameters
+    ----------
+    mtl : :class:`~astropy.table.Table`
+        An astropy Table. Must contain the columns TIMESTAMP,
+        TARGET_STATE, VERSION, ZTILEID and PRIORITY.
+
+    Returns
+    -------
+    :class:`~astropy.table.Table`
+        The input table with TIMESTAMP updated to now, the second part of
+        TARGET_STATE updated to be OFF, the git VERSION updated, the
+        ZTILEID set to -1 and the PRIORITY set to 0.
+    """
+    # ADM this ensures that data types are not altered for empty arrays.
+    if len(mtl) > 0:
+        mtl["TIMESTAMP"] = get_utc_date(survey="main")
+        newts = [f"{t.split("|")[0]}|OFF" for t in mtl["TARGET_STATE"]]
+        mtl["TARGET_STATE"] = np.array(newts)
+        mtl["VERSION"] = dt_version
+        mtl["ZTILEID"] = -1
+        mtl["PRIORITY"] = 0
 
     return mtl
 

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1249,7 +1249,7 @@ def turn_off_dr11_hp(pixlist, bricks=None, dr11brickids=None, mtldir=None,
         ii = dr9ordr11bricks["DRVERSION"] == 11
         dr11brickids = dr9ordr11bricks[ii]["BRICKID"]
 
-    # ADM using the set of dr11 BRICKIDs will be quicker for look-ups.
+    # ADM using the set of dr11 BRICKIDs will be quicker for look ups.
     sdr11bids = set(dr11brickids)
 
     for npix, pix in enumerate(pixlist):
@@ -1374,7 +1374,7 @@ def turn_off_dr11(pixlist=None, mtldir=None, obscon="DARK", verbose=True,
         if npix % 500 == 0 and npix > 0:
             rate = (time() - t0) / npix
             log.info(f"Updated {npix}/{npixels} HEALPixels; {rate:.1f}"
-                     f"secs/pixel...t = {(time()-t0)/60.:.1f} mins")
+                     f" secs/pixel...t = {(time()-t0)/60.:.1f} mins")
         npix[...] += 1
         return result
 
@@ -1636,7 +1636,7 @@ def add_to_ledgers(targs, mtldir=None, pixlist=None, obscon="DARK",
         if npix % 2 == 0 and npix > 0:
             rate = (time() - t0) / npix
             log.info(f"Updated {npix}/{npixels} HEALPixels; {rate:.1f}"
-                     f"secs/pixel...t = {(time()-t0)/60.:.1f} mins")
+                     f" secs/pixel...t = {(time()-t0)/60.:.1f} mins")
         npix[...] += 1
         return result
 
@@ -1754,8 +1754,8 @@ def make_ledger_in_hp(targets, outdirname, nside, pixlist, obscon="DARK",
     return
 
 
-def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
-                numproc=1, timestamp=None, append=False, tcnames=None):
+def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK", numproc=1,
+                timestamp=None, append=False, tcnames=None, dr=None):
     """
     Make initial MTL ledger files for HEALPixels, in parallel.
 
@@ -1791,6 +1791,10 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
         ledgers for only those target classes. The passed classes
         must be from the DESI_TARGET column, which must exist in the
         target files associated with `hpdirname`.
+    dr : :class:`int`, optional, defaults to ``None``
+        If passed, limit targets to a Data Release of the Legacy Surveys.
+        For example, pass 11 to limit targets to official DR11 bricks.
+        Expects `outdirname`/survey-bricks-dr.fits to exist.
 
     Returns
     -------
@@ -1807,13 +1811,28 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
     if tcnames is not None:
         from desitarget.targetmask import desi_mask
 
+    # ADM if a request was made to limit to a certain Legacy Surveys Data
+    # ADM Release then build the list of bricks for that DR.
+    if dr is not None:
+        # ADM initialize the object that records the brick areas.
+        from desiutil import brick
+        bricks = brick.Bricks(bricksize=0.25)
+        # ADM read which BRICKIDs are in a given Data Release.
+        brickfn = os.path.join(outdirname, get_bricks_file_name())
+        drbricks = fitsio.read(brickfn)
+        # ADM limit to the passed Data Release.
+        ii = drbricks["DRVERSION"] == dr
+        drbrickids = drbricks[ii]["BRICKID"]
+        # ADM using the set of BRICKIDs will be quicker for look ups.
+        sbids = set(drbrickids)
+
     # ADM grab information regarding how the targets were constructed.
     hdr, dt = io.read_targets_header(hpdirname, dtype=True)
     # ADM check the obscon for which the targets were made is
     # ADM consistent with the requested obscon.
     oc = hdr["OBSCON"]
     if obscon not in oc:
-        msg = "File is type {} but requested behavior is {}".format(oc, obscon)
+        msg = f"File is type {oc} but requested behavior is {obscon}"
         log.critical(msg)
         raise ValueError(msg)
 
@@ -1859,15 +1878,25 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
     # ADM the common function that is actually parallelized across.
     def _make_ledger_in_hp(pixnum):
         """make initial ledger in a single HEALPixel"""
+
         # ADM construct a list of all pixels in pixnum at the MTL nside.
         setpix = set(nside2nside(nside, mtlnside, pixnum))
         pix = [p for p in pixlist if p in setpix]
         if len(pix) == 0:
             return
+
         # ADM read in the needed columns from the targets.
         targs = io.read_targets_in_hp(hpdirname, nside, pixnum, columns=cols)
         if len(targs) == 0:
             return
+
+        # ADM if requested, limit to only bricks from a certain DR.
+        if dr is not None:
+            brickids = bricks.brickid(targs["RA"], targs["DEC"])
+            ii = np.array([bid in sbids for bid in brickids])
+            # ADM limit passed targets to bricks for Data Release.
+            targs = targs[ii]
+
         # ADM if requested, limit to only certain target classes.
         if tcnames is not None:
             ii = np.zeros(len(targs), dtype="?")
@@ -1885,6 +1914,7 @@ def make_ledger(hpdirname, outdirname, pixlist=None, obscon="DARK",
             zerod = [np.zeros(len(targs)), np.zeros(len(targs))]
             targs = rfn.append_fields(
                 targs, misscols, data=zerod, dtypes=[dtdt, dtdt], usemask=False)
+
         # ADM write MTLs for the targs split over HEALPixels in pixlist.
         return make_ledger_in_hp(
             targs, outdirname, mtlnside, pix, obscon=obscon,

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1999,7 +1999,7 @@ def standard_off_columns(mtl):
     # ADM this ensures that data types are not altered for empty arrays.
     if len(mtl) > 0:
         mtl["TIMESTAMP"] = get_utc_date(survey="main")
-        newts = [f"{t.split("|")[0]}|OFF" for t in mtl["TARGET_STATE"]]
+        newts = [f'{t.split("|")[0]}|OFF' for t in mtl["TARGET_STATE"]]
         mtl["TARGET_STATE"] = np.array(newts)
         mtl["VERSION"] = dt_version
         mtl["ZTILEID"] = -1

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -459,6 +459,18 @@ def get_ztile_file_name(survey='main'):
     return fn
 
 
+def get_bricks_file_name():
+    """Convenience function to get name of the dr9-or-dr11 brick file.
+
+    Returns
+    -------
+    :class:`str`
+        The name of the brick file.
+    """
+
+    return "survey-bricks-dr.fits"
+
+
 def _get_mtl_nside():
     """Grab the HEALPixel nside to be used for MTL ledger files.
 
@@ -1176,6 +1188,79 @@ def purge_tiles(tiles, obscon, mtldir=None, secondary=False, verbose=True):
     return Table(np.concatenate(gonetargs)), gonetiles
 
 
+def turn_off_dr9_in_dr11(pixlist, bricks=None, dr11brickids=None, mtldir=None,
+                         obscon="DARK", verbose=True, updatedonefile=True):
+    """
+    Set DR9 targets in DR11 bricks to PRIORITY of 0 in MTLs.
+
+    Parameters
+    ----------
+    pixlist : :class:`list` or `int`
+        HEALPixels at :func:`_get_mtl_nside()` in which to process MTLs.
+    bricks : :class:`class`, optional, defaults to ``None``
+        Legacy Surveys bricks object. If parallelizing across multiple
+        pixels this can be passed as a speed-up as it takes a little time
+        to initialize. If not passed, the function initializes it.
+    dr11brickids : :class:`~numpy.array`, optional, defaults to ``None``
+        List of BRICKIDs that are in DR11. If this is not passed, then
+        these are read from the dr9-or-dr11 brick file in `mtldir`.
+    mtldir : :class:`str`, optional, defaults to ``None``
+        Full path to the directory that hosts the MTLs. If ``None``, then
+        look up the MTL directory from the $MTL_DIR environment variable.
+        If `dr11brickids` is not passed then this directory must contain
+        the file of bricks that are in DR11, which should be named the
+        same as the output from :func:`get_bricks_file_name()`.
+    obscon : :class:`str`, optional, defaults to "DARK"
+        A string matching ONE obscondition in the desitarget bitmask yaml
+        file (i.e. in `desitarget.targetmask.obsconditions`).
+        Governs the sub-directory for which the ledgers are processed.
+    verbose : :class:`bool`, optional, defaults to ``True``
+        If ``True`` then log target and file information.
+    updatedonefile: :class:`bool`, optional, defaults to ``True``
+        If ``False`` then do NOT write a timestamp to the MTL
+        dr11 "done" file indicating an update has occurred.
+
+    Returns
+    -------
+    Nothing, but updates the `targets` in the appropriate ledgers in
+    the `mtldir`.
+    """
+    t0 = time()
+
+    # ADM get the standard nside.
+    nside = _get_mtl_nside()
+
+    # ADM grab the MTL directory (in case we're relying on $MTL_DIR).
+    mtldir = get_mtl_dir(mtldir)
+
+    # ADM in case an integer was passed.
+    pixlist = np.atleast_1d(pixlist)
+
+    # ADM if bricks wasn't passed, set up Legacy Surveys bricks object.
+    if bricks is None:
+        from desiutil import brick
+        bricks = brick.Bricks(bricksize=0.25)
+
+    if dr11brickids is None:
+        brickfn = os.path.join(mtldir, get_bricks_file_name())
+        dr9ordr11bricks = fitsio.read(brickfn)
+        ii = dr9ordr11bricks["DRVERSION"] == 11
+        dr11brickids = dr9ordr11bricks[ii]["BRICKID"]
+
+    for pix in pixlist:
+        fn = io.find_target_files(mtldir, flavor="mtl", survey="main",
+                                  hp=pix, resolve=True, obscon=obscon,
+                                  ender="ecsv")
+        try:
+            mtl = io.read_mtl_ledger(fn)
+            # ADM the file may not exist, in which case there's nothing
+            # ADM to be done.
+        except FileNotFoundError:
+            return
+        brickid = bricks.brickid(mtl["RA"], mtl["DEC"])
+
+
+        
 def add_to_ledgers_in_hp(targets, pixlist, mtldir=None, obscon="DARK",
                          timestamp=None, verbose=True, updatedonefiles=False):
     """

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1302,13 +1302,16 @@ def turn_off_dr11_hp(pixlist, bricks=None, dr11brickids=None, mtldir=None,
     return
 
 
-def turn_off_dr11(mtldir=None, obscon="DARK", verbose=True, numproc=1,
-                  updatedonefile=True):
+def turn_off_dr11(pixlist=None, mtldir=None, obscon="DARK", verbose=True,
+                  numproc=1, updatedonefile=True):
     """
     Set targets in DR11 bricks to PRIORITY 0 in all MTLs, in parallel.
 
     Parameters
     ----------
+    pixlist : :class:`list` or `int`, optional, default to ``None``
+        HEALPixels at :func:`_get_mtl_nside()` in which to process MTLs.
+        Default is to run all HEALPixels at :func:`_get_mtl_nside()`.
     mtldir : :class:`str`, optional, defaults to ``None``
         Full path to the directory that hosts the MTLs. If ``None``, then
         look up the MTL directory from the $MTL_DIR environment variable.
@@ -1338,7 +1341,11 @@ def turn_off_dr11(mtldir=None, obscon="DARK", verbose=True, numproc=1,
     mtldir = get_mtl_dir(mtldir)
 
     # ADM a list of all pixels at the relevant nside.
-    pixlist = np.arange(hp.nside2npix(nside))
+    if pixlist is None:
+        pixlist = np.arange(hp.nside2npix(nside))
+
+    # ADM in case an integer was passed.
+    pixlist = np.atleast_1d(pixlist)
     npixels = len(pixlist)
 
     # ADM Set up the Legacy Surveys bricks object.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -1188,10 +1188,10 @@ def purge_tiles(tiles, obscon, mtldir=None, secondary=False, verbose=True):
     return Table(np.concatenate(gonetargs)), gonetiles
 
 
-def turn_off_in_dr11(pixlist, bricks=None, dr11brickids=None, mtldir=None,
+def turn_off_dr11_hp(pixlist, bricks=None, dr11brickids=None, mtldir=None,
                      obscon="DARK", verbose=True, updatedonefile=True):
     """
-    Set targets that are officially in DR11 bricks to PRIORITY 0 in MTLs.
+    Set targets in DR11 bricks to PRIORITY 0 in MTLs, in HEALPixels.
 
     Parameters
     ----------
@@ -1252,7 +1252,7 @@ def turn_off_in_dr11(pixlist, bricks=None, dr11brickids=None, mtldir=None,
     # ADM using the set of dr11 BRICKIDs will be quicker for look-ups.
     sdr11bids = set(dr11brickids)
 
-    for pix in pixlist:
+    for npix, pix in enumerate(pixlist):
         fn = io.find_target_files(mtldir, flavor="mtl", survey="main",
                                   hp=pix, resolve=True, obscon=obscon,
                                   ender="ecsv")
@@ -1262,19 +1262,144 @@ def turn_off_in_dr11(pixlist, bricks=None, dr11brickids=None, mtldir=None,
             brickids = bricks.brickid(mtl["RA"], mtl["DEC"])
             # ADM update the relevant entries that are in DR11 bricks...
             ii = np.array([bid in sdr11bids for bid in brickids])
-            newrows = standard_off_columns(mtl[~ii])
+            newrows = standard_off_columns(mtl[ii])
             # ADM ...and write these updates to the end of the ledger.
             if len(newrows) > 0:
                 nrows, filename = io.write_mtl(
                     mtldir, newrows, ecsv=True, survey="main", obscon=obscon,
                     nsidefile=nside, hpxlist=pix, append=True)
 
-        log.info(f"Turned off {nrows} DR11 entries in {filename}")
+                msg = f"Turned off {nrows} DR11 entries in {filename}..."
+                msg += f"t={time()-t0:.1f}s"
+                log.info(msg)
 
         # ADM the file may not exist for this HEALPixel, in which case
         # ADM there's nothing to be done.
         except FileNotFoundError:
             pass
+
+    # ADM if requested, updated the "off" done tiles file.
+    if updatedonefile:
+        # ADM construct the full path to the "off" done file.
+        mtldonefn = os.path.join(mtldir, get_mtl_tile_file_name())
+        mtldonefn = mtldonefn.replace("tiles", "off")
+
+        # ADM populate the entries.
+        offtiles = np.zeros(1, dtype=mtltilefiledm.dtype)
+        offtiles["TIMESTAMP"] = get_utc_date(survey="main")
+        # ADM add the version of desitarget.
+        offtiles["VERSION"] = dt_version
+        # ADM add the program/obscon.
+        offtiles["PROGRAM"] = obscon
+        # ADM other entires are "null".
+        offtiles["TILEID"] = -1
+        offtiles["ZDATE"] = -1
+        offtiles["ARCHIVEDATE"] = -1
+
+        # ADM write to file.
+        io.write_mtl_tile_file(mtldonefn, offtiles)
+
+    return
+
+
+def turn_off_dr11(mtldir=None, obscon="DARK", verbose=True, numproc=1,
+                  updatedonefile=True):
+    """
+    Set targets in DR11 bricks to PRIORITY 0 in all MTLs, in parallel.
+
+    Parameters
+    ----------
+    mtldir : :class:`str`, optional, defaults to ``None``
+        Full path to the directory that hosts the MTLs. If ``None``, then
+        look up the MTL directory from the $MTL_DIR environment variable.
+        If `dr11brickids` is not passed then this directory must contain
+        the file of bricks that are in DR11, which should be named the
+        same as the output from :func:`get_bricks_file_name()`.
+    obscon : :class:`str`, optional, defaults to "DARK"
+        A string matching ONE obscondition in the desitarget bitmask yaml
+        file (i.e. in `desitarget.targetmask.obsconditions`).
+        Governs the sub-directory for which the ledgers are processed.
+    verbose : :class:`bool`, optional, defaults to ``True``
+        If ``True`` then log extra target and file information.
+    numproc : :class:`int`, optional, defaults to 1 for serial
+        Number of processes to parallelize across.
+    updatedonefile: :class:`bool`, optional, defaults to ``True``
+        If ``False`` then do NOT write a timestamp to the MTL
+        dr11 "done" file indicating an update has occurred.
+
+    Returns
+    -------
+    Nothing, but updates the `targets` in all ledgers in the `mtldir`.
+    """
+    # ADM get the standard nside.
+    nside = _get_mtl_nside()
+
+    # ADM grab the MTL directory (in case we're relying on $MTL_DIR).
+    mtldir = get_mtl_dir(mtldir)
+
+    # ADM a list of all pixels at the relevant nside.
+    pixlist = np.arange(hp.nside2npix(nside))
+    npixels = len(pixlist)
+
+    # ADM Set up the Legacy Surveys bricks object.
+    from desiutil import brick
+    bricks = brick.Bricks(bricksize=0.25)
+
+    # Determine the list of brickids that are in DR11.
+    brickfn = os.path.join(mtldir, get_bricks_file_name())
+    dr9ordr11bricks = fitsio.read(brickfn)
+    ii = dr9ordr11bricks["DRVERSION"] == 11
+    dr11brickids = dr9ordr11bricks[ii]["BRICKID"]
+
+    # ADM the common function that is actually parallelized across.
+    def _turn_off_dr11_hp(pixnum):
+        """set targets in DR11 bricks to PRIORTY 0 in one HEALPixel"""
+        return turn_off_dr11_hp(pixnum, bricks=bricks, dr11brickids=dr11brickids,
+                                mtldir=mtldir, obscon=obscon, verbose=verbose,
+                                updatedonefile=False)
+
+    # ADM this is just to count pixels in _update_status.
+    npix = np.ones((), dtype='i8')
+    t0 = time()
+
+    def _update_status(result):
+        """wrap key reduction operation on the main parallel process"""
+        if npix % 500 == 0 and npix > 0:
+            rate = (time() - t0) / npix
+            log.info(f"Updated {npix}/{npixels} HEALPixels; {rate:.1f}"
+                     f"secs/pixel...t = {(time()-t0)/60.:.1f} mins")
+        npix[...] += 1
+        return result
+
+    # ADM Parallel process across HEALPixels.
+    if numproc > 1:
+        pool = sharedmem.MapReduce(np=numproc)
+        with pool:
+            pool.map(_turn_off_dr11_hp, pixlist, reduce=_update_status)
+    else:
+        for pixel in pixlist:
+            _update_status(_turn_off_dr11_hp(pixel))
+
+    # ADM if requested, updated the "off" done tiles file.
+    if updatedonefile:
+        # ADM construct the full path to the "off" done file.
+        mtldonefn = os.path.join(mtldir, get_mtl_tile_file_name())
+        mtldonefn = mtldonefn.replace("tiles", "off")
+
+        # ADM populate the entries.
+        offtiles = np.zeros(1, dtype=mtltilefiledm.dtype)
+        offtiles["TIMESTAMP"] = get_utc_date(survey="main")
+        # ADM add the version of desitarget.
+        offtiles["VERSION"] = dt_version
+        # ADM add the program/obscon.
+        offtiles["PROGRAM"] = obscon
+        # ADM other entires are "null".
+        offtiles["TILEID"] = -1
+        offtiles["ZDATE"] = -1
+        offtiles["ARCHIVEDATE"] = -1
+
+        # ADM write to file.
+        io.write_mtl_tile_file(mtldonefn, offtiles)
 
     return
 

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -935,7 +935,7 @@ def get_supp_skies(ras, decs, radius=2., dr="dr2"):
 
 def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
                      nside=None, pixlist=None, mindec=-30., mingalb=10.,
-                     radius=2.):
+                     radius=2., dr="dr2"):
     """Generate supplemental sky locations using Gaia-G-band avoidance.
 
     Parameters
@@ -962,6 +962,9 @@ def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
         (e.g. send 10 to limit to areas beyond -10o <= b < 10o).
     radius : :class:`float`, optional, defaults to 2
         Radius at which to avoid (all) Gaia sources (arcseconds).
+    dr : :class:`str`, optional, defaults to "dr2"
+        Name of a Gaia data release from which to draw sources. Passed to
+        :func:`~desitarget.gaiamatch.find_gaia_files()`.
 
     Returns
     -------
@@ -985,7 +988,7 @@ def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
         nskiespersqdeg = density_of_sky_fibers(margin=4)
 
     # ADM determine the HEALPixel nside of the standard Gaia files.
-    anyfiles = find_gaia_files([0, 0], radec=True)
+    anyfiles = find_gaia_files([0, 0], radec=True, dr=dr)
     hdr = fitsio.read_header(anyfiles[0], "GAIAHPX")
     nsidegaia = hdr["HPXNSIDE"]
 
@@ -1025,7 +1028,7 @@ def supplement_skies(nskiespersqdeg=None, numproc=16, gaiadir=None,
     def _get_supp(pix):
         """wrapper on get_supp_skies() given a HEALPixel"""
         ii = (pixels == pix)
-        return get_supp_skies(ras[ii], decs[ii], radius=radius)
+        return get_supp_skies(ras[ii], decs[ii], radius=radius, dr=dr)
 
     # ADM this is just to count pixels in _update_status.
     npix = np.zeros((), dtype='i8')

--- a/py/desitarget/skyfibers.py
+++ b/py/desitarget/skyfibers.py
@@ -872,7 +872,7 @@ def repartition_skies(skydirname, numproc=1):
     return
 
 
-def get_supp_skies(ras, decs, radius=2.):
+def get_supp_skies(ras, decs, radius=2., dr="dr2"):
     """Random locations, avoid Gaia, format, return supplemental skies.
 
     Parameters
@@ -883,6 +883,9 @@ def get_supp_skies(ras, decs, radius=2.):
         Declinations of sky locations (degrees).
     radius : :class:`float`, optional, defaults to 2
         Radius at which to avoid (all) Gaia sources (arcseconds).
+    dr : :class:`str`, optional, defaults to "dr2"
+        Name of a Gaia data release from which to draw sources. Passed to
+        :func:`~desitarget.gaiamatch.find_gaia_files()`.
 
     Returns
     -------
@@ -896,7 +899,7 @@ def get_supp_skies(ras, decs, radius=2.):
           Gaia-file HEALPixel, but should work for all cases.
     """
     # ADM determine Gaia files of interest and read the RAs/Decs.
-    fns = find_gaia_files([ras, decs], neighbors=True, radec=True)
+    fns = find_gaia_files([ras, decs], neighbors=True, radec=True, dr=dr)
     gobjs = np.concatenate(
         [fitsio.read(fn, columns=["RA", "DEC"]) for fn in fns])
 


### PR DESCRIPTION
This PR adds the (hopefully) final updates to run targeting files on DR11. It mainly focuses on skies, supplemental skies and MTLs, and updates:

- The `RELEASE` number/schema for `SAFE` / `BAD_SKY` skies.
  * They now get assigned a release number of `RELEASE//1000`, but only if `RELEASE//1000 > 10` for backward compatibility (i.e., only starting with DR11).
    - This prevents `TARGETID`s from being duplicated with DR9 `SAFE`/`BAD_SKY` locations, which previously had a generic `RELEASE` number of 0.
- The supplemental skies so that they use Gaia DR3.
  * This guarantees that DR11 supplemental skies can't share a `TARGETID` with DR9 supplemental skies.
- The slurming/bundling function to add a gnu parallel option for supplemental skies.
- Functionality that adds targets to the MTLs to facilitate only adding DR11 targets in DR11 bricks.
- The MTL software to include new code to turn off DR9 targets in DR11 bricks.

I'll merge this in an hour or so to start making official products for DR11 targets.