### PR TITLE
Update the MTL loop to process secondary BACKUP ledgers

### DIFF
--- a/bin/force_mtl_overrides
+++ b/bin/force_mtl_overrides
@@ -12,7 +12,8 @@ ap = ArgumentParser(description='Force override ledgers to be processed and adde
 ap.add_argument("obscon",
                 help="String matching ONE obscondition in the bitmask yaml file \
                 (e.g. 'BRIGHT'). Controls priorities when merging targets,      \
-                which tiles to process, etc.", choices=["DARK", "BRIGHT", "BACKUP"])
+                which tiles to process, etc.",
+                choices=["DARK", "BRIGHT", "BACKUP", "DARK1B", "BRIGHT1B"])
 ap.add_argument("-s", "--survey",
                 help="Flavor of survey to run. Defaults to [{}]".format(survey),
                 default=survey, choices=["main", "sv3", "sv2"])

--- a/bin/run_mtl_loop
+++ b/bin/run_mtl_loop
@@ -48,7 +48,7 @@ scndstates = [False]
 
 # ADM if nosecondary wasn't passed, also process the secondary ledger
 # ADM for programs that actually have secondary ledgers (BRIGHT/DARK).
-if ns.obscon in ["BRIGHT", "DARK", "BRIGHT1B", "DARK1B"]:
+if ns.obscon in ["BRIGHT", "DARK", "BRIGHT1B", "DARK1B", "BACKUP"]:
     if not(ns.nosecondary):
         scndstates = [True, False]
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,13 @@ desitarget Change Log
 5.2.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Update MTL loop for secondary `BACKUP` ledgers [`PR #890`_]. Includes:
+    * Add `BACKUP` as an option for processing secondary MTLs.
+    * Handle an endianness bug in newer versions of numpy/astropy.
+    * Restore the :func:`ledger_overrides` function.
+    * Add `BRIGHT1B` and `DARK1B` as options for override ledgers.
+
+.. _`PR #890`: https://github.com/desihub/desitarget/pull/890
 
 5.2.0 (2026-06-09)
 ------------------

--- a/py/desitarget/brightmask.py
+++ b/py/desitarget/brightmask.py
@@ -856,7 +856,7 @@ def get_safe_targets(targs, sourcemask, bricks_are_hpx=False):
         raise ValueError(msg)
     release = release[0]
     if release <= 10:
-        release =0
+        release = 0
     safes["RELEASE"] = release
 
     safes["TARGETID"] = encode_targetid(objid=safes['BRICK_OBJID'],

--- a/py/desitarget/geomask.py
+++ b/py/desitarget/geomask.py
@@ -1297,7 +1297,7 @@ def bundle_bricks(pixnum, maxpernode, nside, brickspersec=1., prefix='targets',
 
     # ADM also write the various batch files needed for GNU parallel.
     # ADM this counts the command line args, as parallel expects that.
-    argscnt = 6 + int(surveydir2 != None)
+    argscnt = 6 + int(surveydir2 is not None)
     if extra is not None:
         argscnt += len(extra.split())
     args = " ".join(["{"+str(i)+"}" for i in np.arange(argscnt)+1])

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -2173,6 +2173,148 @@ def process_overrides(ledgerfn, tabform='ascii.basic'):
     return mtl
 
 
+def ledger_overrides(overfn, obscon, colsub=None, valsub=None,
+                     mtldir=None, secondary=False, numoverride=999):
+    """
+    Create (or append to) a ledger to override the standard ledgers.
+
+    Parameters
+    ----------
+    overfn : :class:`str`
+        Full path to the filename that contains the override information.
+        Must contain at least `RA`, `DEC`, `TARGETID` and be in a format
+        that can be read automatically by astropy.table.Table.read().
+    obscon : :class:`str`
+        A string matching ONE obscondition in the desitarget bitmask yaml
+        file (i.e. in `desitarget.targetmask.obsconditions`), e.g. "DARK"
+        Used to construct the directory to find the Main Survey ledgers.
+    colsub : :class:`dict`, optional
+        If passed, each key should correspond to the name of a ledger
+        column and each value should correspond to the name of a column
+        in `overfn`. The ledger columns are overwritten by the
+        corresponding column in `overfn` (for the appropriate TARGETID).
+    valsub : :class:`dict`, optional
+        If passed, each key should correspond to the name of a ledger
+        column and each value to a single number or string. The "value"
+        will be overwritten into the "key" column of the ledger. Takes
+        precedence over colsub.
+    mtldir : :class:`str`, optional, defaults to ``None``
+        Full path to the directory that hosts the MTL ledgers and the MTL
+        tile file. If ``None``, then look up the MTL directory from the
+        $MTL_DIR environment variable.
+    secondary : :class:`bool`, optional, defaults to ``False``
+        If ``True`` then process secondary targets instead of primaries
+        for passed `obscon`.
+    numoverride : :class:`int`, optional, defaults to 999
+        The override ledger is read every time the MTL loop is run. This
+        is the number of times to override the standard results in the
+        MTL loop. Defaults to 999, i.e. essentially "always override."
+
+    Returns
+    -------
+    :class:`str`
+        The directory containing the ledgers that were updated.
+
+    Notes
+    -----
+    - Regardless of the inputs, the TIMESTAMP in the output override
+      ledger is always updated to now, the second part of TARGET_STATE is
+      always updated to OVERRIDE, the git VERSION is always updated and
+      the ZTILEID is always set to -1.
+    """
+    # ADM grab the MTL directory (in case we're relying on $MTL_DIR).
+    mtldir = get_mtl_dir(mtldir)
+
+    # ADM construct the relevant sub-directory for this survey and
+    # ADM set of observing conditions.
+    resolve = True
+    msg = "running on {} ledgers with obscon={} and survey=main"
+    if secondary:
+        log.info(msg.format("SECONDARY", obscon))
+        resolve = None
+    else:
+        log.info(msg.format("PRIMARY", obscon))
+    outdir = io.find_target_files(mtldir, flavor="mtl", obscon=obscon,
+                                  survey="main", resolve=resolve, override=True)
+    # ADM and create the sub-directory if it doesn't exist.
+    os.makedirs(outdir, exist_ok=True)
+
+    # ADM read in the file with override information.
+    objs = Table.read(overfn)
+    # ADM be somewhat forgiving and convert lower-case columns.
+    for colname in ["RA", "DEC", "TARGETID"]:
+        try:
+            objs.rename_column(colname.lower(), colname)
+        except KeyError:
+            pass
+        # ADM check all required columns are present.
+        if colname not in objs.colnames:
+            msg = "{} must be a column in {}!".format(colname, overfn)
+            log.error(msg)
+            raise IOError(msg)
+
+    # ADM retrieve the current ledger entry for each target to be overrode.
+    nside = _get_mtl_nside()
+    theta, phi = np.radians(90-objs["DEC"]), np.radians(objs["RA"])
+    pixnum = hp.ang2pix(nside, theta, phi, nest=True)
+    for tid, pix in zip(objs["TARGETID"], pixnum):
+        # ADM construct the input/output ledger filenames.
+        infn = io.find_target_files(mtldir, flavor="mtl", survey="main", hp=pix,
+                                    resolve=resolve, obscon=obscon, ender="ecsv")
+        outfn = io.find_target_files(
+            mtldir, flavor="mtl", survey="main", hp=pix, resolve=resolve,
+            obscon=obscon, override=True, ender="ecsv")
+
+        ledger = Table(io.read_mtl_ledger(infn))
+        ii = ledger["TARGETID"] == tid
+        # ADM warn if one of the TARGETIDs seems incorrect.
+        if not np.any(ii):
+            msg = "TARGETID {} from {} not in file {}!".format(tid, overfn, infn)
+            log.warning(msg)
+        entry = ledger[ii]
+
+        # ADM substitute the column entries, where requested.
+        ii = objs["TARGETID"] == tid
+        if colsub is not None:
+            for col in colsub:
+                if col not in ledger.colnames:
+                    msg = "column {} from colsub not in ledger!!!".format(col)
+                    log.error(msg)
+                    raise ValueError(msg)
+                entry[col] = objs[ii][colsub[col]]
+        # ADM overwrite ledger entries, where requested.
+        if valsub is not None:
+            for col, val in valsub.items():
+                if col not in ledger.colnames:
+                    msg = "column {} from valsub not in ledger!!!".format(col)
+                    log.error(msg)
+                    raise ValueError(msg)
+                entry[col] = val
+
+        # ADM add the number of times to override to the ledger entry.
+        entry["NUMOVERRIDE"] = numoverride
+        # ADM add some other standardized column information.
+        entry = standard_override_columns(entry)
+
+        # ADM finally write out the override ledger entry, after first
+        # ADM checking if the file exists.
+        if os.path.exists(outfn):
+            f = open(outfn, "a")
+            ascii.write(entry, f, format='no_header', formats=mtlformatdict)
+            f.close()
+            checkfn = outfn
+        else:
+            _, checkfn = io.write_mtl(
+                mtldir, entry.as_array(), indir=infn, ecsv=True, survey="main",
+                obscon=obscon, nsidefile=nside, hpxlist=pix, scnd=secondary,
+                override=True)
+        log.info('Wrote target {} from {} to {}'.format(tid, overfn, checkfn))
+
+    log.info("Touched pixels {}".format(",".join([str(pix) for pix in pixnum])))
+
+    return outdir
+
+
 def update_lya_1b(obscon="DARK", mtldir=None, timestamp=None, donefile=True):
     """
     Effectively add two observations for LyA quasars for DESI-1B.

--- a/py/desitarget/mtl.py
+++ b/py/desitarget/mtl.py
@@ -3277,9 +3277,10 @@ def make_zcat(zcatdir, tiles, obscon, survey, allow_overlaps=False):
 
     # ADM write out the zcat as a file with the correct data model.
     dm = survey_data_model(zcatdatamodel, survey=survey)
-    qsozcat = Table(np.zeros(len(zs), dtype=dm.dtype))
+    qsozcat = np.zeros(len(zs), dtype=dm.dtype)
     for col in qsozcat.dtype.names:
         qsozcat[col] = zs[col]
+    qsozcat = Table(qsozcat)
 
     return qsozcat
 


### PR DESCRIPTION
So far, we have not been processing _secondary_ `BACKUP` ledgers in the MTL loop. This PR addresses that by:

- Adding secondary ledgers as an automatically triggered option when executing `run_mtl_loop BACKUP`. 

This PR also includes a few more minor additions:

- An update that ensures that tables produced by `run_mtl_loop` to combine data from the spectroscopic pipeline correctly preserve endianness.
- The restoration of the `ledger_overrides()` function, and the option to force the associated override information into `DARK1B` and `BRIGHT1B` ledgers.