### PR TITLE
Fix multiprocessing usage on python 3.14

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,26 +18,19 @@ jobs:
             matrix:
                 include:
                   - os: ubuntu-latest
-                    python-version: '3.13'
+                    python-version: '3.14'
                     numpy-version: '<3.0'
                     scipy-version: ''
                     matplotlib-version: ''
                     astropy-version: ''
                     numba-version: ''
                   - os: ubuntu-latest
-                    python-version: '3.12'
-                    numpy-version: '<2.3'
-                    scipy-version: '<1.16'
-                    matplotlib-version: '<3.12'
-                    astropy-version: '<8.0'
+                    python-version: '3.13'
+                    numpy-version: '<3.0'
+                    scipy-version: ''
+                    matplotlib-version: ''
+                    astropy-version: ''
                     numba-version: ''
-                  - os: ubuntu-latest
-                    python-version: '3.11'
-                    numpy-version: '<2.1'
-                    scipy-version: '<1.14'
-                    matplotlib-version: '<3.10'
-                    astropy-version: '<7.0'
-                    numba-version: '<0.70'
                   - os: ubuntu-latest
                     python-version: '3.10'
                     numpy-version: '<2.0'
@@ -48,7 +41,9 @@ jobs:
 
         steps:
             - name: Install System Packages
-              run: sudo apt install libbz2-dev subversion
+              run: |
+                sudo apt-get -y update
+                sudo apt-get -y install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v5
             - name: Set up Python ${{ matrix.python-version }}
@@ -101,7 +96,9 @@ jobs:
 
         steps:
             - name: Install System Packages
-              run: sudo apt install libbz2-dev subversion
+              run: |
+                sudo apt-get -y update
+                sudo apt-get -y install libbz2-dev subversion
             - name: Checkout code
               uses: actions/checkout@v5
             - name: Set up Python ${{ matrix.python-version }}

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desitarget Change Log
 5.4.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Python 3.14 support: Update multiprocessing to use fork instead of
+  forkserver [`PR #898`_].
+
+.. _`PR #898`: https://github.com/desihub/desitarget/pull/898
 
 5.4.0 (2026-08-24)
 ------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,7 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    # 'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
     'healpy': ('https://healpy.readthedocs.io/en/stable/', None),

--- a/py/desitarget/internal/sharedmem.py
+++ b/py/desitarget/internal/sharedmem.py
@@ -145,6 +145,17 @@ import mmap
 #logger = multiprocessing.log_to_stderr()
 #logger.setLevel(multiprocessing.SUBDEBUG)
 
+#- This module relies on fork() semantics (e.g. closures and locals shared
+#- via copy-on-write memory instead of being pickled to worker processes).
+#- Since Python 3.14 the default multiprocessing start method on Linux is
+#- "forkserver" instead of "fork", which breaks that assumption. Force the
+#- "fork" context explicitly; this matches the pre-3.14 default on POSIX
+#- systems, which is the only platform this module supports anyway.
+if sys.platform != 'win32':
+    _mp = multiprocessing.get_context('fork')
+else:
+    _mp = multiprocessing
+
 __shmdebug__ = False
 
 def set_debug(flag):
@@ -246,7 +257,7 @@ class ProcessGroup(object):
         # each dead child releases one sempahore
         # when all dead guard will proceed to set guarddead
         self.semaphore = threading.Semaphore(0)
-        self.JoinedProcesses = multiprocessing.RawValue('l')
+        self.JoinedProcesses = _mp.RawValue('l')
         self.P = [
             backend.WorkerFactory(target=self._workerMain,
                 args=(rank,)) \
@@ -414,7 +425,7 @@ class Ordered(object):
       #  self.counter = lambda : None
         #multiprocessing.RawValue('l')
         self.event = backend.EventFactory()
-        self.counter = multiprocessing.RawValue('l')
+        self.counter = _mp.RawValue('l')
         self.tls = backend.StorageFactory()
 
     def reset(self):
@@ -449,13 +460,13 @@ class ThreadBackend:
         return worker
 
 class ProcessBackend:
-      QueueFactory = staticmethod(multiprocessing.Queue)
-      EventFactory = staticmethod(multiprocessing.Event)
-      LockFactory = staticmethod(multiprocessing.Lock)
+      QueueFactory = staticmethod(_mp.Queue)
+      EventFactory = staticmethod(_mp.Event)
+      LockFactory = staticmethod(_mp.Lock)
 
       @staticmethod
       def WorkerFactory(*args, **kwargs):
-        worker = multiprocessing.Process(*args, **kwargs)
+        worker = _mp.Process(*args, **kwargs)
         worker.daemon = True
         return worker
       @staticmethod

--- a/py/desitarget/internal/sharedmem.py
+++ b/py/desitarget/internal/sharedmem.py
@@ -151,8 +151,11 @@ import mmap
 #- "forkserver" instead of "fork", which breaks that assumption. Force the
 #- "fork" context explicitly; this matches the pre-3.14 default on POSIX
 #- systems, which is the only platform this module supports anyway.
-if sys.platform != 'win32':
-    _mp = multiprocessing.get_context('fork')
+if os.name == 'posix':
+    try:
+        _mp = multiprocessing.get_context('fork')
+    except ValueError:
+        _mp = multiprocessing.get_context()
 else:
     _mp = multiprocessing
 


### PR DESCRIPTION
This PR fixes the multiprocessing usage on python 3.14, which uses forkserver instead of fork by default.  Add python 3.14 to test matrix, keep python 3.13 and 3.10, but drop python 3.11 and 3.12 to keep test runtimes reasonable.