### PR TITLE
Run geomask tests from a temp directory to avoid leftover files

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,8 +7,10 @@ desitarget Change Log
 
 * Python 3.14 support: Update multiprocessing to use fork instead of
   forkserver [`PR #898`_].
+* test_geomask clean up temporary files when done [`PR #899`_].
 
 .. _`PR #898`: https://github.com/desihub/desitarget/pull/898
+.. _`PR #899`: https://github.com/desihub/desitarget/pull/899
 
 5.4.0 (2026-08-24)
 ------------------

--- a/py/desitarget/test/test_geomask.py
+++ b/py/desitarget/test/test_geomask.py
@@ -5,6 +5,8 @@
 import unittest
 import numpy as np
 import os
+import shutil
+import tempfile
 
 from desitarget import geomask
 
@@ -16,6 +18,16 @@ class TestGEOMASK(unittest.TestCase):
         drdir = '/blat/foo'  # doesn't have to exist, just for paths
         self.surveydir = os.path.join(drdir, 'decam')
         self.surveydir2 = os.path.join(drdir, '90prime-mosaic')
+        # bundle_bricks writes its output scripts to the current
+        # working directory, so run from a temporary directory
+        # that is removed again in tearDown.
+        self.origdir = os.getcwd()
+        self.testdir = tempfile.mkdtemp()
+        os.chdir(self.testdir)
+
+    def tearDown(self):
+        os.chdir(self.origdir)
+        shutil.rmtree(self.testdir, ignore_errors=True)
 
     def test_bundle_bricks(self):
         """


### PR DESCRIPTION
bundle_bricks() writes its driver/gnu-parallel/tasks scripts to the current working directory, so test_bundle_bricks was leaving targets-driver.sh, targets-gnu-parallel.sh, and targets.tasks behind in whatever directory pytest was run from.  This PR updates the tests to use a temporary directory and cleanup after itself so that it doesn't leave files behind in the code directory when running tests.