### PR TITLE
Use tempdirs in tests instead of writing to the current directory

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,11 +6,12 @@ desitarget Change Log
 ------------------
 
 * Fix tests that wrote to the current directory instead of a tempdir,
-  so that tests pass on a read-only filesystem.
+  so that tests pass on a read-only filesystem [`PR #901`_].
 * Python 3.14 support: Update multiprocessing to use fork instead of
   forkserver [`PR #898`_].
 
 .. _`PR #898`: https://github.com/desihub/desitarget/pull/898
+.. _`PR #901`: https://github.com/desihub/desitarget/pull/901
 
 5.4.0 (2026-08-24)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desitarget Change Log
 5.4.1 (unreleased)
 ------------------
 
+* Fix tests that wrote to the current directory instead of a tempdir,
+  so that tests pass on a read-only filesystem.
 * Python 3.14 support: Update multiprocessing to use fork instead of
   forkserver [`PR #898`_].
 

--- a/py/desitarget/test/test_brightmask.py
+++ b/py/desitarget/test/test_brightmask.py
@@ -12,7 +12,6 @@ import numpy.lib.recfunctions as rfn
 from glob import glob
 import healpy as hp
 import tempfile
-import shutil
 
 from desitarget import brightmask, io
 from desitarget.targetmask import desi_mask, targetid_mask
@@ -36,7 +35,8 @@ class TestBRIGHTMASK(unittest.TestCase):
         os.environ["URAT_DIR"] = os.path.join(testdir, 't4', 'urat')
 
         # ADM a temporary output directory to test writing masks.
-        cls.maskdir = tempfile.mkdtemp()
+        cls._maskdir_obj = tempfile.TemporaryDirectory()
+        cls.maskdir = cls._maskdir_obj.name
 
         # ADM allowed HEALPixels in the Tycho directory.
         pixnum = []
@@ -85,8 +85,7 @@ class TestBRIGHTMASK(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         # ADM remove the temporary output directory.
-        if os.path.exists(cls.maskdir):
-            shutil.rmtree(cls.maskdir)
+        cls._maskdir_obj.cleanup()
 
         # ADM reset the environment variables.
         if cls.gaiadir_orig is not None:

--- a/py/desitarget/test/test_geomask.py
+++ b/py/desitarget/test/test_geomask.py
@@ -5,6 +5,8 @@
 import unittest
 import numpy as np
 import os
+import shutil
+import tempfile
 
 from desitarget import geomask
 
@@ -21,13 +23,22 @@ class TestGEOMASK(unittest.TestCase):
         """
         Test the bundle_bricks scripting code executes without bugs
         """
-        blat = geomask.bundle_bricks(1, 1, 1,
-                                     surveydirs=[self.surveydir])
-        self.assertTrue(blat is None)
+        # bundle_bricks writes a driver script to the current
+        # directory, so run it from a tempdir.
+        origdir = os.getcwd()
+        testdir = tempfile.mkdtemp()
+        try:
+            os.chdir(testdir)
+            blat = geomask.bundle_bricks(1, 1, 1,
+                                         surveydirs=[self.surveydir])
+            self.assertTrue(blat is None)
 
-        foo = geomask.bundle_bricks(1, 1, 1,
-                                    surveydirs=[self.surveydir, self.surveydir2])
-        self.assertTrue(foo is None)
+            foo = geomask.bundle_bricks(1, 1, 1,
+                                        surveydirs=[self.surveydir, self.surveydir2])
+            self.assertTrue(foo is None)
+        finally:
+            os.chdir(origdir)
+            shutil.rmtree(testdir, ignore_errors=True)
 
     def test_match(self):
         a = np.array([1, 2, 3, 4])

--- a/py/desitarget/test/test_geomask.py
+++ b/py/desitarget/test/test_geomask.py
@@ -5,7 +5,6 @@
 import unittest
 import numpy as np
 import os
-import shutil
 import tempfile
 
 from desitarget import geomask
@@ -26,19 +25,18 @@ class TestGEOMASK(unittest.TestCase):
         # bundle_bricks writes a driver script to the current
         # directory, so run it from a tempdir.
         origdir = os.getcwd()
-        testdir = tempfile.mkdtemp()
-        try:
-            os.chdir(testdir)
-            blat = geomask.bundle_bricks(1, 1, 1,
-                                         surveydirs=[self.surveydir])
-            self.assertTrue(blat is None)
+        with tempfile.TemporaryDirectory() as testdir:
+            try:
+                os.chdir(testdir)
+                blat = geomask.bundle_bricks(1, 1, 1,
+                                             surveydirs=[self.surveydir])
+                self.assertTrue(blat is None)
 
-            foo = geomask.bundle_bricks(1, 1, 1,
-                                        surveydirs=[self.surveydir, self.surveydir2])
-            self.assertTrue(foo is None)
-        finally:
-            os.chdir(origdir)
-            shutil.rmtree(testdir, ignore_errors=True)
+                foo = geomask.bundle_bricks(1, 1, 1,
+                                            surveydirs=[self.surveydir, self.surveydir2])
+                self.assertTrue(foo is None)
+            finally:
+                os.chdir(origdir)
 
     def test_match(self):
         a = np.array([1, 2, 3, 4])

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -4,7 +4,6 @@
 """
 import unittest
 from importlib import resources
-import shutil
 import os.path
 import tempfile
 from astropy.io import fits
@@ -23,11 +22,11 @@ class TestIO(unittest.TestCase):
         cls.datadir = str(resources.files('desitarget').joinpath('test/t'))
 
     def setUp(self):
-        self.testdir = tempfile.mkdtemp()
+        self._testdir_obj = tempfile.TemporaryDirectory()
+        self.testdir = self._testdir_obj.name
 
     def tearDown(self):
-        if os.path.exists(self.testdir):
-            shutil.rmtree(self.testdir, ignore_errors=True)
+        self._testdir_obj.cleanup()
 
     def test_list_tractorfiles(self):
         files = io.list_tractorfiles(self.datadir)

--- a/py/desitarget/test/test_io.py
+++ b/py/desitarget/test/test_io.py
@@ -6,7 +6,7 @@ import unittest
 from importlib import resources
 import shutil
 import os.path
-from uuid import uuid4
+import tempfile
 from astropy.io import fits
 import numpy as np
 import fitsio
@@ -23,7 +23,7 @@ class TestIO(unittest.TestCase):
         cls.datadir = str(resources.files('desitarget').joinpath('test/t'))
 
     def setUp(self):
-        self.testdir = 'test-{}'.format(uuid4().hex)
+        self.testdir = tempfile.mkdtemp()
 
     def tearDown(self):
         if os.path.exists(self.testdir):

--- a/py/desitarget/test/test_mock_build.py
+++ b/py/desitarget/test/test_mock_build.py
@@ -22,11 +22,11 @@ from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
 class TestMockBuild(unittest.TestCase):
 
     def setUp(self):
-        self.outdir = tempfile.mkdtemp()
+        self._outdir_obj = tempfile.TemporaryDirectory()
+        self.outdir = self._outdir_obj.name
 
     def tearDown(self):
-        if os.path.exists(self.outdir):
-            shutil.rmtree(self.outdir)
+        self._outdir_obj.cleanup()
 
     @unittest.skipUnless('DESITARGET_RUN_MOCK_UNITTEST' in os.environ, '$DESITARGET_RUN_MOCK_UNITTEST not set; skipping expensive mock tests')
     def test_targets_truth(self):

--- a/py/desitarget/test/test_mtl.py
+++ b/py/desitarget/test/test_mtl.py
@@ -15,6 +15,7 @@ except ImportError:
     norr = True
 
 import os
+import tempfile
 import unittest
 import numpy as np
 from astropy.table import Table, join
@@ -332,10 +333,10 @@ class TestMTL(unittest.TestCase):
         t = self.update_data_model(t)
         zcat = self.update_data_model(self.zcat.copy())
         mtl = make_mtl(t, "BRIGHT", zcat=zcat, trim=True)
-        testfile = 'test-aszqweladfqwezceas.fits'
-        mtl.write(testfile, overwrite=True)
-        x = mtl.read(testfile)
-        os.remove(testfile)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            testfile = os.path.join(tmpdir, 'test-aszqweladfqwezceas.fits')
+            mtl.write(testfile, overwrite=True)
+            x = mtl.read(testfile)
         if x.masked:
             self.assertTrue(np.all(
                 mtl['NUMOBS_MORE'].mask == x['NUMOBS_MORE'].mask))

--- a/py/desitarget/test/test_qa.py
+++ b/py/desitarget/test/test_qa.py
@@ -5,7 +5,6 @@
 import unittest
 import os
 import sys
-import shutil
 import tempfile
 import warnings
 import numpy as np
@@ -45,7 +44,8 @@ class TestQA(unittest.TestCase):
         cls.cmxfile = os.path.join(cls.datadir, 'cmx-targets.fits')
         cls.pixmapfile = os.path.join(cls.datadir, 'pixweight.fits')
         cls.origdir = os.getcwd()
-        cls.testdir = tempfile.mkdtemp()
+        cls._testdir_obj = tempfile.TemporaryDirectory()
+        cls.testdir = cls._testdir_obj.name
         log.info("working in {}...".format(cls.testdir))
         os.chdir(cls.testdir)
 
@@ -58,8 +58,7 @@ class TestQA(unittest.TestCase):
         log.info(f'DESI_SURVEYOPS set back to {cls.desi_surveyops}')
         # - Remove all test input and output files.
         os.chdir(cls.origdir)
-        if os.path.exists(cls.testdir):
-            shutil.rmtree(cls.testdir)
+        cls._testdir_obj.cleanup()
 
     def setUp(self):
         # Treat some specific warnings as errors so that we can find and fix

--- a/py/desitarget/test/test_veto.py
+++ b/py/desitarget/test/test_veto.py
@@ -7,7 +7,7 @@ import shutil
 import os
 import astropy
 from importlib import resources
-from uuid import uuid4
+import tempfile
 import numpy as np
 
 from desitarget import io
@@ -22,7 +22,7 @@ class TestVETO(unittest.TestCase):
 
     def setUp(self):
         # ADM make an entire copy of the test MTL directory structure.
-        self.testdir = "test-{}".format(uuid4().hex)
+        self.testdir = tempfile.mkdtemp()
         shutil.copytree(self.datadir, os.path.join(self.testdir, "main"))
         # ADM we need to remove the bad test file from the MTL mock
         # ADM directory, otherwise updates will fail on that file.

--- a/py/desitarget/test/test_veto.py
+++ b/py/desitarget/test/test_veto.py
@@ -22,7 +22,8 @@ class TestVETO(unittest.TestCase):
 
     def setUp(self):
         # ADM make an entire copy of the test MTL directory structure.
-        self.testdir = tempfile.mkdtemp()
+        self._testdir_obj = tempfile.TemporaryDirectory()
+        self.testdir = self._testdir_obj.name
         shutil.copytree(self.datadir, os.path.join(self.testdir, "main"))
         # ADM we need to remove the bad test file from the MTL mock
         # ADM directory, otherwise updates will fail on that file.
@@ -34,8 +35,7 @@ class TestVETO(unittest.TestCase):
             self.datadir, "veto/bright1b/bad/bad-veto-bright1b.ecsv")
 
     def tearDown(self):
-        if os.path.exists(self.testdir):
-            shutil.rmtree(self.testdir, ignore_errors=True)
+        self._testdir_obj.cleanup()
 
     def test_veto_file(self):
         """Test a good veto file can be read but a bad one can't"""


### PR DESCRIPTION
test_geomask, test_io, test_mtl, and test_veto all wrote output files/directories directly to the current working directory (or a relative path), which fails on a read-only filesystem, e.g. /global/common/software when running from a NERSC batch node. Switch them to tempfile.mkdtemp()/TemporaryDirectory, restoring cwd afterward where the code under test (bundle_bricks) writes to cwd itself.

Supersedes #899, fixing that problem plus more.  Co-authored with Claude.